### PR TITLE
refactor#30: 회원 식별자 UUID로 전환

### DIFF
--- a/src/main/java/com/bob/domain/area/command/AuthenticationCommand.java
+++ b/src/main/java/com/bob/domain/area/command/AuthenticationCommand.java
@@ -1,13 +1,14 @@
 package com.bob.domain.area.command;
 
 import com.bob.domain.member.service.dto.command.AuthenticationPurpose;
+import java.util.UUID;
 
 public record AuthenticationCommand(
     Integer emdId,
     Double lat,
     Double lon,
     AuthenticationPurpose purpose,
-    Long memberId
+    UUID memberId
 ) {
 
   public boolean isGuest() {

--- a/src/main/java/com/bob/domain/area/entity/activity/ActivityArea.java
+++ b/src/main/java/com/bob/domain/area/entity/activity/ActivityArea.java
@@ -10,6 +10,7 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,7 +47,7 @@ public class ActivityArea {
     return new ActivityArea(id, member, emdArea, LocalDate.now());
   }
 
-  public static ActivityAreaId createId(Long memberId, Integer emdAreaId) {
+  public static ActivityAreaId createId(UUID memberId, Integer emdAreaId) {
     return new ActivityAreaId(memberId, emdAreaId);
   }
 

--- a/src/main/java/com/bob/domain/area/entity/activity/ActivityAreaId.java
+++ b/src/main/java/com/bob/domain/area/entity/activity/ActivityAreaId.java
@@ -3,6 +3,7 @@ package com.bob.domain.area.entity.activity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 public class ActivityAreaId implements Serializable {
 
   @Column
-  private Long memberId;
+  private UUID memberId;
 
   @Column
   private Integer emdAreaId;

--- a/src/main/java/com/bob/domain/area/service/AreaService.java
+++ b/src/main/java/com/bob/domain/area/service/AreaService.java
@@ -2,29 +2,26 @@ package com.bob.domain.area.service;
 
 import com.bob.domain.area.command.AuthenticationCommand;
 import com.bob.domain.area.entity.EmdArea;
-import com.bob.domain.area.repository.ActivityAreaRepository;
-import com.bob.domain.area.service.reader.ActivityAreaReader;
-import com.bob.domain.area.service.reader.AreaReader;
-import com.bob.domain.member.entity.Member;
 import com.bob.domain.area.entity.activity.ActivityArea;
 import com.bob.domain.area.entity.activity.ActivityAreaId;
+import com.bob.domain.area.service.reader.AreaReader;
+import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.service.reader.MemberReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.global.utils.geo.GeometryUtils;
 import java.time.LocalDate;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class AreaService {
 
-  private final ActivityAreaRepository activityAreaRepository;
-  private final ActivityAreaReader activityAreaReader;
   private final AreaReader areaReader;
   private final MemberReader memberReader;
 
@@ -43,22 +40,29 @@ public class AreaService {
     }
   }
 
-  private void handleReAuthenticate(AuthenticationCommand command) {
-    if(command.isGuest()) throw new ApplicationException(ApplicationError.NOT_EXISTS_MEMBER);
+  private void handleChangeArea(AuthenticationCommand command, EmdArea emdArea) {
+    verifyLoginMember(command.isGuest());
+    Member member = memberReader.readMemberById(command.memberId());
+    verifyIsSameArea(member.getActivityArea().getEmdArea().getId(), command.emdId());
     ActivityAreaId id = ActivityArea.createId(command.memberId(), command.emdId());
-    ActivityArea activityArea = activityAreaReader.readActivityArea(id);
-    activityArea.updateAuthenticationAt(LocalDate.now());
+    member.updateActivityArea(ActivityArea.create(id, member, emdArea));
   }
 
-  private void handleChangeArea(AuthenticationCommand command, EmdArea emdArea) {
-    if(command.isGuest()) throw new ApplicationException(ApplicationError.NOT_EXISTS_MEMBER);
-    ActivityAreaId id = ActivityArea.createId(command.memberId(), command.emdId());
-    activityAreaRepository.deleteById(id);
-
+  private void handleReAuthenticate(AuthenticationCommand command) {
+    verifyLoginMember(command.isGuest());
     Member member = memberReader.readMemberById(command.memberId());
-    ActivityArea newActivityArea = ActivityArea.create(id, member, emdArea);
+    member.getActivityArea().updateAuthenticationAt(LocalDate.now());
+  }
 
-    activityAreaRepository.save(newActivityArea);
-    member.updateActivityArea(newActivityArea);
+  private void verifyLoginMember(boolean isGuest) {
+    if (isGuest) {
+      throw new ApplicationException(ApplicationError.NOT_EXISTS_MEMBER);
+    }
+  }
+
+  private void verifyIsSameArea(Integer oldId, Integer newId) {
+    if (Objects.equals(oldId, newId)) {
+      throw new ApplicationException(ApplicationError.IS_SAME_REQUEST);
+    }
   }
 }

--- a/src/main/java/com/bob/domain/area/service/AreaService.java
+++ b/src/main/java/com/bob/domain/area/service/AreaService.java
@@ -11,7 +11,7 @@ import com.bob.domain.area.entity.activity.ActivityAreaId;
 import com.bob.domain.member.service.reader.MemberReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
-import com.bob.global.utils.GeometryUtils;
+import com.bob.global.utils.geo.GeometryUtils;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;

--- a/src/main/java/com/bob/domain/member/entity/Member.java
+++ b/src/main/java/com/bob/domain/member/entity/Member.java
@@ -2,16 +2,16 @@ package com.bob.domain.member.entity;
 
 import com.bob.domain.area.entity.activity.ActivityArea;
 import com.bob.global.audit.BaseTime;
+import com.bob.global.utils.uuid.GeneratedUuidV7;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,8 +27,8 @@ import lombok.NoArgsConstructor;
 public class Member extends BaseTime {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  @GeneratedUuidV7
+  private UUID id;
 
   @Column(unique = true, length = 50, nullable = false)
   private String email;

--- a/src/main/java/com/bob/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/bob/domain/member/repository/MemberRepository.java
@@ -1,10 +1,11 @@
 package com.bob.domain.member.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.bob.domain.member.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, UUID> {
 
   Optional<Member> findByEmail(String email);
 

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -4,8 +4,8 @@ import static com.bob.global.exception.response.ApplicationError.ALREADY_EXISTS_
 import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PASSWORD;
 import static com.bob.global.exception.response.ApplicationError.IS_SAME_VALUE;
 import static com.bob.global.exception.response.ApplicationError.UNVERIFIED_EMAIL;
-import static com.bob.global.utils.ImageDirectory.PROFILE;
-import static com.bob.global.utils.ImageUtils.generateImageFileName;
+import static com.bob.global.utils.image.ImageDirectory.PROFILE;
+import static com.bob.global.utils.image.ImageUtils.generateImageFileName;
 
 import com.bob.domain.area.entity.EmdArea;
 import com.bob.domain.area.service.reader.AreaReader;

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.bob.domain.member.service;
 
 import static com.bob.global.exception.response.ApplicationError.ALREADY_EXISTS_EMAIL;
 import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PASSWORD;
-import static com.bob.global.exception.response.ApplicationError.IS_SAME_VALUE;
+import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
 import static com.bob.global.exception.response.ApplicationError.UNVERIFIED_EMAIL;
 import static com.bob.global.utils.image.ImageDirectory.PROFILE;
 import static com.bob.global.utils.image.ImageUtils.generateImageFileName;
@@ -99,7 +99,7 @@ public class MemberService {
 
   private static void verifyNickname(Member member, String nickname) {
     if (member.isEqualsNickname(nickname)) {
-      throw new ApplicationException(IS_SAME_VALUE);
+      throw new ApplicationException(IS_SAME_REQUEST);
     }
   }
 

--- a/src/main/java/com/bob/domain/member/service/dto/command/ChangePasswordCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/ChangePasswordCommand.java
@@ -1,7 +1,9 @@
 package com.bob.domain.member.service.dto.command;
 
+import java.util.UUID;
+
 public record ChangePasswordCommand(
-    Long memberId,
+    UUID memberId,
     String oldPassword,
     String newPassword
 ) {

--- a/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileCommand.java
@@ -1,7 +1,9 @@
 package com.bob.domain.member.service.dto.command;
 
+import java.util.UUID;
+
 public record ChangeProfileCommand(
-    Long memberId,
+    UUID memberId,
     String nickname
 ) {
 

--- a/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileImageUrlCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileImageUrlCommand.java
@@ -1,7 +1,9 @@
 package com.bob.domain.member.service.dto.command;
 
+import java.util.UUID;
+
 public record ChangeProfileImageUrlCommand(
-    Long memberId,
+    UUID memberId,
     String contentType
 ) {
 

--- a/src/main/java/com/bob/domain/member/service/dto/query/ReadProfileQuery.java
+++ b/src/main/java/com/bob/domain/member/service/dto/query/ReadProfileQuery.java
@@ -1,10 +1,12 @@
 package com.bob.domain.member.service.dto.query;
 
+import java.util.UUID;
+
 public record ReadProfileQuery(
-    Long memberId
+    UUID memberId
 ) {
 
-  public static ReadProfileQuery of(Long memberId) {
+  public static ReadProfileQuery of(UUID memberId) {
     return new ReadProfileQuery(memberId);
   }
 }

--- a/src/main/java/com/bob/domain/member/service/dto/query/ReadProfileWithPostsQuery.java
+++ b/src/main/java/com/bob/domain/member/service/dto/query/ReadProfileWithPostsQuery.java
@@ -1,9 +1,10 @@
 package com.bob.domain.member.service.dto.query;
 
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public record ReadProfileWithPostsQuery(
-    Long memberId,
+    UUID memberId,
     Pageable pageable
 ) {
 

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
@@ -2,6 +2,7 @@ package com.bob.domain.member.service.dto.response;
 
 import com.bob.domain.area.entity.activity.ActivityArea;
 import com.bob.domain.member.entity.Member;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +10,7 @@ import lombok.Getter;
 @Builder
 public class MemberProfileResponse {
 
-  private Long memberId;
+  private UUID memberId;
   private String nickname;
   private String profileImageUrl;
   private Area area;

--- a/src/main/java/com/bob/domain/member/service/port/PostSearcher.java
+++ b/src/main/java/com/bob/domain/member/service/port/PostSearcher.java
@@ -2,9 +2,10 @@ package com.bob.domain.member.service.port;
 
 import com.bob.domain.post.service.dto.response.PostSummaryResponse;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public interface PostSearcher {
 
-  List<PostSummaryResponse> readPostsOfMember(Long memberId, Pageable pageable);
+  List<PostSummaryResponse> readPostsOfMember(UUID memberId, Pageable pageable);
 }

--- a/src/main/java/com/bob/domain/member/service/reader/MemberReader.java
+++ b/src/main/java/com/bob/domain/member/service/reader/MemberReader.java
@@ -4,6 +4,7 @@ import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.repository.MemberRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,7 +16,7 @@ public class MemberReader {
 
   private final MemberRepository memberRepository;
 
-  public Member readMemberById(Long id) {
+  public Member readMemberById(UUID id) {
     return memberRepository.findById(id)
         .orElseThrow(() -> new ApplicationException(ApplicationError.NOT_EXISTS_MEMBER));
   }

--- a/src/main/java/com/bob/domain/post/adapter/PostProvider.java
+++ b/src/main/java/com/bob/domain/post/adapter/PostProvider.java
@@ -3,6 +3,7 @@ package com.bob.domain.post.adapter;
 import com.bob.domain.member.service.port.PostSearcher;
 import com.bob.domain.post.service.dto.response.PostSummaryResponse;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class PostProvider implements PostSearcher {
 
   @Override
-  public List<PostSummaryResponse> readPostsOfMember(Long memberId, Pageable pageable) {
+  public List<PostSummaryResponse> readPostsOfMember(UUID memberId, Pageable pageable) {
     // TODO : 사용자의 게시글 조회
     return List.of();
   }

--- a/src/main/java/com/bob/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostRepository.java
@@ -2,9 +2,10 @@ package com.bob.domain.post.repository;
 
 import com.bob.domain.post.entity.Post;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PostRepository extends CrudRepository<Post, Long> {
 
-  List<Post> findAllBySellerId(Long sellerId);
+  List<Post> findAllBySellerId(UUID sellerId);
 }

--- a/src/main/java/com/bob/domain/post/service/dto/command/CreatePostCommand.java
+++ b/src/main/java/com/bob/domain/post/service/dto/command/CreatePostCommand.java
@@ -8,11 +8,12 @@ import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.status.BookStatus;
 import com.bob.domain.post.entity.status.PostStatus;
 import java.time.LocalDate;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record CreatePostCommand(
-    Long memberId,
+    UUID memberId,
     Long categoryId,
     Integer sellPrice,
     String postDescription,

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -12,13 +12,13 @@ public enum ApplicationError {
   UN_SUPPORTED_TYPE("E001", "지원하지 않는 형식입니다.", HttpStatus.BAD_REQUEST),
   UN_SUPPORTED_CATEGORY("E002", "지원하지 않는 카테고리입니다.", HttpStatus.BAD_REQUEST),
   UN_SUPPORTED_BOOK_STATUS("E003", "지원하지 않는 도서 상태입니다.", HttpStatus.BAD_REQUEST),
+  IS_SAME_REQUEST("E004", "변경 사항이 없습니다.", HttpStatus.BAD_REQUEST),
 
   // 사용자 예외
   UNVERIFIED_EMAIL("E101", "이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),
   ALREADY_EXISTS_EMAIL("E102", "해당 이메일로 가입된 계정이 존재합니다.", HttpStatus.CONFLICT),
   NOT_EXISTS_MEMBER("E103", "사용자를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
   INVALID_OLD_PASSWORD("E104", "비밀번호가 틀립니다.", HttpStatus.BAD_REQUEST),
-  IS_SAME_VALUE("E105", "변경 사항이 없습니다.", HttpStatus.BAD_REQUEST),
 
   EXPIRED_MAIL_CODE("E111", "인증 코드가 만료되었습니다.", HttpStatus.GONE),
   INVALID_MAIL_CODE("E112", "입력하신 인증 코드가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
@@ -26,7 +26,6 @@ public enum ApplicationError {
   // 지역 예외
   NOT_EXISTS_AREA("E201", "존재하지 않는 읍/면/동 입니다.", HttpStatus.BAD_REQUEST),
   NOT_EXISTS_ACTIVITY_AREA("E201", "활동지역을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-
   INVALID_AREA_AUTHENTICATION("E211", "현재 위치를 인증할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
   // 게시글 예외

--- a/src/main/java/com/bob/global/props/CookieProps.java
+++ b/src/main/java/com/bob/global/props/CookieProps.java
@@ -1,6 +1,6 @@
 package com.bob.global.props;
 
-import com.bob.global.utils.CookieUtils;
+import com.bob.global.utils.web.CookieUtils;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/bob/global/utils/geo/GeometryUtils.java
+++ b/src/main/java/com/bob/global/utils/geo/GeometryUtils.java
@@ -1,4 +1,4 @@
-package com.bob.global.utils;
+package com.bob.global.utils.geo;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;

--- a/src/main/java/com/bob/global/utils/image/ImageDirectory.java
+++ b/src/main/java/com/bob/global/utils/image/ImageDirectory.java
@@ -1,4 +1,4 @@
-package com.bob.global.utils;
+package com.bob.global.utils.image;
 
 import lombok.Getter;
 

--- a/src/main/java/com/bob/global/utils/image/ImageUtils.java
+++ b/src/main/java/com/bob/global/utils/image/ImageUtils.java
@@ -1,4 +1,4 @@
-package com.bob.global.utils;
+package com.bob.global.utils.image;
 
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;

--- a/src/main/java/com/bob/global/utils/uuid/GeneratedUuidV7.java
+++ b/src/main/java/com/bob/global/utils/uuid/GeneratedUuidV7.java
@@ -1,0 +1,16 @@
+package com.bob.global.utils.uuid;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.hibernate.annotations.IdGeneratorType;
+
+@IdGeneratorType(UuidV7Generator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, METHOD})
+public @interface GeneratedUuidV7 {
+
+}

--- a/src/main/java/com/bob/global/utils/uuid/UuidUtils.java
+++ b/src/main/java/com/bob/global/utils/uuid/UuidUtils.java
@@ -1,0 +1,32 @@
+package com.bob.global.utils.uuid;
+
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.UUID;
+
+public class UuidUtils {
+
+  private static final SecureRandom random = new SecureRandom();
+
+  public static UUID randomV7() {
+    ByteBuffer buf = ByteBuffer.wrap(randomBytes());
+    long high = buf.getLong();
+    long low = buf.getLong();
+    return new UUID(high, low);
+  }
+
+  private static byte[] randomBytes() {
+    byte[] value = new byte[16];
+    random.nextBytes(value);
+
+    ByteBuffer timestamp = ByteBuffer.allocate(Long.BYTES);
+    timestamp.putLong(System.currentTimeMillis());
+
+    System.arraycopy(timestamp.array(), 2, value, 0, 6);
+
+    value[6] = (byte) ((value[6] & 0x0F) | 0x70);
+    value[8] = (byte) ((value[8] & 0x3F) | 0x80);
+
+    return value;
+  }
+}

--- a/src/main/java/com/bob/global/utils/uuid/UuidV7Generator.java
+++ b/src/main/java/com/bob/global/utils/uuid/UuidV7Generator.java
@@ -1,0 +1,12 @@
+package com.bob.global.utils.uuid;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.enhanced.SequenceStyleGenerator;
+
+public class UuidV7Generator extends SequenceStyleGenerator {
+
+  @Override
+  public Object generate(SharedSessionContractImplementor session, Object object) {
+    return UuidUtils.randomV7();
+  }
+}

--- a/src/main/java/com/bob/global/utils/web/CookieUtils.java
+++ b/src/main/java/com/bob/global/utils/web/CookieUtils.java
@@ -1,4 +1,4 @@
-package com.bob.global.utils;
+package com.bob.global.utils.web;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
+++ b/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -20,7 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
 import com.bob.global.exception.response.AuthenticationError;
 import com.bob.infra.auth.jwt.JwtProvider;
-import com.bob.global.utils.CookieUtils;
+import com.bob.global.utils.web.CookieUtils;
 
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {

--- a/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
+++ b/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -39,9 +40,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
   @Override
   protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
     MemberDetails principal = (MemberDetails) authentication.getPrincipal();
-    Long memberId = principal.getId();
-    String accessToken = jwtProvider.generateAccessToken(memberId);
-    String refreshToken = jwtProvider.generateRefreshToken(memberId);
+    UUID memberId = principal.id();
+    String accessToken = jwtProvider.generateAccessToken(memberId.toString());
+    String refreshToken = jwtProvider.generateRefreshToken(memberId.toString());
     CookieUtils.addCookie(response, "AUTHORIZATION", accessToken, 216000);
     CookieUtils.addCookie(response, "REFRESH", refreshToken, 216000);
     response.setStatus(HttpStatus.OK.value());

--- a/src/main/java/com/bob/infra/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/bob/infra/auth/jwt/JwtProvider.java
@@ -3,6 +3,7 @@ package com.bob.infra.auth.jwt;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,7 +24,7 @@ public class JwtProvider {
   @Value("${jwt.refresh-token-expire-time}")
   private Long refreshExpireTime;
 
-  public String generateAccessToken(Long memberId) {
+  public String generateAccessToken(String memberId) {
     return Jwts.builder()
         .setIssuer(ISSUER)
         .setSubject("access-token")
@@ -34,7 +35,7 @@ public class JwtProvider {
         .compact();
   }
 
-  public String generateRefreshToken(Long memberId) {
+  public String generateRefreshToken(String memberId) {
     return Jwts.builder()
         .setIssuer(ISSUER)
         .setSubject("refresh-token")
@@ -45,13 +46,13 @@ public class JwtProvider {
         .compact();
   }
 
-  public Long getMemberId(String token) {
-    return Jwts.parserBuilder()
+  public UUID getMemberId(String token) {
+    return UUID.fromString(Jwts.parserBuilder()
         .setSigningKey(getSecretKey(key))
         .build()
         .parseClaimsJws(token)
         .getBody()
-        .get("memberId", Long.class);
+        .get("memberId", String.class));
   }
 
   public boolean isVerified(String token) {

--- a/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -22,7 +22,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
 import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
-import com.bob.global.utils.CookieUtils;
+import com.bob.global.utils.web.CookieUtils;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/bob/infra/auth/response/MemberDetails.java
+++ b/src/main/java/com/bob/infra/auth/response/MemberDetails.java
@@ -2,16 +2,17 @@ package com.bob.infra.auth.response;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public record MemberDetails(
-    Long id,
-    String password,
-    String email
+    UUID id,
+    String email,
+    String password
 ) implements UserDetails {
 
-  public MemberDetails(Long id) {
+  public MemberDetails(UUID id) {
     this(id, null, null);
   }
 
@@ -28,10 +29,6 @@ public record MemberDetails(
   @Override
   public String getUsername() {
     return email;
-  }
-
-  public Long getId() {
-    return id;
   }
 }
 

--- a/src/main/java/com/bob/infra/auth/service/MemberDetailsService.java
+++ b/src/main/java/com/bob/infra/auth/service/MemberDetailsService.java
@@ -1,13 +1,13 @@
 package com.bob.infra.auth.service;
 
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.repository.MemberRepository;
 import com.bob.infra.auth.response.MemberDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-import com.bob.domain.member.entity.Member;
-import com.bob.domain.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +20,6 @@ public class MemberDetailsService implements UserDetailsService {
     Member member = memberRepository.findByEmail(username)
         .orElseThrow(() -> new UsernameNotFoundException(username));
 
-    return new MemberDetails(member.getId(), member.getPassword(), member.getEmail());
+    return new MemberDetails(member.getId(), member.getEmail(), member.getPassword());
   }
-
 }

--- a/src/main/java/com/bob/web/area/controller/AreaController.java
+++ b/src/main/java/com/bob/web/area/controller/AreaController.java
@@ -5,6 +5,7 @@ import com.bob.web.area.request.AuthenticationRequest;
 import com.bob.web.common.AuthenticationId;
 import com.bob.web.common.CommonResponse;
 import com.bob.web.common.symbol.ResponseSymbol;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +22,7 @@ public class AreaController {
   @PatchMapping("/authentication")
   public CommonResponse<ResponseSymbol> handleAreaAuthentication(
       @RequestBody AuthenticationRequest request,
-      @AuthenticationId Long memberId
+      @AuthenticationId UUID memberId
   ) {
     areaAuthenticationService.authenticate(request.toCommand(memberId));
     return new CommonResponse<>(true, ResponseSymbol.OK);

--- a/src/main/java/com/bob/web/area/request/AuthenticationRequest.java
+++ b/src/main/java/com/bob/web/area/request/AuthenticationRequest.java
@@ -2,6 +2,7 @@ package com.bob.web.area.request;
 
 import com.bob.domain.area.command.AuthenticationCommand;
 import com.bob.domain.member.service.dto.command.AuthenticationPurpose;
+import java.util.UUID;
 
 public record AuthenticationRequest(
     Integer emdId,
@@ -10,7 +11,7 @@ public record AuthenticationRequest(
     String purpose
 ) {
 
-  public AuthenticationCommand toCommand(Long memberId) {
+  public AuthenticationCommand toCommand(UUID memberId) {
     return new AuthenticationCommand(
         emdId,
         lat,

--- a/src/main/java/com/bob/web/member/controller/MemberController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberController.java
@@ -18,6 +18,7 @@ import com.bob.web.member.request.ChangeProfileRequest;
 import com.bob.web.member.request.IssuePasswordRequest;
 import com.bob.web.member.request.ReadImageUploadUrlRequest;
 import com.bob.web.member.request.SignupRequest;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -46,19 +47,19 @@ public class MemberController {
   }
 
   @GetMapping("/me")
-  public ResponseEntity<MemberProfileResponse> handleReadProfile(@AuthenticationId Long memberId) {
+  public ResponseEntity<MemberProfileResponse> handleReadProfile(@AuthenticationId UUID memberId) {
     return ResponseEntity.ok(memberService.readProfileProcess(toQuery(memberId)));
   }
 
   @GetMapping("/{memberId}")
-  public ResponseEntity<MemberProfileWithPostsResponse> handleReadProfileById(@PathVariable Long memberId, Pageable pageable) {
+  public ResponseEntity<MemberProfileWithPostsResponse> handleReadProfileById(@PathVariable UUID memberId, Pageable pageable) {
     return ResponseEntity.ok(memberService.readProfileByIdWithPostsProcess(toQuery(memberId, pageable)));
   }
 
   @PatchMapping("/me")
   public CommonResponse<ResponseSymbol> handleChangeProfile(
       @RequestBody ChangeProfileRequest request,
-      @AuthenticationId Long memberId
+      @AuthenticationId UUID memberId
   ) {
     memberService.changeProfileProcess(request.toCommand(memberId));
     return new CommonResponse<>(true, UPDATED);
@@ -67,7 +68,7 @@ public class MemberController {
   @PatchMapping("/me/password")
   public CommonResponse<ResponseSymbol> handleChangePassword(
       @RequestBody ChangePasswordRequest request,
-      @AuthenticationId Long memberId
+      @AuthenticationId UUID memberId
   ) {
     memberService.changePasswordProcess(request.toCommand(memberId));
     return new CommonResponse<>(true, UPDATED);
@@ -82,7 +83,7 @@ public class MemberController {
   @PatchMapping("/me/image")
   public ResponseEntity<MemberProfileImageUrlResponse> handleGetImageUploadUrl(
       @RequestBody ReadImageUploadUrlRequest request,
-      @AuthenticationId Long memberId
+      @AuthenticationId UUID memberId
   ) {
     return ResponseEntity.ok(memberService.changeProfileImageUrlProcess(request.toQuery(memberId)));
   }

--- a/src/main/java/com/bob/web/member/request/ChangePasswordRequest.java
+++ b/src/main/java/com/bob/web/member/request/ChangePasswordRequest.java
@@ -1,13 +1,14 @@
 package com.bob.web.member.request;
 
 import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
+import java.util.UUID;
 
 public record ChangePasswordRequest(
     String oldPassword,
     String newPassword
 ) {
 
-  public ChangePasswordCommand toCommand(Long memberId) {
+  public ChangePasswordCommand toCommand(UUID memberId) {
     return new ChangePasswordCommand(memberId, oldPassword, newPassword);
   }
 }

--- a/src/main/java/com/bob/web/member/request/ChangeProfileRequest.java
+++ b/src/main/java/com/bob/web/member/request/ChangeProfileRequest.java
@@ -1,12 +1,13 @@
 package com.bob.web.member.request;
 
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
+import java.util.UUID;
 
 public record ChangeProfileRequest(
     String nickname
 ) {
 
-  public ChangeProfileCommand toCommand(Long memberId) {
+  public ChangeProfileCommand toCommand(UUID memberId) {
     return new ChangeProfileCommand(memberId, nickname);
   }
 }

--- a/src/main/java/com/bob/web/member/request/ReadImageUploadUrlRequest.java
+++ b/src/main/java/com/bob/web/member/request/ReadImageUploadUrlRequest.java
@@ -1,12 +1,13 @@
 package com.bob.web.member.request;
 
 import com.bob.domain.member.service.dto.command.ChangeProfileImageUrlCommand;
+import java.util.UUID;
 
 public record ReadImageUploadUrlRequest(
     String contentType
 ) {
 
-  public ChangeProfileImageUrlCommand toQuery(Long memberId) {
+  public ChangeProfileImageUrlCommand toQuery(UUID memberId) {
     return new ChangeProfileImageUrlCommand(memberId, contentType);
   }
 }

--- a/src/main/java/com/bob/web/member/request/ReadProfileByIdRequest.java
+++ b/src/main/java/com/bob/web/member/request/ReadProfileByIdRequest.java
@@ -1,13 +1,14 @@
 package com.bob.web.member.request;
 
 import com.bob.domain.member.service.dto.query.ReadProfileWithPostsQuery;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public record ReadProfileByIdRequest(
-    Long memberId
+    UUID memberId
 ) {
 
-  public static ReadProfileWithPostsQuery toQuery(Long memberId, Pageable pageable) {
+  public static ReadProfileWithPostsQuery toQuery(UUID memberId, Pageable pageable) {
     return new ReadProfileWithPostsQuery(memberId, pageable);
   }
 }

--- a/src/main/java/com/bob/web/member/request/ReadProfileRequest.java
+++ b/src/main/java/com/bob/web/member/request/ReadProfileRequest.java
@@ -1,12 +1,13 @@
 package com.bob.web.member.request;
 
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
+import java.util.UUID;
 
 public record ReadProfileRequest(
 
 ) {
 
-  public static ReadProfileQuery toQuery(Long memberId) {
+  public static ReadProfileQuery toQuery(UUID memberId) {
     return new ReadProfileQuery(memberId);
   }
 }

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -1,12 +1,13 @@
 package com.bob.web.post.controller;
 
-import static com.bob.web.common.symbol.ResponseSymbol.*;
+import static com.bob.web.common.symbol.ResponseSymbol.CREATED;
 
 import com.bob.domain.post.service.PostService;
 import com.bob.web.common.AuthenticationId;
 import com.bob.web.common.CommonResponse;
 import com.bob.web.common.symbol.ResponseSymbol;
 import com.bob.web.post.request.CreatePostRequest;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +27,7 @@ public class PostController {
   @ResponseStatus(HttpStatus.CREATED)
   public CommonResponse<ResponseSymbol> handleCreatePost(
       @RequestBody CreatePostRequest request,
-      @AuthenticationId Long memberId
+      @AuthenticationId UUID memberId
   ) {
     postService.createPostProcess(request.toCommand(memberId));
     return new CommonResponse<>(true, CREATED);

--- a/src/main/java/com/bob/web/post/request/CreatePostRequest.java
+++ b/src/main/java/com/bob/web/post/request/CreatePostRequest.java
@@ -2,6 +2,7 @@ package com.bob.web.post.request;
 
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import java.time.LocalDate;
+import java.util.UUID;
 
 public record CreatePostRequest(
     Long categoryId,
@@ -11,7 +12,7 @@ public record CreatePostRequest(
     BookInfo book
 ) {
 
-  public CreatePostCommand toCommand(Long memberId) {
+  public CreatePostCommand toCommand(UUID memberId) {
     return CreatePostCommand.builder()
         .memberId(memberId)
         .categoryId(categoryId)

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -202,7 +202,7 @@ class MemberServiceIntgTest extends TestContainerSupport {
     // when & then
     assertThatThrownBy(() -> memberService.changeProfileProcess(command))
         .isInstanceOf(ApplicationException.class)
-        .hasMessage(ApplicationError.IS_SAME_VALUE.getMessage());
+        .hasMessage(ApplicationError.IS_SAME_REQUEST.getMessage());
   }
 
   @Test

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -2,25 +2,25 @@
 -- 📚 BOOKS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS books (
-   id BIGINT AUTO_INCREMENT PRIMARY KEY,
-   isbn13 CHAR(13) NOT NULL UNIQUE,
-   title VARCHAR(50) NOT NULL,
-   description TEXT,
-   price_standard INT,
-   cover VARCHAR(255),
-   pub_date DATE
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    isbn13 CHAR(13) NOT NULL UNIQUE,
+    title VARCHAR(50) NOT NULL,
+    description TEXT,
+    price_standard INT,
+    cover VARCHAR(255),
+    pub_date DATE
 );
 
 -- ========================
--- 🧑 MEMBERS TABLE
+-- 🧑 MEMBERS TABLE (UUID로 수정됨)
 -- ========================
 CREATE TABLE IF NOT EXISTS members (
-     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-     email VARCHAR(50) NOT NULL UNIQUE,
-     password VARCHAR(255) NOT NULL,
-     nickname VARCHAR(20) NOT NULL,
-     profile_image_url VARCHAR(255),
-     created_at DATETIME
+    id BINARY(16) PRIMARY KEY,
+    email VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    nickname VARCHAR(20) NOT NULL,
+    profile_image_url VARCHAR(255),
+    created_at DATETIME
 );
 
 -- ========================
@@ -37,21 +37,21 @@ CREATE TABLE IF NOT EXISTS categories (
 -- 📝 POSTS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS posts (
-   id BIGINT AUTO_INCREMENT PRIMARY KEY,
-   post_status ENUM('READY', 'IN_PROGRESS', 'COMPLETED') NOT NULL,
-   category_id BIGINT NOT NULL,
-   seller_id BIGINT NOT NULL,
-   thumbnail_url VARCHAR(255) NOT NULL,
-   book_id BIGINT NOT NULL,
-   book_status ENUM('BEST', 'HIGH', 'MEDIUM', 'LOW') NOT NULL,
-   sell_price INT NOT NULL,
-   description VARCHAR(200),
-   view_count INT DEFAULT 0,
-   scrap_count INT DEFAULT 0,
-   created_at DATETIME,
-   FOREIGN KEY (category_id) REFERENCES categories(id),
-   FOREIGN KEY (seller_id) REFERENCES members(id),
-   FOREIGN KEY (book_id) REFERENCES books(id)
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    post_status ENUM('READY', 'IN_PROGRESS', 'COMPLETED') NOT NULL,
+    category_id BIGINT NOT NULL,
+    seller_id BINARY(16) NOT NULL,
+    thumbnail_url VARCHAR(255) NOT NULL,
+    book_id BIGINT NOT NULL,
+    book_status ENUM('BEST', 'HIGH', 'MEDIUM', 'LOW') NOT NULL,
+    sell_price INT NOT NULL,
+    description VARCHAR(200),
+    view_count INT DEFAULT 0,
+    scrap_count INT DEFAULT 0,
+    created_at DATETIME,
+    FOREIGN KEY (category_id) REFERENCES categories(id),
+    FOREIGN KEY (seller_id) REFERENCES members(id),
+    FOREIGN KEY (book_id) REFERENCES books(id)
 );
 
 -- ========================
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS posts (
 -- ========================
 CREATE TABLE IF NOT EXISTS like_posts (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    member_id BIGINT NOT NULL,
+    member_id BINARY(16) NOT NULL,
     post_id BIGINT NOT NULL,
     liked_at DATETIME,
     FOREIGN KEY (member_id) REFERENCES members(id),
@@ -70,13 +70,13 @@ CREATE TABLE IF NOT EXISTS like_posts (
 -- 📩 NOTIFICATIONS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS notifications (
-   id BIGINT AUTO_INCREMENT PRIMARY KEY,
-   receiver_id BIGINT NOT NULL,
-   message VARCHAR(255) NOT NULL,
-   is_read BOOLEAN DEFAULT FALSE,
-   type ENUM('CHAT', 'SYSTEM', 'ETC') NOT NULL,
-   created_at DATETIME,
-   FOREIGN KEY (receiver_id) REFERENCES members(id)
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    receiver_id BINARY(16) NOT NULL,
+    message VARCHAR(255) NOT NULL,
+    is_read BOOLEAN DEFAULT FALSE,
+    type ENUM('CHAT', 'SYSTEM', 'ETC') NOT NULL,
+    created_at DATETIME,
+    FOREIGN KEY (receiver_id) REFERENCES members(id)
 );
 
 -- ========================
@@ -103,19 +103,19 @@ CREATE TABLE IF NOT EXISTS sigg_areas (
 -- 🗺️ EMD_AREAS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS emd_areas (
-   id INT PRIMARY KEY,
-   sigg_area_id INT NOT NULL,
-   adm_code VARCHAR(10) NOT NULL,
-   name VARCHAR(50) NOT NULL,
-   geom GEOMETRY SRID 4326,
-   FOREIGN KEY (sigg_area_id) REFERENCES sigg_areas(id)
+    id INT PRIMARY KEY,
+    sigg_area_id INT NOT NULL,
+    adm_code VARCHAR(10) NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    geom GEOMETRY SRID 4326,
+    FOREIGN KEY (sigg_area_id) REFERENCES sigg_areas(id)
 );
 
 -- ========================
 -- 📍 ACTIVITY_AREAS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS activity_areas (
-    member_id BIGINT NOT NULL,
+    member_id BINARY(16) NOT NULL,
     emd_area_id INT NOT NULL,
     authentication_at DATE NOT NULL,
     PRIMARY KEY (member_id, emd_area_id),
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS activity_areas (
 CREATE TABLE IF NOT EXISTS trades (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     post_id BIGINT NOT NULL,
-    buyer_id BIGINT NOT NULL,
+    buyer_id BINARY(16) NOT NULL,
     trade_status ENUM('REQUESTED', 'CANCELED', 'COMPLETED') NOT NULL,
     updated_at DATETIME NOT NULL,
     created_at DATETIME,
@@ -141,44 +141,44 @@ CREATE TABLE IF NOT EXISTS trades (
 -- 💬 CHAT_ROOMS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS chat_rooms (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
-  trade_id BIGINT NOT NULL,
-  title_suffix VARCHAR(100) NOT NULL,
-  last_chat_at DATETIME NOT NULL,
-  status BOOLEAN NOT NULL,
-  created_at DATETIME,
-  modified_at DATETIME,
-  FOREIGN KEY (trade_id) REFERENCES trades(id)
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    trade_id BIGINT NOT NULL,
+    title_suffix VARCHAR(100) NOT NULL,
+    last_chat_at DATETIME NOT NULL,
+    status BOOLEAN NOT NULL,
+    created_at DATETIME,
+    modified_at DATETIME,
+    FOREIGN KEY (trade_id) REFERENCES trades(id)
 );
 
 -- ========================
 -- 💬 CHAT_MESSAGES TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS chat_messages (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
-  chat_room_id BIGINT NOT NULL,
-  sender_id BIGINT NOT NULL,
-  chat_message_type ENUM('MESSAGE', 'IMAGE', 'SYSTEM') NOT NULL,
-  chat_message VARCHAR(500),
-  chat_image_url VARCHAR(255),
-  is_read BOOLEAN DEFAULT FALSE,
-  sent_at DATETIME NOT NULL,
-  FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id),
-  FOREIGN KEY (sender_id) REFERENCES members(id)
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    chat_room_id BIGINT NOT NULL,
+    sender_id BINARY(16) NOT NULL,
+    chat_message_type ENUM('MESSAGE', 'IMAGE', 'SYSTEM') NOT NULL,
+    chat_message VARCHAR(500),
+    chat_image_url VARCHAR(255),
+    is_read BOOLEAN DEFAULT FALSE,
+    sent_at DATETIME NOT NULL,
+    FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id),
+    FOREIGN KEY (sender_id) REFERENCES members(id)
 );
 
 -- ========================
 -- 👥 CHAT_ROOM_MEMBERS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS chat_room_members (
-  id BIGINT AUTO_INCREMENT PRIMARY KEY,
-  chat_room_id BIGINT NOT NULL,
-  member_id BIGINT NOT NULL,
-  is_exited BOOLEAN NOT NULL,
-  exited_at DATETIME,
-  status BOOLEAN NOT NULL,
-  FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id),
-  FOREIGN KEY (member_id) REFERENCES members(id)
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    chat_room_id BIGINT NOT NULL,
+    member_id BINARY(16) NOT NULL,
+    is_exited BOOLEAN NOT NULL,
+    exited_at DATETIME,
+    status BOOLEAN NOT NULL,
+    FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id),
+    FOREIGN KEY (member_id) REFERENCES members(id)
 );
 
 -- ========================

--- a/src/test/unit/java/com/bob/domain/area/entity/activity/ActivityAreaTest.java
+++ b/src/test/unit/java/com/bob/domain/area/entity/activity/ActivityAreaTest.java
@@ -2,12 +2,14 @@ package com.bob.domain.area.entity.activity;
 
 import static com.bob.support.fixture.domain.ActivityAreaFixture.customTimeActivityArea;
 import static com.bob.support.fixture.domain.EmdAreaFixture.defaultEmdArea;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bob.domain.area.entity.EmdArea;
 import com.bob.domain.member.entity.Member;
 import java.time.LocalDate;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +20,7 @@ class ActivityAreaTest {
   @DisplayName("ActivityArea 식별자 생성 테스트")
   void ActivityAreaId를_정상적으로_생성할_수_있다() {
     // given
-    Long memberId = 1L;
+    UUID memberId = MEMBER_ID;
     Integer emdAreaId = 213;
 
     // when

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -2,7 +2,7 @@ package com.bob.domain.member.service;
 
 import static com.bob.global.exception.response.ApplicationError.ALREADY_EXISTS_EMAIL;
 import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PASSWORD;
-import static com.bob.global.exception.response.ApplicationError.IS_SAME_VALUE;
+import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
 import static com.bob.global.exception.response.ApplicationError.NOT_EXISTS_MEMBER;
 import static com.bob.global.exception.response.ApplicationError.UNVERIFIED_EMAIL;
 import static com.bob.support.fixture.command.ChangeProfileCommandFixture.defaultChangeProfileCommand;
@@ -219,7 +219,7 @@ class MemberServiceTest {
     // when & then
     assertThatThrownBy(() -> memberService.changeProfileProcess(command))
         .isInstanceOf(ApplicationException.class)
-        .hasMessage(IS_SAME_VALUE.getMessage());
+        .hasMessage(IS_SAME_REQUEST.getMessage());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/domain/member/service/reader/MemberReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/reader/MemberReaderTest.java
@@ -2,6 +2,7 @@ package com.bob.domain.member.service.reader;
 
 import static com.bob.global.exception.response.ApplicationError.NOT_EXISTS_MEMBER;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,6 +12,7 @@ import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.repository.MemberRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,10 +35,10 @@ class MemberReaderTest {
   void ID를_이용하여_회원_조회에_성공한다() {
     // given
     Member member = defaultIdMember();
-    given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+    given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
     // when
-    Member result = memberReader.readMemberById(1L);
+    Member result = memberReader.readMemberById(member.getId());
 
     // then
     assertThat(result).isEqualTo(member);
@@ -46,10 +48,10 @@ class MemberReaderTest {
   @DisplayName("회원 ID 조회 - 실패 테스트(존재하지 않는 ID)")
   void 존재하지_않는_ID의_회원이면_예외를_반환한다() {
     // given
-    given(memberRepository.findById(1L)).willReturn(Optional.empty());
+    given(memberRepository.findById(any(UUID.class))).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> memberReader.readMemberById(1L))
+    assertThatThrownBy(() -> memberReader.readMemberById(randomUUID()))
         .isInstanceOf(ApplicationException.class)
         .hasMessageContaining(NOT_EXISTS_MEMBER.getMessage());
   }

--- a/src/test/unit/java/com/bob/domain/post/adapter/PostProviderTest.java
+++ b/src/test/unit/java/com/bob/domain/post/adapter/PostProviderTest.java
@@ -1,9 +1,11 @@
 package com.bob.domain.post.adapter;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bob.domain.post.service.dto.response.PostSummaryResponse;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +25,7 @@ class PostProviderTest {
   @DisplayName("사용자 등록 게시글 조회 테스트")
   void 사용자_ID로_게시글_목록을_조회할_수_있다() {
     // given
-    Long memberId = 1L;
+    UUID memberId = MEMBER_ID;
     Pageable pageable = PageRequest.of(0, 10);
 
     // when

--- a/src/test/unit/java/com/bob/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/unit/java/com/bob/domain/post/repository/PostRepositoryTest.java
@@ -3,6 +3,7 @@ package com.bob.domain.post.repository;
 import static com.bob.support.fixture.domain.BookFixture.defaultBook;
 import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
 import static com.bob.support.fixture.domain.PostFixture.defaultPost;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bob.domain.book.entity.Book;
@@ -66,7 +67,7 @@ class PostRepositoryTest {
   @DisplayName("판매자 ID로 게시글 목록 조회 - empty 테스트")
   void 판매자_ID로_게시글이_없으면_빈_리스트를_반환한다() {
     // when
-    List<Post> result = postRepository.findAllBySellerId(-1L);
+    List<Post> result = postRepository.findAllBySellerId(randomUUID());
 
     // then
     assertThat(result).isEmpty();

--- a/src/test/unit/java/com/bob/global/props/CookiePropsTest.java
+++ b/src/test/unit/java/com/bob/global/props/CookiePropsTest.java
@@ -2,7 +2,7 @@ package com.bob.global.props;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.bob.global.utils.CookieUtils;
+import com.bob.global.utils.web.CookieUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;

--- a/src/test/unit/java/com/bob/global/utils/CookieUtilsTest.java
+++ b/src/test/unit/java/com/bob/global/utils/CookieUtilsTest.java
@@ -13,6 +13,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
+import com.bob.global.utils.web.CookieUtils;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/test/unit/java/com/bob/global/utils/GeometryUtilsTest.java
+++ b/src/test/unit/java/com/bob/global/utils/GeometryUtilsTest.java
@@ -2,6 +2,7 @@ package com.bob.global.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.bob.global.utils.geo.GeometryUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Point;

--- a/src/test/unit/java/com/bob/global/utils/ImageUtilsTest.java
+++ b/src/test/unit/java/com/bob/global/utils/ImageUtilsTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import com.bob.global.utils.image.ImageDirectory;
+import com.bob.global.utils.image.ImageUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
@@ -26,6 +26,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -94,12 +95,12 @@ class LoginFilterTest {
     // given
     FilterChain filterChain = mock(FilterChain.class);
 
-    MemberDetails memberDetails = new MemberDetails(1L);
+    MemberDetails memberDetails = new MemberDetails(UUID.randomUUID());
     Authentication authentication = new UsernamePasswordAuthenticationToken(
         memberDetails, null, memberDetails.getAuthorities()
     );
-    given(jwtProvider.generateAccessToken(1L)).willReturn(ACCESS_VALUE);
-    given(jwtProvider.generateRefreshToken(1L)).willReturn(REFRESH_VALUE);
+    given(jwtProvider.generateAccessToken(any(String.class))).willReturn(ACCESS_VALUE);
+    given(jwtProvider.generateRefreshToken(any(String.class))).willReturn(REFRESH_VALUE);
 
     // when
     loginFilter.successfulAuthentication(request, response, filterChain, authentication);

--- a/src/test/unit/java/com/bob/infra/auth/jwt/JwtProviderTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/JwtProviderTest.java
@@ -3,8 +3,10 @@ package com.bob.infra.auth.jwt;
 import static com.bob.support.fixture.auth.JWTFixture.SECRET_KEY;
 import static com.bob.support.fixture.auth.JWTFixture.expiredToken;
 import static com.bob.support.fixture.auth.JWTFixture.validToken;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +29,7 @@ class JwtProviderTest {
   @DisplayName("Access Token 생성 - 성공 테스트")
   void AccessToken을_생성할_수_있다() {
     // when
-    String token = jwtProvider.generateAccessToken(1L);
+    String token = jwtProvider.generateAccessToken(MEMBER_ID.toString());
 
     // then
     assertThat(token).isNotBlank();
@@ -37,7 +39,7 @@ class JwtProviderTest {
   @DisplayName("Refresh Token 생성 - 성공 테스트")
   void RefreshToken을_생성할_수_있다() {
     // when
-    String token = jwtProvider.generateRefreshToken(1L);
+    String token = jwtProvider.generateRefreshToken(MEMBER_ID.toString());
 
     // then
     assertThat(token).isNotBlank();
@@ -47,20 +49,20 @@ class JwtProviderTest {
   @DisplayName("MemberId 추출 - 성공 테스트")
   void Token에서_MemberId를_추출할_수_있다() {
     // given
-    String token = validToken(1L);
+    String token = validToken(MEMBER_ID.toString());
 
     // when
-    Long memberId = jwtProvider.getMemberId(token);
+    UUID memberId = jwtProvider.getMemberId(token);
 
     // then
-    assertThat(memberId).isEqualTo(1L);
+    assertThat(memberId).isEqualTo(MEMBER_ID);
   }
 
   @Test
   @DisplayName("Token 서명 검증 - 성공 테스트")
   void 토큰이_서명되었는지_검증할_수_있다() {
     // given
-    String token = validToken(1L);
+    String token = validToken(MEMBER_ID.toString());
 
     // when
     boolean isVerified = jwtProvider.isVerified(token);
@@ -73,7 +75,7 @@ class JwtProviderTest {
   @DisplayName("Token 만료 여부 확인 - 성공 테스트(만료되지 않은 경우)")
   void 만료되지_않은_토큰이면_false를_반환한다() {
     // given
-    String token = validToken(1L);
+    String token = validToken(MEMBER_ID.toString());
 
     // when
     boolean isExpired = jwtProvider.isExpired(token);
@@ -86,7 +88,7 @@ class JwtProviderTest {
   @DisplayName("Token 만료 여부 확인 - 성공 테스트(만료된 경우)")
   void 만료된_토큰이면_true를_반환한다() {
     // given
-    String token = expiredToken(1L);
+    String token = expiredToken(MEMBER_ID.toString());
 
     // when
     boolean isExpired = jwtProvider.isExpired(token);

--- a/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
@@ -24,6 +24,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,7 +85,7 @@ class JwtAuthorizationFilterTest {
     given(request.getCookies()).willReturn(new Cookie[]{defaultAuthCookie()});
     given(jwtProvider.isVerified(ACCESS_VALUE)).willReturn(true);
     given(jwtProvider.isExpired(ACCESS_VALUE)).willReturn(false);
-    given(jwtProvider.getMemberId(ACCESS_VALUE)).willReturn(1L);
+    given(jwtProvider.getMemberId(ACCESS_VALUE)).willReturn(any(UUID.class));
 
     // when
     jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);

--- a/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
@@ -14,7 +14,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
-import com.bob.global.utils.CookieUtils;
+import com.bob.global.utils.web.CookieUtils;
 import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import com.bob.infra.auth.response.MemberDetails;

--- a/src/test/unit/java/com/bob/infra/auth/service/MemberDetailsServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/MemberDetailsServiceTest.java
@@ -1,5 +1,6 @@
 package com.bob.infra.auth.service;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
 import static com.bob.support.fixture.domain.MemberFixture.otherMember;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +42,7 @@ class MemberDetailsServiceTest {
 
     // then
     assertThat(userDetails).isNotNull();
-    assertThat(userDetails.id()).isEqualTo(1L);
+    assertThat(userDetails.id()).isEqualTo(MEMBER_ID);
     assertThat(userDetails.email()).isEqualTo(member.getEmail());
     assertThat(userDetails.password()).isEqualTo(member.getPassword());
   }

--- a/src/test/unit/java/com/bob/support/fixture/auth/JWTFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/auth/JWTFixture.java
@@ -6,21 +6,22 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.UUID;
 
 public class JWTFixture {
 
   public static final String SECRET_KEY = "testsecretkeytestsecretkeytestse";
   public static final Key SIGNING_KEY = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
 
-  public static String validToken(Long memberId) {
+  public static String validToken(String memberId) {
     return generateToken(memberId, 60_000);
   }
 
-  public static String expiredToken(Long memberId) {
+  public static String expiredToken(String memberId) {
     return generateToken(memberId, -60_000);
   }
 
-  public static String generateToken(Long memberId, long durationMillis) {
+  public static String generateToken(String memberId, long durationMillis) {
     long now = System.currentTimeMillis();
     return Jwts.builder()
         .setIssuer("bookbridge")

--- a/src/test/unit/java/com/bob/support/fixture/command/AuthenticationCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/AuthenticationCommandFixture.java
@@ -1,14 +1,18 @@
 package com.bob.support.fixture.command;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.area.command.AuthenticationCommand;
 import com.bob.domain.member.service.dto.command.AuthenticationPurpose;
+import java.util.UUID;
 
 public class AuthenticationCommandFixture {
 
   public static final int DEFAULT_EMD_ID = 213;
   public static final double DEFAULT_LAT = 37.500578;
   public static final double DEFAULT_LON = 127.036991;
-  public static final Long DEFAULT_MEMBER_ID = 1L;
+  public static final double OTHER_LAT = 37.730629;
+  public static final double OTHER_LON = 127.060564;
 
   public static AuthenticationCommand defaultAuthenticationCommand() {
     return new AuthenticationCommand(
@@ -16,17 +20,17 @@ public class AuthenticationCommandFixture {
         DEFAULT_LAT,
         DEFAULT_LON,
         AuthenticationPurpose.SIGN_UP,
-        DEFAULT_MEMBER_ID
+        MEMBER_ID
     );
   }
 
   public static AuthenticationCommand defaultMismatchAuthenticationCommand() {
     return new AuthenticationCommand(
         DEFAULT_EMD_ID,
-        DEFAULT_LAT+1,
-        DEFAULT_LON+1,
+        DEFAULT_LAT + 1,
+        DEFAULT_LON + 1,
         AuthenticationPurpose.SIGN_UP,
-        DEFAULT_MEMBER_ID
+        MEMBER_ID
     );
   }
 
@@ -36,7 +40,7 @@ public class AuthenticationCommandFixture {
         DEFAULT_LAT,
         DEFAULT_LON,
         AuthenticationPurpose.CHANGE_AREA,
-        DEFAULT_MEMBER_ID
+        MEMBER_ID
     );
   }
 
@@ -46,15 +50,20 @@ public class AuthenticationCommandFixture {
         DEFAULT_LAT,
         DEFAULT_LON,
         AuthenticationPurpose.RE_AUTHENTICATE,
-        DEFAULT_MEMBER_ID
+        MEMBER_ID
     );
   }
 
-  public static AuthenticationCommand customAuthenticationCommand(Long memberId, AuthenticationPurpose purpose) {
+  public static AuthenticationCommand customAuthenticationCommand(
+      UUID memberId,
+      Integer emdId,
+      Double lat, Double lon,
+      AuthenticationPurpose purpose
+  ) {
     return new AuthenticationCommand(
-        DEFAULT_EMD_ID,
-        DEFAULT_LAT,
-        DEFAULT_LON,
+        emdId,
+        lat,
+        lon,
         purpose,
         memberId
     );

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileCommandFixture.java
@@ -1,14 +1,15 @@
 package com.bob.support.fixture.command;
 
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
+import java.util.UUID;
 
 public class ChangeProfileCommandFixture {
 
-  public static ChangeProfileCommand defaultChangeProfileCommand(Long memberId) {
+  public static ChangeProfileCommand defaultChangeProfileCommand(UUID memberId) {
     return new ChangeProfileCommand(memberId, "new-nickname");
   }
 
-  public static ChangeProfileCommand sameNicknameChangeProfileCommand(Long memberId) {
+  public static ChangeProfileCommand sameNicknameChangeProfileCommand(UUID memberId) {
     return new ChangeProfileCommand(memberId, "tester");
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileImageUrlCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileImageUrlCommandFixture.java
@@ -1,18 +1,21 @@
 package com.bob.support.fixture.command;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.member.service.dto.command.ChangeProfileImageUrlCommand;
+import java.util.UUID;
 
 public class ChangeProfileImageUrlCommandFixture {
 
   public static ChangeProfileImageUrlCommand defaultChangeProfileImageUrlCommand() {
-    return new ChangeProfileImageUrlCommand(1L, "image/png");
+    return new ChangeProfileImageUrlCommand(MEMBER_ID, "image/png");
   }
 
-  public static ChangeProfileImageUrlCommand customChangeProfileImageUrlCommand(Long memberId) {
+  public static ChangeProfileImageUrlCommand customChangeProfileImageUrlCommand(UUID memberId) {
     return new ChangeProfileImageUrlCommand(memberId, "image/png");
   }
 
   public static ChangeProfileImageUrlCommand unSupportedChangeProfileImageUrlCommand() {
-    return new ChangeProfileImageUrlCommand(1L, "video/mp4");
+    return new ChangeProfileImageUrlCommand(MEMBER_ID, "video/mp4");
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/command/CreatePostCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreatePostCommandFixture.java
@@ -1,13 +1,16 @@
 package com.bob.support.fixture.command;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import java.time.LocalDate;
+import java.util.UUID;
 
 public class CreatePostCommandFixture {
 
   public static CreatePostCommand defaultCreatePostCommand() {
     return CreatePostCommand.builder()
-        .memberId(1L)
+        .memberId(MEMBER_ID)
         .categoryId(1L)
         .sellPrice(38000)
         .bookStatus("최상")
@@ -22,7 +25,7 @@ public class CreatePostCommandFixture {
         .build();
   }
 
-  public static CreatePostCommand defaultCreatePostCommand(Long memberId, Long categoryId) {
+  public static CreatePostCommand defaultCreatePostCommand(UUID memberId, Long categoryId) {
     return CreatePostCommand.builder()
         .memberId(memberId)
         .categoryId(categoryId)

--- a/src/test/unit/java/com/bob/support/fixture/command/MemberCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/MemberCommandFixture.java
@@ -6,6 +6,7 @@ import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
 import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import java.util.UUID;
 
 public class MemberCommandFixture {
   public static CreateMemberCommand defaultCreateMemberCommand() {
@@ -24,7 +25,7 @@ public class MemberCommandFixture {
     return new ChangePasswordCommand(defaultIdMember().getId(), oldPassword, newPassword);
   }
 
-  public static ChangePasswordCommand customChangePasswordCommand(Long id, String oldPassword, String newPassword) {
+  public static ChangePasswordCommand customChangePasswordCommand(UUID id, String oldPassword, String newPassword) {
     return new ChangePasswordCommand(id, oldPassword, newPassword);
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/domain/ActivityAreaFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/ActivityAreaFixture.java
@@ -1,5 +1,7 @@
 package com.bob.support.fixture.domain;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.area.entity.EmdArea;
 import com.bob.domain.area.entity.activity.ActivityArea;
 import com.bob.domain.area.entity.activity.ActivityAreaId;
@@ -9,11 +11,7 @@ import java.time.LocalDate;
 public class ActivityAreaFixture {
 
   public static ActivityAreaId defaultActivityAreaId() {
-    return new ActivityAreaId(1L, 213);
-  }
-
-  public static ActivityAreaId customActivityAreaId(Long memberId, Integer emdId) {
-    return new ActivityAreaId(memberId, emdId);
+    return new ActivityAreaId(MEMBER_ID, 213);
   }
 
   public static ActivityArea defaultActivityArea() {

--- a/src/test/unit/java/com/bob/support/fixture/domain/EmdAreaFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/EmdAreaFixture.java
@@ -12,4 +12,14 @@ public class EmdAreaFixture {
         .geom(null)
         .build();
   }
+
+  public static EmdArea otherEmdArea() {
+    return EmdArea.builder()
+        .id(1)
+        .admCode("570")
+        .name("신곡동")
+        .siggArea(null)
+        .geom(null)
+        .build();
+  }
 }

--- a/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
@@ -6,8 +6,11 @@ import static com.bob.support.fixture.domain.EmdAreaFixture.defaultEmdArea;
 
 import com.bob.domain.member.entity.Member;
 import java.time.LocalDate;
+import java.util.UUID;
 
 public class MemberFixture {
+
+  public static final UUID MEMBER_ID = UUID.randomUUID();
 
   public static Member defaultMember() {
     return Member.builder()
@@ -19,7 +22,7 @@ public class MemberFixture {
 
   public static Member defaultIdMember() {
     return Member.builder()
-        .id(1L)
+        .id(MEMBER_ID)
         .email("test@email.com")
         .password("password")
         .nickname("tester")

--- a/src/test/unit/java/com/bob/support/fixture/query/MemberQueryFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/query/MemberQueryFixture.java
@@ -1,17 +1,20 @@
 package com.bob.support.fixture.query;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.query.ReadProfileWithPostsQuery;
+import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public class MemberQueryFixture {
 
   public static ReadProfileQuery defaultReadProfileQuery() {
-    return new ReadProfileQuery(1L);
+    return new ReadProfileQuery(MEMBER_ID);
   }
 
-  public static ReadProfileWithPostsQuery defaultReadProfileWithPostsQuery(Long memberId) {
+  public static ReadProfileWithPostsQuery defaultReadProfileWithPostsQuery(UUID memberId) {
     Pageable pageable = PageRequest.of(0, 10);
     return new ReadProfileWithPostsQuery(memberId, pageable);
   }

--- a/src/test/unit/java/com/bob/support/fixture/response/MemberProfileResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/MemberProfileResponseFixture.java
@@ -1,12 +1,14 @@
 package com.bob.support.fixture.response;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 
 public class MemberProfileResponseFixture {
 
   public static final MemberProfileResponse DEFAULT_MEMBER_PROFILE_RESPONSE =
       MemberProfileResponse.builder()
-          .memberId(1L)
+          .memberId(MEMBER_ID)
           .nickname("tester")
           .profileImageUrl("http://image.url")
           .area(new MemberProfileResponse.Area(213, true))

--- a/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.bob.web.member.controller;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.response.MemberProfileImageUrlResponseFixture.DEFAULT_MEMBER_PROFILE_IMAGE_URL_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.DEFAULT_MEMBER_PROFILE_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileWithPostsResponseFixture.DEFAULT_MEMBER_PROFILE_WITH_POSTS_RESPONSE;
@@ -18,6 +19,7 @@ import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
 import com.bob.domain.member.service.MemberService;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,14 +75,14 @@ class MemberControllerTest {
   @DisplayName("내 프로필 조회 API 호출 테스트")
   void 내_프로필_조회_API를_호출할_수_있다() throws Exception {
     // given
-    Long memberId = 1L;
+    UUID memberId = MEMBER_ID;
     given(memberService.readProfileProcess(any())).willReturn(DEFAULT_MEMBER_PROFILE_RESPONSE);
 
     // when & then
     mvc.perform(get("/members/me")
             .requestAttr("memberId", memberId))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.memberId").value(1L))
+        .andExpect(jsonPath("$.memberId").value(MEMBER_ID.toString()))
         .andExpect(jsonPath("$.nickname").value("tester"))
         .andExpect(jsonPath("$.profileImageUrl").value("http://image.url"))
         .andExpect(jsonPath("$.area.emdId").value(213))
@@ -96,7 +98,7 @@ class MemberControllerTest {
     PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
     mvc = standaloneSetup(memberController).setCustomArgumentResolvers(pageableResolver).build();
 
-    Long memberId = 1L;
+    UUID memberId = MEMBER_ID;
     given(memberService.readProfileByIdWithPostsProcess(any())).willReturn(DEFAULT_MEMBER_PROFILE_WITH_POSTS_RESPONSE);
 
     // when & then
@@ -104,7 +106,7 @@ class MemberControllerTest {
             .param("page", "0")
             .param("size", "10"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.profile.memberId").value(1L))
+        .andExpect(jsonPath("$.profile.memberId").value(MEMBER_ID.toString()))
         .andExpect(jsonPath("$.profile.nickname").value("tester"))
         .andExpect(jsonPath("$.posts[0].postId").value(10))
         .andExpect(jsonPath("$.posts[0].postTitle").value("객체지향의 사실과 오해"))
@@ -190,7 +192,7 @@ class MemberControllerTest {
     mvc.perform(patch("/members/me/image")
             .contentType(MediaType.APPLICATION_JSON)
             .content(json)
-            .requestAttr("memberId", 1L))
+            .requestAttr("memberId", MEMBER_ID))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.fileName").value("profile/test.png"))
         .andExpect(jsonPath("$.imageUploadUrl").value("https://s3-url.com/presigned"));


### PR DESCRIPTION
### #️⃣연관된 이슈
> #30 

### 📜 작업 내용
- [x] UUID 7 생성 유틸 클래스 구현
- [x] 커스텀 UUID GenerateValue 어노테이션 작성
- [x] 관련 코드 수정

### 📄 참고 
JPA에서 제공하는 @GeneratedValue를 이용해 UUID를 생성할 경우, UUID 4(모든 비트가 랜덤)가 사용됩니다. 하지만 순차성이 없기 때문에 인덱스 효율과 데이터 삽입의 성능이 떨어지는 단점이 있습니다.

이를 개선하고 삽입 효율을 높이기 위해 타임스탬프 기반의 정렬 가능한 UUID 7을 사용했습니다.

[UUID 4, 7 비교 블로그]
https://itnext.io/why-uuid7-is-better-than-uuid4-as-clustered-index-edb02bf70056

### ⚠️ 종료할 이슈
this closes #30 
