### PR TITLE
feat#27: 게시글 등록 기능 구현

### DIFF
--- a/src/main/java/com/bob/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/bob/domain/book/repository/BookRepository.java
@@ -1,0 +1,10 @@
+package com.bob.domain.book.repository;
+
+import com.bob.domain.book.entity.Book;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BookRepository extends CrudRepository<Book, Long> {
+
+  Optional<Book> findByIsbn13(String isbn);
+}

--- a/src/main/java/com/bob/domain/book/service/BookService.java
+++ b/src/main/java/com/bob/domain/book/service/BookService.java
@@ -1,0 +1,23 @@
+package com.bob.domain.book.service;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.repository.BookRepository;
+import com.bob.domain.book.service.dto.BookCreateCommand;
+import com.bob.domain.book.service.reader.BookReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class BookService {
+
+  private final BookRepository bookRepository;
+  private final BookReader bookReader;
+
+  @Transactional
+  public Book createBookProcess(BookCreateCommand command) {
+    return bookReader.readOptionalBookByIsbn(command.isbn13())
+        .orElseGet(() -> bookRepository.save(command.toBook()));
+  }
+}

--- a/src/main/java/com/bob/domain/book/service/dto/BookCreateCommand.java
+++ b/src/main/java/com/bob/domain/book/service/dto/BookCreateCommand.java
@@ -1,0 +1,25 @@
+package com.bob.domain.book.service.dto;
+
+import com.bob.domain.book.entity.Book;
+import java.time.LocalDate;
+
+public record BookCreateCommand(
+    String isbn13,
+    String title,
+    String description,
+    Integer priceStandard,
+    String cover,
+    LocalDate pubDate
+) {
+
+  public Book toBook() {
+    return Book.builder()
+        .isbn13(isbn13)
+        .title(title)
+        .description(description)
+        .priceStandard(priceStandard)
+        .cover(cover)
+        .pubDate(pubDate)
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/book/service/reader/BookReader.java
+++ b/src/main/java/com/bob/domain/book/service/reader/BookReader.java
@@ -1,0 +1,20 @@
+package com.bob.domain.book.service.reader;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.repository.BookRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class BookReader {
+
+  private final BookRepository bookRepository;
+
+  public Optional<Book> readOptionalBookByIsbn(String isbn) {
+    return bookRepository.findByIsbn13(isbn);
+  }
+}

--- a/src/main/java/com/bob/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/bob/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.bob.domain.category.repository;
+
+import com.bob.domain.category.entity.Category;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CategoryRepository extends CrudRepository<Category, Long> {
+
+}

--- a/src/main/java/com/bob/domain/category/service/reader/CategoryReader.java
+++ b/src/main/java/com/bob/domain/category/service/reader/CategoryReader.java
@@ -1,0 +1,22 @@
+package com.bob.domain.category.service.reader;
+
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.category.repository.CategoryRepository;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CategoryReader {
+
+  private final CategoryRepository categoryRepository;
+
+  public Category readCategoryById(Long categoryId) {
+    return categoryRepository.findById(categoryId)
+        .orElseThrow(() -> new ApplicationException(ApplicationError.UN_SUPPORTED_CATEGORY));
+  }
+}

--- a/src/main/java/com/bob/domain/post/entity/status/BookStatus.java
+++ b/src/main/java/com/bob/domain/post/entity/status/BookStatus.java
@@ -1,5 +1,9 @@
 package com.bob.domain.post.entity.status;
 
+import static com.bob.global.exception.response.ApplicationError.UN_SUPPORTED_BOOK_STATUS;
+
+import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +16,11 @@ public enum BookStatus {
   LOW("하");
 
   private final String status;
+
+  public static BookStatus from(String status) {
+    return Arrays.stream(BookStatus.values())
+        .filter(value -> value.getStatus().equals(status))
+        .findFirst()
+        .orElseThrow(() -> new ApplicationException(UN_SUPPORTED_BOOK_STATUS));
+  }
 }

--- a/src/main/java/com/bob/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package com.bob.domain.post.repository;
+
+import com.bob.domain.post.entity.Post;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PostRepository extends CrudRepository<Post, Long> {
+
+}

--- a/src/main/java/com/bob/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostRepository.java
@@ -1,8 +1,10 @@
 package com.bob.domain.post.repository;
 
 import com.bob.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PostRepository extends CrudRepository<Post, Long> {
 
+  List<Post> findAllBySellerId(Long sellerId);
 }

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -1,0 +1,42 @@
+package com.bob.domain.post.service;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.service.BookService;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.category.service.reader.CategoryReader;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.service.reader.MemberReader;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.repository.PostRepository;
+import com.bob.domain.post.service.dto.command.CreatePostCommand;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostService {
+
+  private final PostRepository postRepository;
+
+  private final BookService bookService;
+  private final MemberReader memberReader;
+  private final CategoryReader categoryReader;
+
+  @Transactional
+  public void createPostProcess(CreatePostCommand command) {
+    Book book = bookService.createBookProcess(command.toBookCreateCommand());
+    Member member = memberReader.readMemberById(command.memberId());
+    verifyAreaAuthentication(member);
+    Category category = categoryReader.readCategoryById(command.categoryId());
+    Post post = command.toPost(book, member, category);
+    postRepository.save(post);
+  }
+
+  private void verifyAreaAuthentication(Member member) {
+    if(member.getActivityArea().isValidAuthentication()) return;
+    throw new ApplicationException(ApplicationError.NOT_VERIFIED_MEMBER);
+  }
+}

--- a/src/main/java/com/bob/domain/post/service/dto/command/CreatePostCommand.java
+++ b/src/main/java/com/bob/domain/post/service/dto/command/CreatePostCommand.java
@@ -1,0 +1,52 @@
+package com.bob.domain.post.service.dto.command;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.service.dto.BookCreateCommand;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.status.BookStatus;
+import com.bob.domain.post.entity.status.PostStatus;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record CreatePostCommand(
+    Long memberId,
+    Long categoryId,
+    Integer sellPrice,
+    String postDescription,
+    String bookStatus,
+    String bookIsbn,
+    String bookTitle,
+    String bookAuthor,
+    String bookDescription,
+    Integer bookPriceStandard,
+    String bookCover,
+    LocalDate bookPubDate
+) {
+
+  public Post toPost(Book book, Member member, Category category) {
+    return Post.builder()
+        .book(book)
+        .seller(member)
+        .category(category)
+        .bookStatus(BookStatus.from(bookStatus))
+        .postStatus(PostStatus.READY)
+        .sellPrice(sellPrice)
+        .description(postDescription)
+        .thumbnailUrl(bookCover)
+        .build();
+  }
+
+  public BookCreateCommand toBookCreateCommand() {
+    return new BookCreateCommand(
+        bookIsbn,
+        bookTitle,
+        bookDescription,
+        bookPriceStandard,
+        bookCover,
+        bookPubDate
+    );
+  }
+}

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -11,6 +11,7 @@ public enum ApplicationError {
   // 공통 예외
   UN_SUPPORTED_TYPE("E001", "지원하지 않는 형식입니다.", HttpStatus.BAD_REQUEST),
   UN_SUPPORTED_CATEGORY("E002", "지원하지 않는 카테고리입니다.", HttpStatus.BAD_REQUEST),
+  UN_SUPPORTED_BOOK_STATUS("E003", "지원하지 않는 도서 상태입니다.", HttpStatus.BAD_REQUEST),
 
   // 사용자 예외
   UNVERIFIED_EMAIL("E101", "이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),
@@ -26,7 +27,10 @@ public enum ApplicationError {
   NOT_EXISTS_AREA("E201", "존재하지 않는 읍/면/동 입니다.", HttpStatus.BAD_REQUEST),
   NOT_EXISTS_ACTIVITY_AREA("E201", "활동지역을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
 
-  INVALID_AREA_AUTHENTICATION("E211", "현재 위치를 인증할 수 없습니다.", HttpStatus.BAD_REQUEST)
+  INVALID_AREA_AUTHENTICATION("E211", "현재 위치를 인증할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+  // 게시글 예외
+  NOT_VERIFIED_MEMBER("E106", "위치 인증을 하지 않은 사용자는 게시글을 작성할 수 없습니다.", HttpStatus.FORBIDDEN),
   ;
 
   private String code;

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ApplicationError {
 
   // 공통 예외
-  NOT_SUPPORT_TYPE("E001", "지원하지 않는 형식입니다.", HttpStatus.BAD_REQUEST),
+  UN_SUPPORTED_TYPE("E001", "지원하지 않는 형식입니다.", HttpStatus.BAD_REQUEST),
 
   // 사용자 예외
   UNVERIFIED_EMAIL("E101", "이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -10,6 +10,7 @@ public enum ApplicationError {
 
   // 공통 예외
   UN_SUPPORTED_TYPE("E001", "지원하지 않는 형식입니다.", HttpStatus.BAD_REQUEST),
+  UN_SUPPORTED_CATEGORY("E002", "지원하지 않는 카테고리입니다.", HttpStatus.BAD_REQUEST),
 
   // 사용자 예외
   UNVERIFIED_EMAIL("E101", "이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/bob/global/utils/ImageUtils.java
+++ b/src/main/java/com/bob/global/utils/ImageUtils.java
@@ -17,7 +17,7 @@ public class ImageUtils {
       case "image/jpeg" -> "jpg";
       case "image/png" -> "png";
       case "image/gif" -> "gif";
-      default -> throw new ApplicationException(ApplicationError.NOT_SUPPORT_TYPE);
+      default -> throw new ApplicationException(ApplicationError.UN_SUPPORTED_TYPE);
     };
   }
 }

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -1,0 +1,34 @@
+package com.bob.web.post.controller;
+
+import static com.bob.web.common.symbol.ResponseSymbol.*;
+
+import com.bob.domain.post.service.PostService;
+import com.bob.web.common.AuthenticationId;
+import com.bob.web.common.CommonResponse;
+import com.bob.web.common.symbol.ResponseSymbol;
+import com.bob.web.post.request.CreatePostRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/posts")
+public class PostController {
+
+  private final PostService postService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public CommonResponse<ResponseSymbol> handleCreatePost(
+      @RequestBody CreatePostRequest request,
+      @AuthenticationId Long memberId
+  ) {
+    postService.createPostProcess(request.toCommand(memberId));
+    return new CommonResponse<>(true, CREATED);
+  }
+}

--- a/src/main/java/com/bob/web/post/request/CreatePostRequest.java
+++ b/src/main/java/com/bob/web/post/request/CreatePostRequest.java
@@ -1,0 +1,44 @@
+package com.bob.web.post.request;
+
+import com.bob.domain.post.service.dto.command.CreatePostCommand;
+import java.time.LocalDate;
+
+public record CreatePostRequest(
+    Long categoryId,
+    Integer sellPrice,
+    String bookStatus,
+    String postDescription,
+    BookInfo book
+) {
+
+  public CreatePostCommand toCommand(Long memberId) {
+    return CreatePostCommand.builder()
+        .memberId(memberId)
+        .categoryId(categoryId)
+        .sellPrice(sellPrice)
+        .postDescription(postDescription)
+        .bookStatus(bookStatus)
+        .bookIsbn(book.isbn())
+        .bookTitle(book.title())
+        .bookAuthor(book.author())
+        .bookDescription(book.description())
+        .bookPriceStandard(book.priceStandard())
+        .bookCover(book.cover())
+        .bookPubDate(book.pubDate())
+        .build();
+  }
+}
+
+record BookInfo(
+    String isbn,
+    String title,
+    String author,
+    String description,
+    Integer priceStandard,
+    String cover,
+    LocalDate pubDate
+) {
+
+}
+
+

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -1,0 +1,114 @@
+package com.bob.domain.post.service;
+
+import static com.bob.global.exception.response.ApplicationError.NOT_VERIFIED_MEMBER;
+import static com.bob.support.fixture.command.CreatePostCommandFixture.defaultCreatePostCommand;
+import static com.bob.support.fixture.domain.ActivityAreaFixture.customActivityArea;
+import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
+import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bob.domain.area.entity.EmdArea;
+import com.bob.domain.area.repository.AreaRepository;
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.repository.BookRepository;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.category.repository.CategoryRepository;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.repository.MemberRepository;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.repository.PostRepository;
+import com.bob.domain.post.service.dto.command.CreatePostCommand;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.support.TestContainerSupport;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("게시글 서비스 통합 테스트")
+@Transactional
+@SpringBootTest
+class PostServiceIntgTest extends TestContainerSupport {
+
+  @Autowired
+  private PostService postService;
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private CategoryRepository categoryRepository;
+
+  @Autowired
+  private BookRepository bookRepository;
+
+  @Autowired
+  private AreaRepository areaRepository;
+
+  private EmdArea emdArea;
+
+  @BeforeEach
+  void setUp() {
+    emdArea = areaRepository.findById(213).get();
+    postRepository.deleteAll();
+    memberRepository.deleteAll();
+    bookRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("게시글 등록 - 성공 테스트")
+  void 위치_인증이_된_사용자는_게시글을_등록할_수_있다() {
+    // given
+    Member seller = defaultMember();
+    memberRepository.save(seller);
+    seller.updateActivityArea(customActivityArea(seller, emdArea));
+    seller.getActivityArea().updateAuthenticationAt(LocalDate.now());
+
+    Category category = categoryRepository.save(defaultCategory());
+    CreatePostCommand command = defaultCreatePostCommand(seller.getId(), category.getId());
+
+    // when
+    postService.createPostProcess(command);
+
+    // then
+    List<Post> posts = postRepository.findAllBySellerId(seller.getId());
+    assertThat(posts).hasSize(1);
+
+    Post saved = posts.get(0);
+    assertThat(saved.getSeller().getId()).isEqualTo(seller.getId());
+    assertThat(saved.getCategory().getId()).isEqualTo(category.getId());
+    assertThat(saved.getBook().getIsbn13()).isEqualTo(command.bookIsbn());
+
+    Book book = bookRepository.findByIsbn13(command.bookIsbn()).get();
+    assertThat(book).isNotNull();
+    assertThat(book.getTitle()).isEqualTo(command.bookTitle());
+  }
+
+  @Test
+  @DisplayName("게시글 등록 - 실패 테스트(위치 인증 X)")
+  void 위치_인증이_안된_사용자는_게시글을_등록할_수_없다() {
+    // given
+    Member seller = defaultMember();
+    memberRepository.save(seller);
+    seller.updateActivityArea(customActivityArea(seller, emdArea));
+    seller.getActivityArea().updateAuthenticationAt(LocalDate.now().minusMonths(2));
+
+    Category category = categoryRepository.save(defaultCategory());
+    CreatePostCommand command = defaultCreatePostCommand(seller.getId(), category.getId());
+
+    // when & then
+    assertThatThrownBy(() -> postService.createPostProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(NOT_VERIFIED_MEMBER.getMessage());
+
+    assertThat(postRepository.findAll()).isEmpty();
+  }
+}

--- a/src/test/unit/java/com/bob/domain/book/service/BookServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/book/service/BookServiceTest.java
@@ -1,0 +1,69 @@
+package com.bob.domain.book.service;
+
+import static com.bob.support.fixture.command.BookCreateCommandFixture.defaultBookCreateCommand;
+import static com.bob.support.fixture.domain.BookFixture.defaultBook;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.repository.BookRepository;
+import com.bob.domain.book.service.dto.BookCreateCommand;
+import com.bob.domain.book.service.reader.BookReader;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookServiceTest {
+
+  @InjectMocks
+  private BookService bookService;
+
+  @Mock
+  private BookReader bookReader;
+
+  @Mock
+  private BookRepository bookRepository;
+
+  @Test
+  @DisplayName("책 조회 및 생성 - 조회된 Book 반환")
+  void 이미_존재하는_도서가_있으면_저장하지_않고_조회된_도서를_반환한다() {
+    // given
+    BookCreateCommand command = defaultBookCreateCommand();
+    Book existingBook = defaultBook();
+    given(bookReader.readOptionalBookByIsbn(command.isbn13())).willReturn(Optional.of(existingBook));
+
+    // when
+    Book result = bookService.createBookProcess(command);
+
+    // then
+    assertThat(result).isEqualTo(existingBook);
+    verify(bookReader).readOptionalBookByIsbn(command.isbn13());
+    verify(bookRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("책 조회 및 생성 - 존재하지 않는 경우 새로 저장 후 반환")
+  void 존재하지_않는_도서면_새로_저장하고_반환한다() {
+    // given
+    BookCreateCommand command = defaultBookCreateCommand();
+    Book newBook = command.toBook();
+    given(bookReader.readOptionalBookByIsbn(command.isbn13())).willReturn(Optional.empty());
+    given(bookRepository.save(any(Book.class))).willReturn(newBook);
+
+    // when
+    Book result = bookService.createBookProcess(command);
+
+    // then
+    assertThat(result).isEqualTo(newBook);
+    verify(bookReader).readOptionalBookByIsbn(command.isbn13());
+    verify(bookRepository).save(any(Book.class));
+  }
+}

--- a/src/test/unit/java/com/bob/domain/book/service/reader/BookReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/book/service/reader/BookReaderTest.java
@@ -1,0 +1,58 @@
+package com.bob.domain.book.service.reader;
+
+import static com.bob.support.fixture.domain.BookFixture.DEFAULT_ISBN;
+import static com.bob.support.fixture.domain.BookFixture.defaultBook;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.repository.BookRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookReaderTest {
+
+  @InjectMocks
+  private BookReader bookReader;
+
+  @Mock
+  private BookRepository bookRepository;
+
+  @Test
+  @DisplayName("ISBN Book 조회 - 존재하는 경우")
+  void isbn으로_책을_조회하면_존재하면_반환한다() {
+    // given
+    Book book = defaultBook();
+    given(bookRepository.findByIsbn13(DEFAULT_ISBN)).willReturn(Optional.of(book));
+
+    // when
+    Optional<Book> result = bookReader.readOptionalBookByIsbn(DEFAULT_ISBN);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get().getIsbn13()).isEqualTo(DEFAULT_ISBN);
+    verify(bookRepository).findByIsbn13(DEFAULT_ISBN);
+  }
+
+  @Test
+  @DisplayName("ISBN Book 조회 - 존재하지 않는 경우")
+  void isbn으로_책을_조회하면_존재하지_않으면_empty를_반환한다() {
+    // given
+    String isbn = "0000000000000";
+    given(bookRepository.findByIsbn13(isbn)).willReturn(Optional.empty());
+
+    // when
+    Optional<Book> result = bookReader.readOptionalBookByIsbn(isbn);
+
+    // then
+    assertThat(result).isEmpty();
+    verify(bookRepository).findByIsbn13(isbn);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/category/service/reader/CategoryReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/category/service/reader/CategoryReaderTest.java
@@ -1,0 +1,59 @@
+package com.bob.domain.category.service.reader;
+
+import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.category.repository.CategoryRepository;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryReaderTest {
+
+  @InjectMocks
+  private CategoryReader categoryReader;
+
+  @Mock
+  private CategoryRepository categoryRepository;
+
+  @Test
+  @DisplayName("카테고리 ID로 조회 - 존재하는 경우")
+  void 카테고리ID로_조회하면_존재하는_경우_정상_반환한다() {
+    // given
+    Category category = defaultCategory();
+    given(categoryRepository.findById(category.getId())).willReturn(Optional.of(category));
+
+    // when
+    Category result = categoryReader.readCategoryById(category.getId());
+
+    // then
+    assertThat(result).isEqualTo(category);
+    verify(categoryRepository).findById(category.getId());
+  }
+
+  @Test
+  @DisplayName("카테고리 ID로 조회 - 존재하지 않는 경우 예외 발생")
+  void 카테고리ID로_조회하면_존재하지_않으면_예외를_던진다() {
+    // given
+    Long categoryId = -1L;
+    given(categoryRepository.findById(categoryId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> categoryReader.readCategoryById(categoryId))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.UN_SUPPORTED_CATEGORY.getMessage());
+
+    verify(categoryRepository).findById(categoryId);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -334,6 +334,6 @@ class MemberServiceTest {
     // when & then
     assertThatThrownBy(() -> memberService.changeProfileImageUrlProcess(command))
         .isInstanceOf(ApplicationException.class)
-        .hasMessageContaining(ApplicationError.NOT_SUPPORT_TYPE.getMessage());
+        .hasMessageContaining(ApplicationError.UN_SUPPORTED_TYPE.getMessage());
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/unit/java/com/bob/domain/post/repository/PostRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.bob.domain.post.repository;
+
+import static com.bob.support.fixture.domain.BookFixture.defaultBook;
+import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
+import static com.bob.support.fixture.domain.PostFixture.defaultPost;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.repository.BookRepository;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.category.repository.CategoryRepository;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.repository.MemberRepository;
+import com.bob.domain.post.entity.Post;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@DisplayName("PostRepository 테스트")
+class PostRepositoryTest {
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private BookRepository bookRepository;
+
+  @Autowired
+  private CategoryRepository categoryRepository;
+
+  private Member savedMember;
+
+  @BeforeEach
+  void setUp() {
+    Member member = defaultMember();
+    Book book = defaultBook();
+    Category category = Category.builder().name("TEST").build();
+
+    savedMember = memberRepository.save(member);
+    Book savedBook = bookRepository.save(book);
+    Category savedCategory = categoryRepository.save(category);
+
+    Post post = defaultPost(savedBook, savedMember, savedCategory);
+    postRepository.save(post);
+  }
+
+  @Test
+  @DisplayName("판매자 ID로 게시글 목록 조회 - 반환 테스트")
+  void 판매자_ID로_게시글을_조회할_수_있다() {
+    // when
+    List<Post> result = postRepository.findAllBySellerId(savedMember.getId());
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result).extracting(post -> post.getSeller().getId()).containsOnly(savedMember.getId());
+  }
+
+  @Test
+  @DisplayName("판매자 ID로 게시글 목록 조회 - empty 테스트")
+  void 판매자_ID로_게시글이_없으면_빈_리스트를_반환한다() {
+    // when
+    List<Post> result = postRepository.findAllBySellerId(-1L);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -1,0 +1,96 @@
+package com.bob.domain.post.service;
+
+import static com.bob.global.exception.response.ApplicationError.NOT_VERIFIED_MEMBER;
+import static com.bob.support.fixture.command.CreatePostCommandFixture.defaultCreatePostCommand;
+import static com.bob.support.fixture.domain.BookFixture.defaultBook;
+import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
+import static com.bob.support.fixture.domain.MemberFixture.authenticatedMember;
+import static com.bob.support.fixture.domain.MemberFixture.unverifiedMember;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.book.service.BookService;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.category.service.reader.CategoryReader;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.service.reader.MemberReader;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.repository.PostRepository;
+import com.bob.domain.post.service.dto.command.CreatePostCommand;
+import com.bob.global.exception.exceptions.ApplicationException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("게시글 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+  @InjectMocks
+  private PostService postService;
+
+  @Mock
+  private BookService bookService;
+
+  @Mock
+  private MemberReader memberReader;
+
+  @Mock
+  private CategoryReader categoryReader;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Test
+  @DisplayName("게시글 등록 - 성공 테스트")
+  void 게시글을_등록할_수_있다() {
+    // given
+    CreatePostCommand command = defaultCreatePostCommand();
+    Book book = defaultBook();
+    Member member = authenticatedMember();
+    Category category = defaultCategory();
+    given(bookService.createBookProcess(command.toBookCreateCommand())).willReturn(book);
+    given(memberReader.readMemberById(command.memberId())).willReturn(member);
+    given(categoryReader.readCategoryById(command.categoryId())).willReturn(category);
+
+    ArgumentCaptor<Post> captor = ArgumentCaptor.forClass(Post.class);
+
+    // when
+    postService.createPostProcess(command);
+
+    // then
+    then(bookService).should().createBookProcess(command.toBookCreateCommand());
+    then(memberReader).should().readMemberById(command.memberId());
+    then(categoryReader).should().readCategoryById(command.categoryId());
+    then(postRepository).should(times(1)).save(captor.capture());
+
+    Post saved = captor.getValue();
+    Assertions.assertThat(saved.getBook()).isEqualTo(book);
+    Assertions.assertThat(saved.getSeller()).isEqualTo(member);
+    Assertions.assertThat(saved.getCategory()).isEqualTo(category);
+  }
+
+  @Test
+  @DisplayName("게시글 등록 - 실패 테스트(위치 인증 안된 사용자)")
+  void 위치인증_되지_않은_사용자는_게시글을_등록할_수_없다() {
+    // given
+    CreatePostCommand command = defaultCreatePostCommand();
+    Member member = unverifiedMember();
+
+    given(bookService.createBookProcess(command.toBookCreateCommand())).willReturn(defaultBook());
+    given(memberReader.readMemberById(command.memberId())).willReturn(member);
+
+    // when & then
+    assertThatThrownBy(() -> postService.createPostProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(NOT_VERIFIED_MEMBER.getMessage());
+  }
+}

--- a/src/test/unit/java/com/bob/global/utils/ImageUtilsTest.java
+++ b/src/test/unit/java/com/bob/global/utils/ImageUtilsTest.java
@@ -26,7 +26,7 @@ class ImageUtilsTest {
         .isInstanceOf(ApplicationException.class)
         .satisfies(ex -> {
           ApplicationException appEx = (ApplicationException) ex;
-          assertThat(appEx.getError()).isEqualTo(ApplicationError.NOT_SUPPORT_TYPE);
+          assertThat(appEx.getError()).isEqualTo(ApplicationError.UN_SUPPORTED_TYPE);
         });
   }
 

--- a/src/test/unit/java/com/bob/support/fixture/command/BookCreateCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/BookCreateCommandFixture.java
@@ -1,0 +1,20 @@
+package com.bob.support.fixture.command;
+
+import static com.bob.support.fixture.domain.BookFixture.DEFAULT_ISBN;
+
+import com.bob.domain.book.service.dto.BookCreateCommand;
+import java.time.LocalDate;
+
+public class BookCreateCommandFixture {
+
+  public static BookCreateCommand defaultBookCreateCommand() {
+    return new BookCreateCommand(
+        DEFAULT_ISBN,
+        "객체지향의 사실과 오해",
+        "설명",
+        10000,
+        "https://image.url",
+        LocalDate.now()
+    );
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/CreatePostCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreatePostCommandFixture.java
@@ -21,4 +21,21 @@ public class CreatePostCommandFixture {
         .bookPubDate(LocalDate.of(2024, 4, 29))
         .build();
   }
+
+  public static CreatePostCommand defaultCreatePostCommand(Long memberId, Long categoryId) {
+    return CreatePostCommand.builder()
+        .memberId(memberId)
+        .categoryId(categoryId)
+        .sellPrice(39000)
+        .bookStatus("최상")
+        .postDescription("신품급 도서 팝니다.")
+        .bookIsbn("9788966264414")
+        .bookTitle("JVM 밑바닥까지 파헤치기")
+        .bookAuthor("저우즈밍")
+        .bookDescription("핵심 JVM 원리 설명")
+        .bookPriceStandard(43000)
+        .bookCover("https://cover.url")
+        .bookPubDate(LocalDate.of(2024, 4, 29))
+        .build();
+  }
 }

--- a/src/test/unit/java/com/bob/support/fixture/command/CreatePostCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreatePostCommandFixture.java
@@ -1,0 +1,24 @@
+package com.bob.support.fixture.command;
+
+import com.bob.domain.post.service.dto.command.CreatePostCommand;
+import java.time.LocalDate;
+
+public class CreatePostCommandFixture {
+
+  public static CreatePostCommand defaultCreatePostCommand() {
+    return CreatePostCommand.builder()
+        .memberId(1L)
+        .categoryId(1L)
+        .sellPrice(38000)
+        .bookStatus("최상")
+        .postDescription("거의 새 책입니다.")
+        .bookIsbn("9788966264414")
+        .bookTitle("JVM 밑바닥까지 파헤치기")
+        .bookAuthor("저우즈밍")
+        .bookDescription("JVM 핵심 원리 소개")
+        .bookPriceStandard(43000)
+        .bookCover("https://image.jpg")
+        .bookPubDate(LocalDate.of(2024, 4, 29))
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/BookFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/BookFixture.java
@@ -1,0 +1,30 @@
+package com.bob.support.fixture.domain;
+
+import com.bob.domain.book.entity.Book;
+import java.time.LocalDate;
+
+public class BookFixture {
+  public static final String DEFAULT_ISBN = "9788998139766";
+
+  public static Book defaultBook() {
+    return Book.builder()
+        .isbn13(DEFAULT_ISBN)
+        .title("객체지향의 사실과 오해")
+        .description("설명")
+        .priceStandard(10000)
+        .cover("https://image.url")
+        .pubDate(LocalDate.now())
+        .build();
+  }
+
+  public static Book customBook(String isbn) {
+    return Book.builder()
+        .isbn13(isbn)
+        .title("커스텀 책")
+        .description("기본 설명")
+        .priceStandard(12000)
+        .cover("https://image.url/cover")
+        .pubDate(LocalDate.now())
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/CategoryFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/CategoryFixture.java
@@ -1,0 +1,16 @@
+package com.bob.support.fixture.domain;
+
+import com.bob.domain.category.entity.Category;
+
+public class CategoryFixture {
+
+  public static final Long DEFAULT_CATEGORY_ID = 1L;
+  public static final String DEFAULT_CATEGORY_NAME = "경제/경영";
+
+  public static Category defaultCategory() {
+    return Category.builder()
+        .id(DEFAULT_CATEGORY_ID)
+        .name(DEFAULT_CATEGORY_NAME)
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
@@ -1,6 +1,11 @@
 package com.bob.support.fixture.domain;
 
+import static com.bob.support.fixture.domain.ActivityAreaFixture.customTimeActivityArea;
+import static com.bob.support.fixture.domain.ActivityAreaFixture.defaultActivityArea;
+import static com.bob.support.fixture.domain.EmdAreaFixture.defaultEmdArea;
+
 import com.bob.domain.member.entity.Member;
+import java.time.LocalDate;
 
 public class MemberFixture {
 
@@ -43,5 +48,17 @@ public class MemberFixture {
         .password(encryptedPassword)
         .nickname("tester")
         .build();
+  }
+
+  public static Member authenticatedMember() {
+    Member member = defaultMember();
+    member.updateActivityArea(defaultActivityArea());
+    return member;
+  }
+
+  public static Member unverifiedMember() {
+    Member member = defaultMember();
+    member.updateActivityArea(customTimeActivityArea(member, defaultEmdArea(), LocalDate.now().minusMonths(2)));
+    return member;
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/domain/PostFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/PostFixture.java
@@ -1,0 +1,24 @@
+package com.bob.support.fixture.domain;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.status.BookStatus;
+import com.bob.domain.post.entity.status.PostStatus;
+
+public class PostFixture {
+
+  public static Post defaultPost(Book book, Member seller, Category category) {
+    return Post.builder()
+        .book(book)
+        .seller(seller)
+        .category(category)
+        .bookStatus(BookStatus.BEST)
+        .postStatus(PostStatus.READY)
+        .sellPrice(30000)
+        .description("Description")
+        .thumbnailUrl("https://image/1.png")
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
+++ b/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
@@ -1,0 +1,70 @@
+package com.bob.web.post.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.bob.domain.post.service.PostService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("게시글 API 테스트")
+@ExtendWith(MockitoExtension.class)
+class PostControllerTest {
+
+  @InjectMocks
+  private PostController postController;
+
+  @Mock
+  private PostService postService;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    mvc = standaloneSetup(postController).build();
+  }
+
+  @Test
+  @DisplayName("게시글 생성 API 호출 테스트")
+  void 게시글_생성_API를_호출할_수_있다() throws Exception {
+    // given
+    String json = """
+        {
+          "categoryId": 1,
+          "sellPrice": 10000,
+          "bookStatus": "최상",
+          "postDescription": "Description",
+          "book": {
+            "bookIsbn": "1111111111111",
+            "bookTitle": "Title",
+            "bookAuthor": "Author",
+            "bookDescription": "Book Description",
+            "bookPriceStandard": 20000,
+            "bookCover": "https://image/1.jpg",
+            "bookPubDate": "2025-05-25"
+          }
+        }
+        """;
+
+    // when & then
+    mvc.perform(post("/posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)
+            .requestAttr("memberId", 1L))
+        .andExpect(status().isCreated());
+
+    verify(postService, times(1)).createPostProcess(any());
+  }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
> #27 

### 📜 작업 내용
- [x] 카테고리 조회 기능 구현
- [x] 책 등록 및 조회 기능 구현
- [x] 게시글 등록 기능 구현

### 📄 참고
기존 서비스 계층끼리의 협력 시 비주인 -> 주인의 경우 port, adapter 구조 사용
주인 -> 비주인의 경우 관계의 주인인 도메인은 비주인의 서비스 계층을 직접 사용

### ⚠️ 종료할 이슈
this closes #27 
