### PR TITLE
feat#23: 프로필 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     implementation 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 
+    // AWS
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.3.0'
+    implementation 'software.amazon.awssdk:s3:2.31.38'
+
     // SMTP
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/src/main/java/com/bob/domain/member/entity/Member.java
+++ b/src/main/java/com/bob/domain/member/entity/Member.java
@@ -62,6 +62,10 @@ public class Member extends BaseTime {
     nickname = newNickname;
   }
 
+  public void updateProfileImageUrl(String newProfileImageUrl) {
+    profileImageUrl = newProfileImageUrl;
+  }
+
   public boolean isEqualsNickname(String oldNickname) {
     return Objects.equals(nickname, oldNickname);
   }

--- a/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileImageUrlCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileImageUrlCommand.java
@@ -1,0 +1,8 @@
+package com.bob.domain.member.service.dto.command;
+
+public record ChangeProfileImageUrlCommand(
+    Long memberId,
+    String contentType
+) {
+
+}

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileImageUrlResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileImageUrlResponse.java
@@ -1,0 +1,19 @@
+package com.bob.domain.member.service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberProfileImageUrlResponse {
+
+  private String fileName;
+  private String imageUploadUrl;
+
+  public static MemberProfileImageUrlResponse of(String fileName, String imageUploadUrl) {
+    return MemberProfileImageUrlResponse.builder()
+        .fileName(fileName)
+        .imageUploadUrl(imageUploadUrl)
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/member/service/port/ImageStorageAccessor.java
+++ b/src/main/java/com/bob/domain/member/service/port/ImageStorageAccessor.java
@@ -1,0 +1,6 @@
+package com.bob.domain.member.service.port;
+
+public interface ImageStorageAccessor {
+
+  String getImageUploadUrl(String imageName, String contentType);
+}

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ApplicationError {
 
+  // 공통 예외
+  NOT_SUPPORT_TYPE("E001", "지원하지 않는 형식입니다.", HttpStatus.BAD_REQUEST),
+
   // 사용자 예외
   UNVERIFIED_EMAIL("E101", "이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),
   ALREADY_EXISTS_EMAIL("E102", "해당 이메일로 가입된 계정이 존재합니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/bob/global/utils/ImageDirectory.java
+++ b/src/main/java/com/bob/global/utils/ImageDirectory.java
@@ -1,0 +1,16 @@
+package com.bob.global.utils;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageDirectory {
+  PROFILE("profile/"),
+  BOOK("book/"),
+  CHAT("chat/");
+
+  private final String prefix;
+
+  ImageDirectory(String prefix) {
+    this.prefix = prefix;
+  }
+}

--- a/src/main/java/com/bob/global/utils/ImageUtils.java
+++ b/src/main/java/com/bob/global/utils/ImageUtils.java
@@ -1,0 +1,23 @@
+package com.bob.global.utils;
+
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import java.util.UUID;
+
+public class ImageUtils {
+
+  public static String generateImageFileName(String contentType, ImageDirectory directory) {
+    String extension = extractExtension(contentType);
+    String uuid = UUID.randomUUID().toString();
+    return directory.getPrefix() + uuid + "." + extension;
+  }
+
+  public static String extractExtension(String contentType) {
+    return switch (contentType) {
+      case "image/jpeg" -> "jpg";
+      case "image/png" -> "png";
+      case "image/gif" -> "gif";
+      default -> throw new ApplicationException(ApplicationError.NOT_SUPPORT_TYPE);
+    };
+  }
+}

--- a/src/main/java/com/bob/infra/aws/adapter/S3Accessor.java
+++ b/src/main/java/com/bob/infra/aws/adapter/S3Accessor.java
@@ -1,0 +1,44 @@
+package com.bob.infra.aws.adapter;
+
+import com.bob.domain.member.service.port.ImageStorageAccessor;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@RequiredArgsConstructor
+@Service
+public class S3Accessor implements ImageStorageAccessor {
+
+  private final S3Presigner signer;
+
+  @Value("${spring.cloud.aws.s3.bucket}")
+  private String bucketName;
+
+  @Override
+  public String getImageUploadUrl(String imageName, String contentType) {
+    PutObjectRequest putObjectRequest = createPutObjectRequest(imageName, contentType);
+    PutObjectPresignRequest putObjectPresignRequest = createPutObjectPresignRequest(putObjectRequest);
+    PresignedPutObjectRequest presignedPutObjectRequest = signer.presignPutObject(putObjectPresignRequest);
+    return presignedPutObjectRequest.url().toString();
+  }
+
+  private PutObjectPresignRequest createPutObjectPresignRequest(PutObjectRequest putObjectRequest) {
+    return PutObjectPresignRequest.builder()
+        .signatureDuration(Duration.ofMinutes(1))
+        .putObjectRequest(putObjectRequest)
+        .build();
+  }
+
+  private PutObjectRequest createPutObjectRequest(String imageName, String contentType) {
+    return PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(imageName)
+        .contentType(contentType)
+        .build();
+  }
+}

--- a/src/main/java/com/bob/infra/config/AwsS3Config.java
+++ b/src/main/java/com/bob/infra/config/AwsS3Config.java
@@ -1,0 +1,46 @@
+package com.bob.infra.config;
+
+import static software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+  @Value("${spring.cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${spring.cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${spring.cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AwsCredentials awsCredentials() {
+    return AwsBasicCredentials.create(accessKey, secretKey);
+  }
+
+  @Bean
+  public S3Presigner s3Presigner(AwsCredentials credentials) {
+    return S3Presigner.builder()
+        .region(Region.of(region))
+        .credentialsProvider(create(credentials))
+        .build();
+  }
+
+  @Bean
+  public S3Client s3Client(AwsCredentials credentials) {
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(create(credentials))
+        .build();
+  }
+}

--- a/src/main/java/com/bob/web/member/controller/MemberController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import static com.bob.web.member.request.ReadProfileByIdRequest.toQuery;
 import static com.bob.web.member.request.ReadProfileRequest.toQuery;
 
 import com.bob.domain.member.service.MemberService;
+import com.bob.domain.member.service.dto.response.MemberProfileImageUrlResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileWithPostsResponse;
 import com.bob.web.common.AuthenticationId;
@@ -15,6 +16,7 @@ import com.bob.web.common.symbol.ResponseSymbol;
 import com.bob.web.member.request.ChangePasswordRequest;
 import com.bob.web.member.request.ChangeProfileRequest;
 import com.bob.web.member.request.IssuePasswordRequest;
+import com.bob.web.member.request.ReadImageUploadUrlRequest;
 import com.bob.web.member.request.SignupRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -75,5 +77,13 @@ public class MemberController {
   public CommonResponse<ResponseSymbol> handleSendTempPassword(@RequestBody IssuePasswordRequest request) {
     memberService.issueTempPasswordProcess(request.toCommand());
     return new CommonResponse<>(true, SENT);
+  }
+
+  @PatchMapping("/me/image")
+  public ResponseEntity<MemberProfileImageUrlResponse> handleGetImageUploadUrl(
+      @RequestBody ReadImageUploadUrlRequest request,
+      @AuthenticationId Long memberId
+  ) {
+    return ResponseEntity.ok(memberService.changeProfileImageUrlProcess(request.toQuery(memberId)));
   }
 }

--- a/src/main/java/com/bob/web/member/request/ReadImageUploadUrlRequest.java
+++ b/src/main/java/com/bob/web/member/request/ReadImageUploadUrlRequest.java
@@ -1,0 +1,12 @@
+package com.bob.web.member.request;
+
+import com.bob.domain.member.service.dto.command.ChangeProfileImageUrlCommand;
+
+public record ReadImageUploadUrlRequest(
+    String contentType
+) {
+
+  public ChangeProfileImageUrlCommand toQuery(Long memberId) {
+    return new ChangeProfileImageUrlCommand(memberId, contentType);
+  }
+}

--- a/src/test/intg/resources/application-intg.yml
+++ b/src/test/intg/resources/application-intg.yml
@@ -17,8 +17,17 @@ spring:
     username: "test"
     password: "test"
 
+  cloud:
+    aws:
+      credentials:
+        access-key: access
+        secret-key: secret
+      region:
+        static: region
+      s3:
+        bucket: bucket
+
 jwt:
-  token-prefix: PRIFIX
   secret-key: secret
   access-token-expire-time: 1
   refresh-token-expire-time: 1

--- a/src/test/unit/java/com/bob/domain/member/entity/MemberTest.java
+++ b/src/test/unit/java/com/bob/domain/member/entity/MemberTest.java
@@ -74,4 +74,18 @@ class MemberTest {
     // then
     assertThat(result).isEqualTo(expected);
   }
+
+  @Test
+  @DisplayName("프로필 이미지 URL 수정 테스트")
+  void 프로필_이미지_URL을_수정할_수_있다() {
+    // given
+    Member member = defaultIdMember();
+    String newProfileImageUrl = "profile/test.jpg";
+
+    // when
+    member.updateProfileImageUrl(newProfileImageUrl);
+
+    // then
+    assertThat(member.getProfileImageUrl()).isEqualTo(newProfileImageUrl);
+  }
 }

--- a/src/test/unit/java/com/bob/global/utils/ImageUtilsTest.java
+++ b/src/test/unit/java/com/bob/global/utils/ImageUtilsTest.java
@@ -1,0 +1,42 @@
+package com.bob.global.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("이미지 Util 테스트")
+class ImageUtilsTest {
+
+  @Test
+  @DisplayName("Content-Type 기반 파일 확장자 추출 테스트")
+  void contentType으로_확장자를_추출할_수_있다() {
+    assertThat(ImageUtils.extractExtension("image/jpeg")).isEqualTo("jpg");
+    assertThat(ImageUtils.extractExtension("image/png")).isEqualTo("png");
+    assertThat(ImageUtils.extractExtension("image/gif")).isEqualTo("gif");
+  }
+
+  @Test
+  @DisplayName("지원하지 않는 Content-Type 테스트")
+  void 지원하지_않는_ContentType이면_예외가_발생한다() {
+    assertThatThrownBy(() -> ImageUtils.extractExtension("video/mp4"))
+        .isInstanceOf(ApplicationException.class)
+        .satisfies(ex -> {
+          ApplicationException appEx = (ApplicationException) ex;
+          assertThat(appEx.getError()).isEqualTo(ApplicationError.NOT_SUPPORT_TYPE);
+        });
+  }
+
+  @Test
+  @DisplayName("이미지 파일 이름 생성 테스트")
+  void 이미지_파일명을_생성할_수_있다() {
+    String fileName = ImageUtils.generateImageFileName("image/png", ImageDirectory.PROFILE);
+
+    assertThat(fileName).startsWith("profile/");
+    assertThat(fileName).endsWith(".png");
+    assertThat(fileName.length()).isGreaterThan("profile/.png".length());
+  }
+}

--- a/src/test/unit/java/com/bob/infra/aws/adapter/S3AccessorTest.java
+++ b/src/test/unit/java/com/bob/infra/aws/adapter/S3AccessorTest.java
@@ -1,0 +1,58 @@
+package com.bob.infra.aws.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@DisplayName("S3 Presigned URL 생성 테스트")
+@ExtendWith(MockitoExtension.class)
+class S3AccessorTest {
+
+  @Mock
+  private S3Presigner signer;
+
+  @InjectMocks
+  private S3Accessor s3Accessor;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(s3Accessor, "bucketName", "bucket");
+  }
+
+  @Test
+  @DisplayName("Presigned PUT URL 생성 테스트")
+  void presignedPutUrl을_생성할_수_있다() throws MalformedURLException {
+    // given
+    String fileName = "profile/test.png";
+    String contentType = "image/png";
+    URI uri = URI.create("https://dummy-s3.com/" + fileName);
+
+    PresignedPutObjectRequest presignedRequest = mock(PresignedPutObjectRequest.class);
+    given(presignedRequest.url()).willReturn(uri.toURL());
+    given(signer.presignPutObject(any(PutObjectPresignRequest.class))).willReturn(presignedRequest);
+
+    // when
+    String result = s3Accessor.getImageUploadUrl(fileName, contentType);
+
+    // then
+    assertThat(result).isEqualTo(uri.toString());
+    verify(signer, times(1)).presignPutObject(any(PutObjectPresignRequest.class));
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileImageUrlCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileImageUrlCommandFixture.java
@@ -1,0 +1,14 @@
+package com.bob.support.fixture.command;
+
+import com.bob.domain.member.service.dto.command.ChangeProfileImageUrlCommand;
+
+public class ChangeProfileImageUrlCommandFixture {
+
+  public static ChangeProfileImageUrlCommand defaultChangeProfileImageUrlCommand() {
+    return new ChangeProfileImageUrlCommand(1L, "image/png");
+  }
+
+  public static ChangeProfileImageUrlCommand unSupportedChangeProfileImageUrlCommand() {
+    return new ChangeProfileImageUrlCommand(1L, "video/mp4");
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileImageUrlCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileImageUrlCommandFixture.java
@@ -8,6 +8,10 @@ public class ChangeProfileImageUrlCommandFixture {
     return new ChangeProfileImageUrlCommand(1L, "image/png");
   }
 
+  public static ChangeProfileImageUrlCommand customChangeProfileImageUrlCommand(Long memberId) {
+    return new ChangeProfileImageUrlCommand(memberId, "image/png");
+  }
+
   public static ChangeProfileImageUrlCommand unSupportedChangeProfileImageUrlCommand() {
     return new ChangeProfileImageUrlCommand(1L, "video/mp4");
   }

--- a/src/test/unit/java/com/bob/support/fixture/response/MemberProfileImageUrlResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/MemberProfileImageUrlResponseFixture.java
@@ -1,0 +1,20 @@
+package com.bob.support.fixture.response;
+
+import com.bob.domain.member.service.dto.response.MemberProfileImageUrlResponse;
+
+public class MemberProfileImageUrlResponseFixture {
+
+  public static final MemberProfileImageUrlResponse DEFAULT_MEMBER_PROFILE_IMAGE_URL_RESPONSE =
+      MemberProfileImageUrlResponse.builder()
+          .fileName("profile/test.png")
+          .imageUploadUrl("https://s3-url.com/presigned")
+          .build();
+
+  public static MemberProfileImageUrlResponse mockPresignedUrlResponse(String fileName) {
+    String dummyUrl = "https://dummy-presigned-url.com/" + fileName;
+    return MemberProfileImageUrlResponse.builder()
+        .fileName(fileName)
+        .imageUploadUrl(dummyUrl)
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.bob.web.member.controller;
 
+import static com.bob.support.fixture.response.MemberProfileImageUrlResponseFixture.DEFAULT_MEMBER_PROFILE_IMAGE_URL_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.DEFAULT_MEMBER_PROFILE_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileWithPostsResponseFixture.DEFAULT_MEMBER_PROFILE_WITH_POSTS_RESPONSE;
 import static org.mockito.ArgumentMatchers.any;
@@ -173,4 +174,28 @@ class MemberControllerTest {
     // then
     verify(memberService, times(1)).issueTempPasswordProcess(any(IssuePasswordCommand.class));
   }
+
+  @Test
+  @DisplayName("프로필 이미지 변경 API 호출 테스트")
+  void 프로필_이미지_Presigned_URL_발급_API를_호출할_수_있다() throws Exception {
+    // given
+    String json = """
+    {
+      "contentType": "image/png"
+    }
+    """;
+    given(memberService.changeProfileImageUrlProcess(any())).willReturn(DEFAULT_MEMBER_PROFILE_IMAGE_URL_RESPONSE);
+
+    // when & then
+    mvc.perform(patch("/members/me/image")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)
+            .requestAttr("memberId", 1L))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.fileName").value("profile/test.png"))
+        .andExpect(jsonPath("$.imageUploadUrl").value("https://s3-url.com/presigned"));
+
+    verify(memberService, times(1)).changeProfileImageUrlProcess(any());
+  }
+
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #23

### 📜 작업 내용
- [x] S3 연결 및 설정파일 작성
- [x] 이미지 업로드 요청 시 presigned URL 발급 및 경로 저장 기능 구현

### 📄 참고
이미지 업로드는 Presigned URL 방식을 사용하여 클라이언트가 직접 S3에 PUT 요청을 보냅니다.
- 서버는 클라이언트 요청 시 content type을 바탕으로 S3 업로드용 Presigned URL을 발급하고, 클라이언트는 해당 URL을 통해 이미지를 S3에 업로드합니다.

### ⚠️ 종료할 이슈
this closes #23 
