### PR TITLE
feat#5: 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // SMTP
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ jacocoTestCoverageVerification {
                     'toy.bookswap.**.response.**',
                     'toy.bookswap.**.command.**',
                     'toy.bookswap.**.query.**',
+                    'toy.bookswap.**.symbol.**',
             ]
 
             // LINE 커버리지

--- a/src/main/java/toy/bookswap/domain/member/command/CreateMemberCommand.java
+++ b/src/main/java/toy/bookswap/domain/member/command/CreateMemberCommand.java
@@ -1,0 +1,9 @@
+package toy.bookswap.domain.member.command;
+
+public record CreateMemberCommand(
+    String email,
+    String password,
+    String nickname
+) {
+
+}

--- a/src/main/java/toy/bookswap/domain/member/repository/MemberRepository.java
+++ b/src/main/java/toy/bookswap/domain/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package toy.bookswap.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import toy.bookswap.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/toy/bookswap/domain/member/service/MemberService.java
+++ b/src/main/java/toy/bookswap/domain/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package toy.bookswap.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import toy.bookswap.domain.member.command.CreateMemberCommand;
+import toy.bookswap.domain.member.entity.Member;
+import toy.bookswap.domain.member.repository.MemberRepository;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+  private final BCryptPasswordEncoder encoder;
+  private final MemberRepository memberRepository;
+
+  public void signupProcess(CreateMemberCommand command) {
+    Member newMember = Member.builder()
+        .email(command.email())
+        .password(encoder.encode(command.password()))
+        .nickname(command.nickname())
+        .build();
+    memberRepository.save(newMember);
+  }
+}

--- a/src/main/java/toy/bookswap/domain/member/service/MemberService.java
+++ b/src/main/java/toy/bookswap/domain/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package toy.bookswap.domain.member.service;
 
 import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,7 +20,7 @@ public class MemberService {
   private final StringRedisTemplate redisTemplate;
 
   public void signupProcess(CreateMemberCommand command) {
-    verifyEmail((command.email()));
+    verifyEmail(command.email());
     Member newMember = Member.builder()
         .email(command.email())
         .password(encoder.encode(command.password()))

--- a/src/main/java/toy/bookswap/domain/member/service/MemberService.java
+++ b/src/main/java/toy/bookswap/domain/member/service/MemberService.java
@@ -1,6 +1,9 @@
 package toy.bookswap.domain.member.service;
 
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,13 +18,23 @@ public class MemberService {
 
   private final BCryptPasswordEncoder encoder;
   private final MemberRepository memberRepository;
+  private final StringRedisTemplate redisTemplate;
 
   public void signupProcess(CreateMemberCommand command) {
+    verifyEmail((command.email()));
     Member newMember = Member.builder()
         .email(command.email())
         .password(encoder.encode(command.password()))
         .nickname(command.nickname())
         .build();
     memberRepository.save(newMember);
+  }
+
+  private void verifyEmail(String email) {
+    // TODO - 공통 Exception 처리
+    if(!Objects.equals(redisTemplate.opsForValue().get("email-verified:" + email), "true")) {
+      throw new RuntimeException("이메일 인증이 완료되지 않았습니다.");
+    }
+    redisTemplate.delete("email-verified:" + email);
   }
 }

--- a/src/main/java/toy/bookswap/global/config/MailConfig.java
+++ b/src/main/java/toy/bookswap/global/config/MailConfig.java
@@ -1,0 +1,42 @@
+package toy.bookswap.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+  @Value("${spring.mail.username}")
+  private String username;
+
+  @Value("${spring.mail.password}")
+  private String password;
+
+  @Bean
+  public JavaMailSenderImpl mailSender() {
+    JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+    mailSender.setHost("smtp.gmail.com");
+    mailSender.setPort(587);
+    mailSender.setUsername(username);
+    mailSender.setPassword(password);
+
+    Properties props = mailSender.getJavaMailProperties();
+    props.put("mail.smtp.auth", "true");
+    props.put("mail.smtp.starttls.enable", "true");
+
+    return mailSender;
+  }
+
+  @Bean
+  public SimpleMailMessage defaultMailMessage() {
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setFrom(username);
+    message.setSubject("[BookSwap] 이메일 인증 안내");
+    return message;
+  }
+}

--- a/src/main/java/toy/bookswap/global/config/RedisConfig.java
+++ b/src/main/java/toy/bookswap/global/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package toy.bookswap.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory();
+  }
+
+  @Bean
+  public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+    StringRedisTemplate template = new StringRedisTemplate(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new StringRedisSerializer());
+    return template;
+  }
+}

--- a/src/main/java/toy/bookswap/global/config/WebConfig.java
+++ b/src/main/java/toy/bookswap/global/config/WebConfig.java
@@ -1,0 +1,14 @@
+package toy.bookswap.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class WebConfig {
+
+  @Bean
+  public BCryptPasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/toy/bookswap/global/infra/mail/GoogleMailService.java
+++ b/src/main/java/toy/bookswap/global/infra/mail/GoogleMailService.java
@@ -1,0 +1,52 @@
+package toy.bookswap.global.infra.mail;
+
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GoogleMailService implements MailService {
+
+  private final JavaMailSender mailSender;
+  private final SimpleMailMessage message;
+  private final StringRedisTemplate redisTemplate;
+
+  @Override
+  public void sendMailProcess(String email) {
+    String verificationCode = generateCode();
+    saveEmailData(email, verificationCode, 3);
+    message.setText("인증코드 : " + verificationCode);
+    message.setTo(email);
+    mailSender.send(message);
+  }
+
+  @Override
+  public void verifyMailProcess(String email, String code) {
+    // TODO - 공통 Exception 처리
+    String storedCode = getStoredCode(email)
+        .orElseThrow(() -> new RuntimeException("인증 코드가 만료되었습니다."));
+
+    if (!storedCode.equals(code)) {
+      throw new RuntimeException("인증 코드가 유효하지 않습니다.");
+    }
+    saveEmailData("email-verified:" + email, "true", 10);
+    deleteEmailData(email);
+  }
+
+  private void saveEmailData(String key, String data, int time) {
+    redisTemplate.opsForValue().set(key, data, Duration.ofMinutes(time));
+  }
+
+  private void deleteEmailData(String key) {
+    redisTemplate.delete(key);
+  }
+
+  private Optional<String> getStoredCode(String key) {
+    return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+  }
+}

--- a/src/main/java/toy/bookswap/global/infra/mail/MailService.java
+++ b/src/main/java/toy/bookswap/global/infra/mail/MailService.java
@@ -1,0 +1,21 @@
+package toy.bookswap.global.infra.mail;
+
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public interface MailService {
+
+  void sendMailProcess(String email);
+
+  void verifyMailProcess(String email, String code);
+
+  default String generateCode() {
+    String candidateChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    Random random = new Random();
+    return random.ints(6, 0, candidateChars.length())
+        .mapToObj(candidateChars::charAt)
+        .map(String::valueOf)
+        .collect(Collectors.joining());
+  }
+}

--- a/src/main/java/toy/bookswap/web/auth/mail/MailController.java
+++ b/src/main/java/toy/bookswap/web/auth/mail/MailController.java
@@ -1,0 +1,33 @@
+package toy.bookswap.web.auth.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import toy.bookswap.global.infra.mail.MailService;
+import toy.bookswap.web.common.CommonResponse;
+import toy.bookswap.web.common.symbol.ResponseSymbol;
+
+@RequiredArgsConstructor
+@RequestMapping("/auth/email")
+@RestController
+public class MailController {
+
+  private final MailService mailService;
+
+  @PostMapping
+  public CommonResponse<ResponseSymbol> sendCode(@RequestParam("email") String email) {
+    mailService.sendMailProcess(email);
+    return new CommonResponse<>(true, ResponseSymbol.SENT);
+  }
+
+  @PostMapping("/confirm")
+  public CommonResponse<ResponseSymbol> verifyCode(
+      @RequestParam("email") String email,
+      @RequestParam("code") String code
+  ) {
+    mailService.verifyMailProcess(email, code);
+    return new CommonResponse<>(true, ResponseSymbol.VERIFIED);
+  }
+}

--- a/src/main/java/toy/bookswap/web/common/CommonResponse.java
+++ b/src/main/java/toy/bookswap/web/common/CommonResponse.java
@@ -1,0 +1,12 @@
+package toy.bookswap.web.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommonResponse<T> {
+
+  private boolean success;
+  private T result;
+}

--- a/src/main/java/toy/bookswap/web/common/symbol/ResponseSymbol.java
+++ b/src/main/java/toy/bookswap/web/common/symbol/ResponseSymbol.java
@@ -1,0 +1,9 @@
+package toy.bookswap.web.common.symbol;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ResponseSymbol {
+  OK, FAILED, CREATED, UPDATED, DELETED;
+}
+

--- a/src/main/java/toy/bookswap/web/common/symbol/ResponseSymbol.java
+++ b/src/main/java/toy/bookswap/web/common/symbol/ResponseSymbol.java
@@ -4,6 +4,6 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ResponseSymbol {
-  OK, FAILED, CREATED, UPDATED, DELETED;
+  OK, FAILED, CREATED, UPDATED, DELETED, SENT, VERIFIED;
 }
 

--- a/src/main/java/toy/bookswap/web/member/controller/MemberController.java
+++ b/src/main/java/toy/bookswap/web/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package toy.bookswap.web.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import toy.bookswap.domain.member.service.MemberService;
+import toy.bookswap.web.common.CommonResponse;
+import toy.bookswap.web.common.symbol.ResponseSymbol;
+import toy.bookswap.web.member.request.SignupRequest;
+
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@RestController
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @PostMapping
+  public CommonResponse<ResponseSymbol> singup(@RequestBody SignupRequest request) {
+    memberService.signupProcess(request.toCommand());
+    return new CommonResponse<>(true, ResponseSymbol.CREATED);
+  }
+}

--- a/src/main/java/toy/bookswap/web/member/controller/MemberController.java
+++ b/src/main/java/toy/bookswap/web/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package toy.bookswap.web.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import toy.bookswap.domain.member.service.MemberService;
 import toy.bookswap.web.common.CommonResponse;
@@ -18,6 +20,7 @@ public class MemberController {
   private final MemberService memberService;
 
   @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
   public CommonResponse<ResponseSymbol> singup(@RequestBody SignupRequest request) {
     memberService.signupProcess(request.toCommand());
     return new CommonResponse<>(true, ResponseSymbol.CREATED);

--- a/src/main/java/toy/bookswap/web/member/request/SignupRequest.java
+++ b/src/main/java/toy/bookswap/web/member/request/SignupRequest.java
@@ -1,0 +1,14 @@
+package toy.bookswap.web.member.request;
+
+import toy.bookswap.domain.member.command.CreateMemberCommand;
+
+public record SignupRequest(
+    String nickname,
+    String email,
+    String password
+) {
+
+  public CreateMemberCommand toCommand() {
+    return new CreateMemberCommand(email, password, nickname);
+  }
+}

--- a/src/test/java/toy/bookswap/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/toy/bookswap/domain/member/service/MemberServiceTest.java
@@ -1,23 +1,28 @@
 package toy.bookswap.domain.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import toy.bookswap.domain.member.command.CreateMemberCommand;
 import toy.bookswap.domain.member.entity.Member;
 import toy.bookswap.domain.member.repository.MemberRepository;
 
+@DisplayName("사용자 회원가입 테스트")
 @ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+class MemberSingupServiceTest {
 
   @Mock
   private MemberRepository memberRepository;
@@ -25,28 +30,57 @@ class MemberServiceTest {
   @Mock
   private BCryptPasswordEncoder encoder;
 
+  @Mock
+  private StringRedisTemplate redisTemplate;
+
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
   @InjectMocks
   private MemberService memberService;
 
   @Test
-  void 회원가입_시_비밀번호는_암호화되어_저장된다() {
+  @DisplayName("회원가입 - 성공 테스트")
+  void signupProcessTest() {
     // given
     String rawPassword = "password";
     String encodedPassword = "$2a$10";
-    CreateMemberCommand command = new CreateMemberCommand("test@email.com", rawPassword, "tester");
+    String email = "test@email.com";
+    CreateMemberCommand command = new CreateMemberCommand(email, rawPassword, "tester");
 
     ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+
     given(encoder.encode(rawPassword)).willReturn(encodedPassword);
+    given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.get("email-verified:" + email)).willReturn("true");
 
     // when
     memberService.signupProcess(command);
 
     // then
+    then(valueOperations).should().get("email-verified:" + email);
     then(memberRepository).should(times(1)).save(captor.capture());
-
     Member saved = captor.getValue();
     assertThat(saved.getEmail()).isEqualTo("test@email.com");
     assertThat(saved.getNickname()).isEqualTo("tester");
     assertThat(saved.getPassword()).isEqualTo(encodedPassword);
+    then(redisTemplate).should().delete("email-verified:" + email);
   }
+
+  @Test
+  @DisplayName("회원가입 - 실패 테스트(이메일 인증 X)")
+  void signupProcessFailNotVerifiedTest() {
+    // given
+    String email = "test@email.com";
+    CreateMemberCommand command = new CreateMemberCommand(email, "password", "tester");
+
+    given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.get("email-verified:" + email)).willReturn(null);
+
+    // when & then
+    assertThatThrownBy(() -> memberService.signupProcess(command))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("이메일 인증이 완료되지 않았습니다.");
+  }
+
 }

--- a/src/test/java/toy/bookswap/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/toy/bookswap/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,52 @@
+package toy.bookswap.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import toy.bookswap.domain.member.command.CreateMemberCommand;
+import toy.bookswap.domain.member.entity.Member;
+import toy.bookswap.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private BCryptPasswordEncoder encoder;
+
+  @InjectMocks
+  private MemberService memberService;
+
+  @Test
+  void 회원가입_시_비밀번호는_암호화되어_저장된다() {
+    // given
+    String rawPassword = "password";
+    String encodedPassword = "$2a$10";
+    CreateMemberCommand command = new CreateMemberCommand("test@email.com", rawPassword, "tester");
+
+    ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+    given(encoder.encode(rawPassword)).willReturn(encodedPassword);
+
+    // when
+    memberService.signupProcess(command);
+
+    // then
+    then(memberRepository).should(times(1)).save(captor.capture());
+
+    Member saved = captor.getValue();
+    assertThat(saved.getEmail()).isEqualTo("test@email.com");
+    assertThat(saved.getNickname()).isEqualTo("tester");
+    assertThat(saved.getPassword()).isEqualTo(encodedPassword);
+  }
+}

--- a/src/test/java/toy/bookswap/global/infra/mail/GoogleMailServiceTest.java
+++ b/src/test/java/toy/bookswap/global/infra/mail/GoogleMailServiceTest.java
@@ -1,0 +1,104 @@
+package toy.bookswap.global.infra.mail;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@DisplayName("Email 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class GoogleMailServiceTest {
+
+  @Mock
+  private JavaMailSender mailSender;
+
+  @Mock
+  private SimpleMailMessage simpleMailMessage;
+
+  @Mock
+  private StringRedisTemplate redisTemplate;
+
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
+  @InjectMocks
+  private GoogleMailService googleMailService;
+
+  @BeforeEach
+  void setUp() {
+    given(redisTemplate.opsForValue()).willReturn(valueOperations);
+  }
+
+  @Test
+  @DisplayName("이메일 전송 - 성공 테스트")
+  void sendMailProcessTest() {
+    // given
+    String email = "test@email.com";
+
+    // when
+    googleMailService.sendMailProcess(email);
+
+    // then
+    then(mailSender).should().send(simpleMailMessage);
+    then(redisTemplate).should().opsForValue();
+  }
+
+  @Test
+  @DisplayName("이메일 인증 코드 검증 - 성공 테스트")
+  void verifyMailProcessTest() {
+    // given
+    String email = "test@email.com";
+    String code = "ABC123";
+    given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.get(email)).willReturn(code);
+
+    // when
+    googleMailService.verifyMailProcess(email, code);
+
+    // then
+    then(valueOperations).should().get(email);
+    then(valueOperations).should().set("email-verified:" + email, "true", Duration.ofMinutes(10));
+    then(redisTemplate).should().delete(email);
+  }
+
+  @Test
+  @DisplayName("인증 코드 검증 - 실패 테스트(인증 코드 불일치)")
+  void verifyMailProcessMismatchTest() {
+    // given
+    String email = "test@email.com";
+    String storedCode = "XYZ789";
+    String inputCode = "ABC123";
+
+    given(redisTemplate.opsForValue().get(email)).willReturn(storedCode);
+
+    // when, then
+    assertThatThrownBy(() -> googleMailService.verifyMailProcess(email, inputCode))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("인증 코드가 유효하지 않습니다.");
+  }
+
+  @Test
+  @DisplayName("인증 코드 만료 - 실패 테스트(인증 코드 만료)")
+  void verifyMailProcessExpiredTest() {
+    // given
+    String email = "test@email.com";
+    given(redisTemplate.opsForValue().get(email)).willReturn(null);
+
+    // when, then
+    assertThatThrownBy(() -> googleMailService.verifyMailProcess(email, "any"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("인증 코드가 만료되었습니다.");
+  }
+}

--- a/src/test/java/toy/bookswap/web/auth/mail/MailControllerTest.java
+++ b/src/test/java/toy/bookswap/web/auth/mail/MailControllerTest.java
@@ -1,0 +1,55 @@
+package toy.bookswap.web.auth.mail;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import toy.bookswap.global.infra.mail.MailService;
+
+@DisplayName("이메일 API 테스트")
+@ExtendWith(MockitoExtension.class)
+class MailControllerTest {
+
+  @Mock
+  private MailService mailService;
+
+  @InjectMocks
+  private MailController mailController;
+
+  @Test
+  @DisplayName("이메일 인증 코드 전송 요청 테스트")
+  void callSendCodeTest() throws Exception {
+    MockMvc mvc = standaloneSetup(mailController).build();
+
+    mvc.perform(post("/auth/email")
+        .param("email", "test@email.com")
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+    ).andExpect(status().isOk());
+
+    verify(mailService, times(1)).sendMailProcess("test@email.com");
+  }
+
+  @Test
+  @DisplayName("이메일 인증 코드 검증 요청 테스트")
+  void callVerifyCodeTest() throws Exception {
+    MockMvc mvc = standaloneSetup(mailController).build();
+
+    mvc.perform(post("/auth/email/confirm")
+        .param("email", "test@email.com")
+        .param("code", "ABC123")
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+    ).andExpect(status().isOk());
+
+    verify(mailService, times(1)).verifyMailProcess("test@email.com", "ABC123");
+  }
+}

--- a/src/test/java/toy/bookswap/web/member/controller/MemberControllerTest.java
+++ b/src/test/java/toy/bookswap/web/member/controller/MemberControllerTest.java
@@ -17,8 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import toy.bookswap.domain.member.command.CreateMemberCommand;
 import toy.bookswap.domain.member.service.MemberService;
-import toy.bookswap.web.member.request.SignupRequest;
 
+@DisplayName("회원 API 테스트")
 @ExtendWith(MockitoExtension.class)
 class MemberControllerTest {
 
@@ -42,23 +42,10 @@ class MemberControllerTest {
         """;
 
     mvc.perform(post("/members")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(json)
-        ).andExpect(status().isOk());
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(json)
+    ).andExpect(status().isCreated());
 
-    verify(memberService, times(1)).signupProcess(any(CreateMemberCommand.class));
-  }
-
-  @Test
-  @DisplayName("회원가입 서비스 호출 테스트")
-  void callSignupProcessTest() {
-    // given
-    SignupRequest request = new SignupRequest("test@email.com", "1234", "테스터");
-
-    // when
-    memberController.singup(request);
-
-    // then
     verify(memberService, times(1)).signupProcess(any(CreateMemberCommand.class));
   }
 }

--- a/src/test/java/toy/bookswap/web/member/controller/MemberControllerTest.java
+++ b/src/test/java/toy/bookswap/web/member/controller/MemberControllerTest.java
@@ -1,0 +1,64 @@
+package toy.bookswap.web.member.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import toy.bookswap.domain.member.command.CreateMemberCommand;
+import toy.bookswap.domain.member.service.MemberService;
+import toy.bookswap.web.member.request.SignupRequest;
+
+@ExtendWith(MockitoExtension.class)
+class MemberControllerTest {
+
+  @Mock
+  private MemberService memberService;
+
+  @InjectMocks
+  private MemberController memberController;
+
+  @Test
+  @DisplayName("회원가입 API 호출 테스트")
+  void callSignupAPITest() throws Exception {
+    MockMvc mvc = standaloneSetup(memberController).build();
+
+    String json = """
+        {
+            "email": "test@email.com",
+            "password": "1234",
+            "nickname": "테스터"
+        }
+        """;
+
+    mvc.perform(post("/members")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)
+        ).andExpect(status().isOk());
+
+    verify(memberService, times(1)).signupProcess(any(CreateMemberCommand.class));
+  }
+
+  @Test
+  @DisplayName("회원가입 서비스 호출 테스트")
+  void callSignupProcessTest() {
+    // given
+    SignupRequest request = new SignupRequest("test@email.com", "1234", "테스터");
+
+    // when
+    memberController.singup(request);
+
+    // then
+    verify(memberService, times(1)).signupProcess(any(CreateMemberCommand.class));
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,3 +7,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+  mail:
+    username: "test"
+    password: "test"


### PR DESCRIPTION
### #️⃣연관된 이슈
> ex) #5 

### 📜 작업 내용
> 사용자 회원가입 기능 구현
회원가입 시 이메일 인증(인증 코드 발송 + 검증) 기능 구현

### 🖼️ 스크린샷 (선택)
이메일 인증 코드 발송 스크린샷
![image](https://github.com/user-attachments/assets/ae5ae63f-fbfe-4216-abd5-762349deb080)

### 📄 구현 참고
회원가입 과정에서 이메일 인증 완료 여부를 별도로 관리할 필요가 있었고, 인증 코드의 유효성과 인증 완료 상태를 여러 서버 인스턴스 간에 공유해야 했기 때문에 Redis를 사용하여 인증 정보를 관리했습니다. (외부 메일 서비스 : Google SMTP 사용)

### ⚠️ 종료할 이슈
this closes #5 
