### PR TITLE
feat#35: 게시글 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -88,6 +88,11 @@ public class MemberService {
   }
 
   @Transactional(readOnly = true)
+  public MemberPostsResponse readMemberFavoritePosts(ReadMemberPostsQuery query) {
+    return MemberPostsResponse.from(postSearcher.readMemberFavoritePostsSummary(query.memberId(), query.pageable()));
+  }
+
+  @Transactional(readOnly = true)
   public MemberProfileWithPostsResponse readProfileByIdWithPostsProcess(ReadProfileWithPostsQuery query) {
     Member member = memberReader.readMemberById(query.memberId());
     MemberProfileResponse profile = MemberProfileResponse.of(member);

--- a/src/main/java/com/bob/domain/member/service/dto/response/internal/MemberPostsResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/internal/MemberPostsResponse.java
@@ -1,5 +1,6 @@
 package com.bob.domain.member.service.dto.response.internal;
 
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import java.util.List;
 import lombok.Builder;
@@ -16,6 +17,13 @@ public class MemberPostsResponse {
     return MemberPostsResponse.builder()
         .totalCount(summary.totalCount())
         .posts(MemberPostSummary.from(summary.posts()))
+        .build();
+  }
+
+  public static MemberPostsResponse from(PostFavoritesResponse summary) {
+    return MemberPostsResponse.builder()
+        .totalCount(summary.totalCount())
+        .posts(MemberPostSummary.from(summary.postFavorites()))
         .build();
   }
 }

--- a/src/main/java/com/bob/domain/member/service/port/PostSearcher.java
+++ b/src/main/java/com/bob/domain/member/service/port/PostSearcher.java
@@ -1,5 +1,6 @@
 package com.bob.domain.member.service.port;
 
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -7,4 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface PostSearcher {
 
   PostsResponse readMemberPostSummary(UUID memberId, Pageable pageable);
+
+  PostFavoritesResponse readMemberFavoritePostsSummary(UUID memberId, Pageable pageable);
 }

--- a/src/main/java/com/bob/domain/post/adapter/PostProvider.java
+++ b/src/main/java/com/bob/domain/post/adapter/PostProvider.java
@@ -3,6 +3,8 @@ package com.bob.domain.post.adapter;
 import com.bob.domain.member.service.port.PostSearcher;
 import com.bob.domain.post.service.PostService;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
+import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,10 @@ public class PostProvider implements PostSearcher {
   @Override
   public PostsResponse readMemberPostSummary(UUID memberId, Pageable pageable) {
     return postService.readFilteredPostsProcess(ReadFilteredPostsQuery.of(memberId), pageable);
+  }
+
+  @Override
+  public PostFavoritesResponse readMemberFavoritePostsSummary(UUID memberId, Pageable pageable) {
+    return postService.readMemberFavoritePostsProcess(ReadMemberFavoritePostsQuery.of(memberId), pageable);
   }
 }

--- a/src/main/java/com/bob/domain/post/entity/PostFavorite.java
+++ b/src/main/java/com/bob/domain/post/entity/PostFavorite.java
@@ -1,6 +1,7 @@
 package com.bob.domain.post.entity;
 
-import jakarta.persistence.Column;
+import com.bob.domain.member.entity.Member;
+import com.bob.global.audit.BaseTime;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,21 +10,24 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import com.bob.domain.member.entity.Member;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Entity
-@Table(name = "like_posts")
-public class LikePost {
+@Table(name = "post_favorites",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "post_id"})
+    }
+)
+public class PostFavorite extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,6 +41,10 @@ public class LikePost {
   @JoinColumn(name = "post_id", nullable = false)
   private Post post;
 
-  @Column
-  private LocalDateTime likedAt;
+  public static PostFavorite create(Member member, Post post) {
+    return PostFavorite.builder()
+        .member(member)
+        .post(post)
+        .build();
+  }
 }

--- a/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
@@ -1,0 +1,8 @@
+package com.bob.domain.post.repository;
+
+import com.bob.domain.post.entity.PostFavorite;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PostFavoriteRepository extends CrudRepository<PostFavorite, Long> {
+
+}

--- a/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
@@ -1,8 +1,10 @@
 package com.bob.domain.post.repository;
 
 import com.bob.domain.post.entity.PostFavorite;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PostFavoriteRepository extends CrudRepository<PostFavorite, Long> {
@@ -10,4 +12,8 @@ public interface PostFavoriteRepository extends CrudRepository<PostFavorite, Lon
   Optional<PostFavorite> findByMemberIdAndPostId(UUID memberId, Long postId);
 
   Boolean existsByMemberIdAndPostId(UUID memberId, Long postId);
+
+  List<PostFavorite> findByMemberIdOrderByCreatedAtDesc(UUID memberId, Pageable pageable);
+
+  Long countByMemberId(UUID memberId);
 }

--- a/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface PostFavoriteRepository extends CrudRepository<PostFavorite, Long> {
 
   Optional<PostFavorite> findByMemberIdAndPostId(UUID memberId, Long postId);
+
+  Boolean existsByMemberIdAndPostId(UUID memberId, Long postId);
 }

--- a/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
@@ -1,8 +1,11 @@
 package com.bob.domain.post.repository;
 
 import com.bob.domain.post.entity.PostFavorite;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PostFavoriteRepository extends CrudRepository<PostFavorite, Long> {
 
+  Optional<PostFavorite> findByMemberIdAndPostId(UUID memberId, Long postId);
 }

--- a/src/main/java/com/bob/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostRepository.java
@@ -16,4 +16,8 @@ public interface PostRepository extends CrudRepository<Post, Long>, CustomPostRe
   @Modifying
   @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
   void increaseViewCount(@Param("postId") Long postId);
+
+  @Modifying
+  @Query("UPDATE Post p SET p.scrapCount = p.scrapCount + 1 WHERE p.id = :postId")
+  void increaseFavoriteCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/bob/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostRepository.java
@@ -20,4 +20,8 @@ public interface PostRepository extends CrudRepository<Post, Long>, CustomPostRe
   @Modifying
   @Query("UPDATE Post p SET p.scrapCount = p.scrapCount + 1 WHERE p.id = :postId")
   void increaseFavoriteCount(@Param("postId") Long postId);
+
+  @Modifying
+  @Query("UPDATE Post p SET p.scrapCount = p.scrapCount - 1 WHERE p.id = :postId AND p.scrapCount > 0")
+  void decreaseFavoriteCount(@Param("postId") Long postId);
 }

--- a/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
+++ b/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
@@ -6,7 +6,10 @@ import static com.bob.global.exception.response.ApplicationError.ALREADY_POST_FA
 
 import com.bob.domain.member.entity.Member;
 import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.repository.PostFavoriteRepository;
+import com.bob.domain.post.service.reader.PostFavoriteReader;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostFavoriteService {
 
   private final PostFavoriteRepository postFavoriteRepository;
+  private final PostFavoriteReader postFavoriteReader;
 
   @Transactional
   public void createPostFavoriteProcess(Member member, Post post) {
     safeRegister(() -> postFavoriteRepository.save(create(member, post)), ALREADY_POST_FAVORITE);
   }
+
+  @Transactional
+  public void deletePostFavoriteProcess(UUID memberId, Long postId) {
+    PostFavorite favorite = postFavoriteReader.readFavoritePostByMemberIdAndPostId(memberId, postId);
+    postFavoriteRepository.delete(favorite);
+  }
+
 }

--- a/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
+++ b/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
@@ -1,0 +1,24 @@
+package com.bob.domain.post.service;
+
+import static com.bob.domain.post.entity.PostFavorite.create;
+import static com.bob.domain.post.service.helper.PostFavoriteHandler.safeRegister;
+import static com.bob.global.exception.response.ApplicationError.ALREADY_POST_FAVORITE;
+
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.repository.PostFavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostFavoriteService {
+
+  private final PostFavoriteRepository postFavoriteRepository;
+
+  @Transactional
+  public void createPostFavoriteProcess(Member member, Post post) {
+    safeRegister(() -> postFavoriteRepository.save(create(member, post)), ALREADY_POST_FAVORITE);
+  }
+}

--- a/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
+++ b/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
@@ -8,9 +8,12 @@ import com.bob.domain.member.entity.Member;
 import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.repository.PostFavoriteRepository;
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.reader.PostFavoriteReader;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,5 +38,12 @@ public class PostFavoriteService {
   @Transactional
   public boolean isFavorite(UUID memberId, Long postId) {
     return postFavoriteRepository.existsByMemberIdAndPostId(memberId, postId);
+  }
+
+  @Transactional
+  public PostFavoritesResponse readMemberFavoritePosts(UUID memberId, Pageable pageable) {
+    List<PostFavorite> postFavorites = postFavoriteRepository.findByMemberIdOrderByCreatedAtDesc(memberId, pageable);
+    Long totalCount = postFavoriteRepository.countByMemberId(memberId);
+    return PostFavoritesResponse.of(totalCount, postFavorites);
   }
 }

--- a/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
+++ b/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
@@ -32,4 +32,8 @@ public class PostFavoriteService {
     postFavoriteRepository.delete(favorite);
   }
 
+  @Transactional
+  public boolean isFavorite(UUID memberId, Long postId) {
+    return postFavoriteRepository.existsByMemberIdAndPostId(memberId, postId);
+  }
 }

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -12,8 +12,10 @@ import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
+import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import com.bob.domain.post.service.reader.PostReader;
 import com.bob.global.exception.exceptions.ApplicationException;
@@ -75,6 +77,11 @@ public class PostService {
     List<Post> posts = postReader.readFilteredPosts(query, pageable);
     Long totalCount = postRepository.countFilteredPosts(query);
     return PostsResponse.of(totalCount, posts);
+  }
+
+  @Transactional(readOnly = true)
+  public PostFavoritesResponse readMemberFavoritePostsProcess(ReadMemberFavoritePostsQuery query, Pageable pageable) {
+    return postFavoriteService.readMemberFavoritePosts(query.memberId(), pageable);
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -64,6 +64,12 @@ public class PostService {
     postRepository.increaseFavoriteCount(post.getId());
   }
 
+  @Transactional
+  public void unregisterPostFavoriteProcess(RegisterPostFavoriteCommand command) {
+    postFavoriteService.deletePostFavoriteProcess(command.memberId(), command.postId());
+    postRepository.decreaseFavoriteCount(command.postId());
+  }
+
   @Transactional(readOnly = true)
   public PostsResponse readFilteredPostsProcess(ReadFilteredPostsQuery query, Pageable pageable) {
     List<Post> posts = postReader.readFilteredPosts(query, pageable);

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -10,6 +10,7 @@ import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
+import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
@@ -32,6 +33,8 @@ public class PostService {
   private final PostRepository postRepository;
   private final PostReader postReader;
 
+  private final PostFavoriteService postFavoriteService;
+
   private final BookService bookService;
   private final MemberReader memberReader;
   private final CategoryReader categoryReader;
@@ -51,6 +54,14 @@ public class PostService {
       return;
     }
     throw new ApplicationException(ApplicationError.NOT_VERIFIED_MEMBER);
+  }
+
+  @Transactional
+  public void registerPostFavoriteProcess(RegisterPostFavoriteCommand command) {
+    Member member = memberReader.readMemberById(command.memberId());
+    Post post = postReader.readPostById(command.postId());
+    postFavoriteService.createPostFavoriteProcess(member, post);
+    postRepository.increaseFavoriteCount(post.getId());
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -82,7 +82,7 @@ public class PostService {
     postRepository.increaseViewCount(query.postId());
     Post post = postReader.readPostById(query.postId());
     boolean isOwner = query.memberId() != null && post.getSeller().getId().equals(query.memberId());
-    boolean isFavorite = false; // TODO : 게시글 좋아요 기능 구현 후 좋아요 여부 매핑
+    boolean isFavorite = postFavoriteService.isFavorite(query.memberId(), post.getId());
     return PostDetailResponse.of(post, isFavorite, isOwner, List.of()); // TODO : 첨부 이미지 기능 구현 시 이미지 경로 List 매핑
   }
 

--- a/src/main/java/com/bob/domain/post/service/dto/command/RegisterPostFavoriteCommand.java
+++ b/src/main/java/com/bob/domain/post/service/dto/command/RegisterPostFavoriteCommand.java
@@ -1,0 +1,10 @@
+package com.bob.domain.post.service.dto.command;
+
+import java.util.UUID;
+
+public record RegisterPostFavoriteCommand(
+    UUID memberId,
+    Long postId
+) {
+
+}

--- a/src/main/java/com/bob/domain/post/service/dto/query/ReadMemberFavoritePostsQuery.java
+++ b/src/main/java/com/bob/domain/post/service/dto/query/ReadMemberFavoritePostsQuery.java
@@ -1,0 +1,12 @@
+package com.bob.domain.post.service.dto.query;
+
+import java.util.UUID;
+
+public record ReadMemberFavoritePostsQuery(
+    UUID memberId
+) {
+
+  public static ReadMemberFavoritePostsQuery of(UUID memberId) {
+    return new ReadMemberFavoritePostsQuery(memberId);
+  }
+}

--- a/src/main/java/com/bob/domain/post/service/dto/response/PostFavoritesResponse.java
+++ b/src/main/java/com/bob/domain/post/service/dto/response/PostFavoritesResponse.java
@@ -1,0 +1,20 @@
+package com.bob.domain.post.service.dto.response;
+
+import com.bob.domain.post.entity.PostFavorite;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record PostFavoritesResponse(
+    Long totalCount,
+    List<PostSummary> postFavorites
+) {
+
+  public static PostFavoritesResponse of(Long totalCount, List<PostFavorite> postList) {
+    List<PostSummary> summaries = postList.stream()
+        .map((postFavorite) -> PostSummary.of(postFavorite.getPost()))
+        .toList();
+
+    return new PostFavoritesResponse(totalCount, summaries);
+  }
+}

--- a/src/main/java/com/bob/domain/post/service/helper/PostFavoriteHandler.java
+++ b/src/main/java/com/bob/domain/post/service/helper/PostFavoriteHandler.java
@@ -1,0 +1,16 @@
+package com.bob.domain.post.service.helper;
+
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class PostFavoriteHandler {
+
+  public static void safeRegister(Runnable action, ApplicationError error) {
+    try {
+      action.run();
+    } catch (DataIntegrityViolationException e) {
+      throw new ApplicationException(error);
+    }
+  }
+}

--- a/src/main/java/com/bob/domain/post/service/reader/PostFavoriteReader.java
+++ b/src/main/java/com/bob/domain/post/service/reader/PostFavoriteReader.java
@@ -1,0 +1,23 @@
+package com.bob.domain.post.service.reader;
+
+import com.bob.domain.post.entity.PostFavorite;
+import com.bob.domain.post.repository.PostFavoriteRepository;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PostFavoriteReader {
+
+  private final PostFavoriteRepository postFavoriteRepository;
+
+  public PostFavorite readFavoritePostByMemberIdAndPostId(UUID memberId, Long postId) {
+    return postFavoriteRepository.findByMemberIdAndPostId(memberId, postId)
+        .orElseThrow(() -> new ApplicationException(ApplicationError.INVALID_POST_FAVORITE));
+  }
+}

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -35,6 +35,7 @@ public enum ApplicationError {
   NOT_EXIST_POST("E302", "게시글을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
   NOT_POST_OWNER("E303", "게시글 작성자가 아닙니다.", HttpStatus.FORBIDDEN),
   ALREADY_POST_FAVORITE("E304", "이미 좋아요한 게시글입니다.", HttpStatus.BAD_REQUEST),
+  INVALID_POST_FAVORITE("E305", "좋아요 하지 않은 게시글입니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private String code;

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -34,6 +34,7 @@ public enum ApplicationError {
   NOT_VERIFIED_MEMBER("E301", "위치 인증을 하지 않은 사용자는 게시글을 작성할 수 없습니다.", HttpStatus.FORBIDDEN),
   NOT_EXIST_POST("E302", "게시글을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
   NOT_POST_OWNER("E303", "게시글 작성자가 아닙니다.", HttpStatus.FORBIDDEN),
+  ALREADY_POST_FAVORITE("E304", "이미 좋아요한 게시글입니다.", HttpStatus.BAD_REQUEST),
   ;
 
   private String code;

--- a/src/main/java/com/bob/web/member/controller/MemberController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberController.java
@@ -62,6 +62,14 @@ public class MemberController {
     return ResponseEntity.ok(memberService.readMemberPostsProcess(ReadMemberPostsRequest.toQuery(memberId, pageable)));
   }
 
+  @GetMapping("/me/favorites")
+  public ResponseEntity<MemberPostsResponse> handleReadMemberFavoritePosts(
+      @AuthenticationId UUID memberId,
+      Pageable pageable
+  ) {
+    return ResponseEntity.ok(memberService.readMemberFavoritePosts(ReadMemberPostsRequest.toQuery(memberId, pageable)));
+  }
+
   @GetMapping("/{memberId}")
   public ResponseEntity<MemberProfileWithPostsResponse> handleReadProfileById(
       @PathVariable UUID memberId,

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.bob.web.post.controller;
 
 import static com.bob.web.common.symbol.ResponseSymbol.CREATED;
+import static com.bob.web.common.symbol.ResponseSymbol.DELETED;
 import static com.bob.web.common.symbol.ResponseSymbol.OK;
 import static com.bob.web.post.request.ReadPostDetailRequest.toQuery;
 import static com.bob.web.post.request.RegisterPostFavoriteRequest.toCommand;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,6 +56,16 @@ public class PostController {
   ) {
     postService.registerPostFavoriteProcess(toCommand(memberId, postId));
     return new CommonResponse<>(true, CREATED);
+  }
+
+  @DeleteMapping("/{postId}/favorite")
+  @ResponseStatus(HttpStatus.OK)
+  public CommonResponse<ResponseSymbol> handleUnregisterFavoritePost(
+      @PathVariable Long postId,
+      @AuthenticationId UUID memberId
+  ) {
+    postService.unregisterPostFavoriteProcess(toCommand(memberId, postId));
+    return new CommonResponse<>(true, DELETED);
   }
 
   @GetMapping

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.bob.web.post.controller;
 import static com.bob.web.common.symbol.ResponseSymbol.CREATED;
 import static com.bob.web.common.symbol.ResponseSymbol.OK;
 import static com.bob.web.post.request.ReadPostDetailRequest.toQuery;
+import static com.bob.web.post.request.RegisterPostFavoriteRequest.toCommand;
 
 import com.bob.domain.post.service.PostService;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
@@ -42,6 +43,16 @@ public class PostController {
       @AuthenticationId UUID memberId
   ) {
     postService.createPostProcess(request.toCommand(memberId));
+    return new CommonResponse<>(true, CREATED);
+  }
+
+  @PostMapping("/{postId}/favorite")
+  @ResponseStatus(HttpStatus.CREATED)
+  public CommonResponse<ResponseSymbol> handleRegisterFavoritePost(
+      @PathVariable Long postId,
+      @AuthenticationId UUID memberId
+  ) {
+    postService.registerPostFavoriteProcess(toCommand(memberId, postId));
     return new CommonResponse<>(true, CREATED);
   }
 

--- a/src/main/java/com/bob/web/post/request/RegisterPostFavoriteRequest.java
+++ b/src/main/java/com/bob/web/post/request/RegisterPostFavoriteRequest.java
@@ -1,0 +1,13 @@
+package com.bob.web.post.request;
+
+import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
+import java.util.UUID;
+
+public record RegisterPostFavoriteRequest(
+
+) {
+
+  public static RegisterPostFavoriteCommand toCommand(UUID memberId, Long postId) {
+    return new RegisterPostFavoriteCommand(memberId, postId);
+  }
+}

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -30,10 +30,12 @@ import com.bob.domain.member.service.dto.query.ReadProfileWithPostsQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileImageUrlResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileWithPostsResponse;
+import com.bob.domain.member.service.dto.response.internal.MemberPostsResponse;
 import com.bob.domain.member.service.port.ImageStorageAccessor;
 import com.bob.domain.member.service.port.MailService;
 import com.bob.domain.member.service.port.MailVerificationStore;
 import com.bob.domain.member.service.port.PostSearcher;
+import com.bob.domain.post.service.dto.query.ReadMemberPostsQuery;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
@@ -44,6 +46,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -162,6 +166,23 @@ class MemberServiceIntgTest extends TestContainerSupport {
     assertThat(response.getMemberPosts().getTotalCount()).isEqualTo(15);
     assertThat(response.getMemberPosts().getPosts().get(0).postTitle()).isEqualTo("자바의 정석");
     assertThat(response.getMemberPosts().getPosts().get(1).postTitle()).isEqualTo("자바 ORM 표준 JPA 프로그래밍");
+  }
+
+  @Test
+  @DisplayName("사용자의 좋아요한 게시글 목록 조회 - 성공 테스트")
+  void 회원은_좋아요한_게시글_목록을_조회할_수_있다() {
+    // given
+    UUID memberId = UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0");
+    Pageable pageable = PageRequest.of(0, 12);
+    ReadMemberPostsQuery query = new ReadMemberPostsQuery(memberId, pageable);
+
+    // when
+    MemberPostsResponse response = memberService.readMemberFavoritePosts(query);
+
+    // then
+    assertThat(response.getTotalCount()).isEqualTo(2);
+    assertThat(response.getPosts().get(0).postTitle()).isEqualTo("자바의 정석"); // 1번 게시글
+    assertThat(response.getPosts().get(1).postTitle()).isEqualTo("토비의 스프링"); // 3번 게시글
   }
 
   @Test

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -38,8 +38,10 @@ import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
+import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostSummary;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import com.bob.global.exception.exceptions.ApplicationException;
@@ -146,6 +148,38 @@ class PostServiceIntgTest extends TestContainerSupport {
     assertThatThrownBy(() -> postService.createPostProcess(command))
         .isInstanceOf(ApplicationException.class)
         .hasMessage(NOT_VERIFIED_MEMBER.getMessage());
+  }
+
+  @DisplayName("사용자 즐겨찾기 게시글 조회 테스트 - 성공 테스트")
+  @Test
+  void 회원이_좋아요한_게시글을_조회할_수_있다() {
+    // given
+    UUID memberId = UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0");
+    ReadMemberFavoritePostsQuery query = ReadMemberFavoritePostsQuery.of(memberId);
+
+    // when
+    PostFavoritesResponse response = postService.readMemberFavoritePostsProcess(query, pageable);
+
+    // then
+    assertThat(response.totalCount()).isEqualTo(2);
+    assertThat(response.postFavorites())
+        .extracting(PostSummary::postTitle)
+        .containsExactlyInAnyOrder("자바의 정석", "토비의 스프링");
+  }
+
+  @DisplayName("사용자 즐겨찾기 게시글 조회 테스트 - 성공 테스트(결과없음)")
+  @Test
+  void 회원이_좋아요한_게시글이_없는_경우_빈_리스트를_반환한다() {
+    // given
+    UUID memberId = UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59");
+    ReadMemberFavoritePostsQuery query = ReadMemberFavoritePostsQuery.of(memberId);
+
+    // when
+    PostFavoritesResponse response = postService.readMemberFavoritePostsProcess(query, pageable);
+
+    // then
+    assertThat(response.totalCount()).isEqualTo(0);
+    assertThat(response.postFavorites()).hasSize(0);
   }
 
   @Test

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -59,11 +59,11 @@ CREATE TABLE IF NOT EXISTS posts (
 -- ========================
 -- ⭐ LIKE_POSTS TABLE
 -- ========================
-CREATE TABLE IF NOT EXISTS like_posts (
+CREATE TABLE IF NOT EXISTS post_favorites (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     member_id BINARY(16) NOT NULL,
     post_id BIGINT NOT NULL,
-    liked_at DATETIME,
+    created_at DATETIME,
     FOREIGN KEY (member_id) REFERENCES members(id),
     FOREIGN KEY (post_id) REFERENCES posts(id)
 );

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -276,7 +276,10 @@ UPDATE emd_areas SET geom = ST_GeomFromText('POLYGON ((37.7410557 127.0741107, 3
 -- 더미 데이터
 -- ========================
 INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 'postReader@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'PostReader');
+INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-0c5f1dbe9c59'), 'otherReader@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'otherReader');
+
 INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 213, CURDATE());
+
 INSERT INTO books (isbn13, title, author, description, price_standard, cover, pub_date) VALUES
 ('9788994492032', '자바의 정석', '남궁성', '자바 기초 입문서', 15000, 'https://cover/1.png', '2020-01-01'),
 ('9788960777330', '자바 ORM 표준 JPA 프로그래밍', '김영한', 'JPA 표준 가이드', 18000, 'https://cover/2.png', '2021-06-01'),
@@ -284,6 +287,7 @@ INSERT INTO books (isbn13, title, author, description, price_standard, cover, pu
 ('9788966261208', '오브젝트', '조영호', '객체지향 설계 입문', 25000, 'https://cover/4.png', '2021-05-15'),
 ('9788999999001', '싸다구 책1', '김저렴', '저렴한 책1', 3000, 'https://cover/5.png', '2019-01-01'),
 ('9788999999002', '싸다구 책2', '박할인', '저렴한 책2', 4000, 'https://cover/6.png', '2018-12-01');
+
 INSERT INTO posts (book_id, seller_id, category_id, book_status, post_status, sell_price, description, registration_area_id, thumbnail_url, created_at) VALUES
 (1, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'BEST', 'READY', 10000, '자바 기초를 다룬 책입니다.', 213, 'https://image/1.png', now()),
 (2, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'HIGH', 'READY', 12000, 'JPA 핵심 이론', 785, 'https://image/2.png', now()),
@@ -300,3 +304,7 @@ INSERT INTO posts (book_id, seller_id, category_id, book_status, post_status, se
 (1, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'BEST', 'READY', 10000, '오래된 게시글', 213, 'https://image/old.png', '2023-01-01 10:00:00'),
 (2, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'HIGH', 'READY', 12000, '중간 게시글', 213, 'https://image/mid.png', '2023-06-01 10:00:00'),
 (3, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'LOW', 'READY', 14000, '최신 게시글', 213, 'https://image/new.png', '2024-01-01 10:00:00');
+
+INSERT INTO post_favorites (member_id, post_id, created_at) VALUES
+(UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, NOW()),
+(UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 3, NOW());

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -19,6 +19,7 @@ import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
 import static com.bob.support.fixture.query.MemberQueryFixture.defaultReadProfileQuery;
 import static com.bob.support.fixture.query.MemberQueryFixture.defaultReadProfileWithPostsQuery;
 import static com.bob.support.fixture.response.MemberProfileImageUrlResponseFixture.mockPresignedUrlResponse;
+import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_FAVORITE_RESPONSE;
 import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POSTS_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -190,6 +191,27 @@ class MemberServiceTest {
         .containsExactly("객체지향의 사실과 오해", "오브젝트");
 
     then(postSearcher).should(times(1)).readMemberPostSummary(query.memberId(), query.pageable());
+  }
+
+  @DisplayName("내가 좋아요한 게시글 목록 조회 테스트")
+  @Test
+  void 좋아요한_게시글_목록을_조회할_수_있다() {
+    // given
+    Member member = defaultIdMember();
+    Pageable pageable = PageRequest.of(0, 10);
+    ReadMemberPostsQuery query = new ReadMemberPostsQuery(member.getId(), pageable);
+    given(postSearcher.readMemberFavoritePostsSummary(query.memberId(), query.pageable())).willReturn(DEFAULT_FAVORITE_RESPONSE());
+
+    // when
+    MemberPostsResponse response = memberService.readMemberFavoritePosts(query);
+
+    // then
+    assertThat(response.getTotalCount()).isEqualTo(2);
+    assertThat(response.getPosts())
+        .extracting(MemberPostSummary::postTitle)
+        .containsExactly("객체지향의 사실과 오해", "오브젝트");
+
+    then(postSearcher).should(times(1)).readMemberFavoritePostsSummary(query.memberId(), query.pageable());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/domain/post/adapter/PostProviderTest.java
+++ b/src/test/unit/java/com/bob/domain/post/adapter/PostProviderTest.java
@@ -1,12 +1,16 @@
 package com.bob.domain.post.adapter;
 
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.query.PostQueryFixture.defaultReadMemberFavoritePostsQuery;
+import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_FAVORITE_RESPONSE;
 import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POSTS_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.bob.domain.post.service.PostService;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
+import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -28,12 +32,13 @@ class PostProviderTest {
   @Mock
   private PostService postService;
 
+  private Pageable pageable = PageRequest.of(0, 12);
+
   @Test
   @DisplayName("사용자 등록 게시글 조회 테스트")
   void 사용자_ID로_게시글_목록을_조회할_수_있다() {
     // given
     UUID memberId = MEMBER_ID;
-    Pageable pageable = PageRequest.of(0, 10);
     given(postService.readFilteredPostsProcess(ReadFilteredPostsQuery.of(memberId), pageable)).willReturn(DEFAULT_POSTS_RESPONSE());
 
     // when
@@ -43,5 +48,22 @@ class PostProviderTest {
     assertThat(result.totalCount()).isEqualTo(2);
     assertThat(result.posts().get(0).postTitle()).isEqualTo("객체지향의 사실과 오해");
     assertThat(result.posts().get(1).postTitle()).isEqualTo("오브젝트");
+  }
+
+  @Test
+  @DisplayName("사용자 즐겨찾기 게시글 목록 조회 테스트")
+  void 사용자_ID로_즐겨찾기_게시글_목록을_조회할_수_있다() {
+    // given
+    UUID memberId = MEMBER_ID;
+    ReadMemberFavoritePostsQuery query = defaultReadMemberFavoritePostsQuery(memberId);
+    given(postService.readMemberFavoritePostsProcess(query, pageable)).willReturn(DEFAULT_FAVORITE_RESPONSE());
+
+    // when
+    PostFavoritesResponse response = postProvider.readMemberFavoritePostsSummary(memberId, pageable);
+
+    // then
+    assertThat(response.totalCount()).isEqualTo(2);
+    assertThat(response.postFavorites().get(0).postTitle()).isEqualTo("객체지향의 사실과 오해");
+    assertThat(response.postFavorites().get(1).postTitle()).isEqualTo("오브젝트");
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/entity/PostFavoriteTest.java
+++ b/src/test/unit/java/com/bob/domain/post/entity/PostFavoriteTest.java
@@ -1,0 +1,35 @@
+package com.bob.domain.post.entity;
+
+import static com.bob.support.fixture.domain.BookFixture.defaultBook;
+import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
+import static com.bob.support.fixture.domain.MemberFixture.authenticatedMember;
+import static com.bob.support.fixture.domain.PostFixture.defaultIdPost;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bob.domain.book.entity.Book;
+import com.bob.domain.category.entity.Category;
+import com.bob.domain.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PostFavorite 도메인 테스트")
+class PostFavoriteTest {
+
+  @Test
+  @DisplayName("PostFavorite 생성 - 정상 테스트")
+  void PostFavorite를_정상적으로_생성할_수_있다() {
+    // given
+    Book book = defaultBook();
+    Member member = authenticatedMember();
+    Category category = defaultCategory();
+    Post post = defaultIdPost(book, member, category);
+
+    // when
+    PostFavorite postFavorite = PostFavorite.create(member, post);
+
+    // then
+    assertThat(postFavorite).isNotNull();
+    assertThat(postFavorite.getMember()).isEqualTo(member);
+    assertThat(postFavorite.getPost()).isEqualTo(post);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
@@ -1,0 +1,70 @@
+package com.bob.domain.post.service;
+
+import static com.bob.global.exception.response.ApplicationError.ALREADY_POST_FAVORITE;
+import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.PostFavorite;
+import com.bob.domain.post.repository.PostFavoriteRepository;
+import com.bob.global.exception.exceptions.ApplicationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PostFavoriteService 테스트")
+class PostFavoriteServiceTest {
+
+  @InjectMocks
+  private PostFavoriteService postFavoriteService;
+
+  @Mock
+  private PostFavoriteRepository postFavoriteRepository;
+
+  @Mock
+  private Post post;
+
+  @Test
+  @DisplayName("게시글 즐겨찾기 등록 - 성공 테스트")
+  void 게시글_즐겨찾기_등록에_성공한다() {
+    // given
+    Member member = defaultIdMember();
+    PostFavorite postFavorite = PostFavorite.create(member, post);
+    given(postFavoriteRepository.save(any(PostFavorite.class))).willReturn(postFavorite);
+
+    // when
+    postFavoriteService.createPostFavoriteProcess(member, post);
+
+    // then
+    then(postFavoriteRepository).should().save(any(PostFavorite.class));
+  }
+
+  @Test
+  @DisplayName("게시글 즐겨찾기 등록 - 실패 테스트 (중복 즐겨찾기)")
+  void 이미_즐겨찾기한_게시글이면_예외가_발생한다() {
+    // given
+    Member member = defaultIdMember();
+    willThrow(new DataIntegrityViolationException("duplicate"))
+        .given(postFavoriteRepository)
+        .save(any(PostFavorite.class));
+
+    // when & then
+    assertThatThrownBy(() ->
+        postFavoriteService.createPostFavoriteProcess(member, post)
+    )
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ALREADY_POST_FAVORITE.getMessage());
+
+    then(postFavoriteRepository).should().save(any(PostFavorite.class));
+  }
+}

--- a/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
@@ -2,6 +2,7 @@ package com.bob.domain.post.service;
 
 import static com.bob.global.exception.response.ApplicationError.ALREADY_POST_FAVORITE;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -15,6 +16,7 @@ import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.repository.PostFavoriteRepository;
 import com.bob.domain.post.service.reader.PostFavoriteReader;
 import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,5 +94,35 @@ class PostFavoriteServiceTest {
     then(postFavoriteRepository)
         .should(times(1))
         .delete(postFavorite);
+  }
+
+  @Test
+  @DisplayName("게시글 좋아요 여부 확인 - true 반환")
+  void 게시글을_좋아요한_경우_true를_반환한다() {
+    // given
+    UUID memberId = UUID.randomUUID();
+    Long postId = 1L;
+    given(postFavoriteRepository.existsByMemberIdAndPostId(memberId, postId)).willReturn(true);
+
+    // when
+    boolean result = postFavoriteService.isFavorite(memberId, postId);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("게시글 좋아요 여부 확인 - false 반환")
+  void 게시글을_좋아요하지_않은_경우_false를_반환한다() {
+    // given
+    UUID memberId = UUID.randomUUID();
+    Long postId = 2L;
+    given(postFavoriteRepository.existsByMemberIdAndPostId(memberId, postId)).willReturn(false);
+
+    // when
+    boolean result = postFavoriteService.isFavorite(memberId, postId);
+
+    // then
+    assertThat(result).isFalse();
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
@@ -7,11 +7,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
 
 import com.bob.domain.member.entity.Member;
 import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.repository.PostFavoriteRepository;
+import com.bob.domain.post.service.reader.PostFavoriteReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,9 @@ class PostFavoriteServiceTest {
 
   @Mock
   private PostFavoriteRepository postFavoriteRepository;
+
+  @Mock
+  private PostFavoriteReader postFavoriteReader;
 
   @Mock
   private Post post;
@@ -66,5 +71,26 @@ class PostFavoriteServiceTest {
         .hasMessage(ALREADY_POST_FAVORITE.getMessage());
 
     then(postFavoriteRepository).should().save(any(PostFavorite.class));
+  }
+
+  @Test
+  @DisplayName("좋아요 해제 - 성공 테스트")
+  void 좋아요를_성공적으로_해제한다() {
+    // given
+    Member member = defaultIdMember();
+    PostFavorite postFavorite = PostFavorite.create(member, post);
+    given(postFavoriteReader.readFavoritePostByMemberIdAndPostId(member.getId(), post.getId())).willReturn(postFavorite);
+
+    // when
+    postFavoriteService.deletePostFavoriteProcess(member.getId(), post.getId());
+
+    // then
+    then(postFavoriteReader)
+        .should(times(1))
+        .readFavoritePostByMemberIdAndPostId(member.getId(), post.getId());
+
+    then(postFavoriteRepository)
+        .should(times(1))
+        .delete(postFavorite);
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/helper/PostFavoriteHandlerTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/helper/PostFavoriteHandlerTest.java
@@ -1,0 +1,42 @@
+package com.bob.domain.post.service.helper;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DisplayName("PostFavoriteHandler 테스트")
+class PostFavoriteHandlerTest {
+
+  @Test
+  @DisplayName("safeRegister - 정상 실행 시 예외가 발생하지 않는다")
+  void safeRegister_정상수행_예외없음() {
+    // given
+    Runnable action = () -> {};
+
+    // when & then
+    assertThatCode(() ->
+        PostFavoriteHandler.safeRegister(action, ApplicationError.ALREADY_POST_FAVORITE)
+    ).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("safeRegister - 중복된 게시글 좋아요")
+  void 중복예외_발생_시_DataIntegrityViolation_예외를_ApplicationException_변환() {
+    // given
+    Runnable action = () -> {
+      throw new DataIntegrityViolationException("Duplicate entry");
+    };
+
+    // when & then
+    assertThatThrownBy(() ->
+        PostFavoriteHandler.safeRegister(action, ApplicationError.ALREADY_POST_FAVORITE)
+    )
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.ALREADY_POST_FAVORITE.getMessage());
+  }
+}

--- a/src/test/unit/java/com/bob/domain/post/service/reader/PostFavoriteReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/reader/PostFavoriteReaderTest.java
@@ -1,0 +1,66 @@
+package com.bob.domain.post.service.reader;
+
+import static com.bob.global.exception.response.ApplicationError.INVALID_POST_FAVORITE;
+import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.PostFavorite;
+import com.bob.domain.post.repository.PostFavoriteRepository;
+import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PostFavoriteReader 테스트")
+class PostFavoriteReaderTest {
+
+  @InjectMocks
+  private PostFavoriteReader postFavoriteReader;
+
+  @Mock
+  private PostFavoriteRepository postFavoriteRepository;
+
+  @Mock
+  private Post post;
+
+  @Test
+  @DisplayName("좋아요 게시글 조회 - 성공 테스트")
+  void 좋아요가_존재하면_PostFavorite를_반환한다() {
+    // given
+    Member member = defaultIdMember();
+    PostFavorite postFavorite = PostFavorite.create(member, post);
+    given(postFavoriteRepository.findByMemberIdAndPostId(member.getId(), post.getId())).willReturn(Optional.of(postFavorite));
+
+    // when
+    PostFavorite result = postFavoriteReader.readFavoritePostByMemberIdAndPostId(member.getId(), post.getId());
+
+    // then
+    assertNotNull(result);
+    then(postFavoriteRepository).should().findByMemberIdAndPostId(member.getId(), post.getId());
+  }
+
+  @Test
+  @DisplayName("좋아요 게시글 조회 - 실패 테스트(존재하지 않는 좋아요 게시글)")
+  void 좋아요가_없으면_ApplicationException이_발생한다() {
+    // given
+    Member member = defaultIdMember();
+    given(postFavoriteRepository.findByMemberIdAndPostId(member.getId(), post.getId())).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() ->
+        postFavoriteReader.readFavoritePostByMemberIdAndPostId(member.getId(), post.getId())
+    )
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(INVALID_POST_FAVORITE.getMessage());
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/RegisterPostFavoriteCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/RegisterPostFavoriteCommandFixture.java
@@ -1,0 +1,12 @@
+package com.bob.support.fixture.command;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
+import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
+
+public class RegisterPostFavoriteCommandFixture {
+
+  public static RegisterPostFavoriteCommand defaultRegisterPostFavoriteCommand() {
+    return new RegisterPostFavoriteCommand(MEMBER_ID, 1L);
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/PostFavoriteFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/PostFavoriteFixture.java
@@ -1,0 +1,27 @@
+package com.bob.support.fixture.domain;
+
+import static com.bob.support.fixture.domain.BookFixture.defaultBook;
+import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
+import static com.bob.support.fixture.domain.MemberFixture.authenticatedMember;
+import static com.bob.support.fixture.domain.PostFixture.defaultPost;
+
+import com.bob.domain.post.entity.PostFavorite;
+import java.util.List;
+
+public class PostFavoriteFixture {
+
+  public static List<PostFavorite> DEFAULT_MOCK_POST_FAVORITES() {
+    return List.of(
+        PostFavorite.builder()
+            .id(1L)
+            .member(authenticatedMember())
+            .post(defaultPost(defaultBook(), authenticatedMember(), defaultCategory()))
+            .build(),
+        PostFavorite.builder()
+            .id(2L)
+            .member(authenticatedMember())
+            .post(defaultPost(defaultBook(), authenticatedMember(), defaultCategory()))
+            .build()
+    );
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/PostFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/PostFixture.java
@@ -26,6 +26,21 @@ public class PostFixture {
         .build();
   }
 
+  public static Post defaultIdPost(Book book, Member seller, Category category) {
+    return Post.builder()
+        .id(1L)
+        .book(book)
+        .seller(seller)
+        .category(category)
+        .bookStatus(BookStatus.BEST)
+        .postStatus(PostStatus.READY)
+        .sellPrice(30000)
+        .description("Description")
+        .registrationAreaId(seller.getActivityArea().getId().getEmdAreaId())
+        .thumbnailUrl("https://image/1.png")
+        .build();
+  }
+
   public static List<Post> DEFAULT_MOCK_POSTS() {
     return List.of(
         Post.builder()

--- a/src/test/unit/java/com/bob/support/fixture/query/PostQueryFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/query/PostQueryFixture.java
@@ -1,9 +1,11 @@
 package com.bob.support.fixture.query;
 
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
+import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
 import com.bob.domain.post.service.dto.query.condition.SearchKey;
 import com.bob.domain.post.service.dto.query.condition.SearchPrice;
 import com.bob.domain.post.service.dto.query.condition.SortKey;
+import java.util.UUID;
 
 public class PostQueryFixture {
 
@@ -18,6 +20,10 @@ public class PostQueryFixture {
         .bookStatus(null)
         .sortKey(SortKey.RECENT)
         .build();
+  }
+
+  public static ReadMemberFavoritePostsQuery defaultReadMemberFavoritePostsQuery(UUID memberId) {
+    return ReadMemberFavoritePostsQuery.of(memberId);
   }
 
   public static ReadFilteredPostsQuery searchTitleQuery() {

--- a/src/test/unit/java/com/bob/support/fixture/response/PostResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/PostResponseFixture.java
@@ -6,6 +6,7 @@ import com.bob.domain.post.entity.status.BookStatus;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
 import com.bob.domain.post.service.dto.response.PostDetailResponse.BookInfo;
 import com.bob.domain.post.service.dto.response.PostDetailResponse.WriterInfo;
+import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostSummary;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import com.bob.domain.trade.entity.status.TradeStatus;
@@ -70,5 +71,9 @@ public class PostResponseFixture {
 
   public static PostsResponse DEFAULT_POSTS_RESPONSE() {
     return PostsResponse.of(2L, DEFAULT_MOCK_POSTS());
+  }
+
+  public static PostFavoritesResponse DEFAULT_FAVORITE_RESPONSE() {
+    return new PostFavoritesResponse(2L, DEFAULT_POST_SUMMARY());
   }
 }

--- a/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
@@ -20,6 +20,8 @@ import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
 import com.bob.domain.member.service.MemberService;
+import com.bob.domain.member.service.dto.response.internal.MemberPostsResponse;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -114,6 +116,27 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.posts[1].postTitle").value("오브젝트"));
 
     verify(memberService, times(1)).readMemberPostsProcess(any());
+  }
+
+
+  @Test
+  @DisplayName("좋아요한 게시글 목록 조회 API 호출 테스트")
+  void 좋아요한_게시글_목록을_조회한다() throws Exception {
+    // given
+    given(memberService.readMemberFavoritePosts(any())).willReturn(DEFAULT_MEMBER_POSTS_RESPONSE);
+
+    // when & then
+    mvc.perform(get("/members/me/favorites")
+            .param("page", "0")
+            .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalCount").value(2))
+        .andExpect(jsonPath("$.posts[0].postId").value(1))
+        .andExpect(jsonPath("$.posts[0].postTitle").value("객체지향의 사실과 오해"))
+        .andExpect(jsonPath("$.posts[1].postId").value(2))
+        .andExpect(jsonPath("$.posts[1].postTitle").value("오브젝트"));
+
+    verify(memberService, times(1)).readMemberFavoritePosts(any());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
+++ b/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
@@ -80,6 +80,22 @@ class PostControllerTest {
   }
 
   @Test
+  @DisplayName("게시글 좋아요 API 호출 테스트")
+  void 게시글_좋아요_API를_호출할_수_있다() throws Exception {
+    Long postId = 1L;
+    UUID memberId = UUID.randomUUID();
+
+    // when & then
+    mvc.perform(post("/posts/{postId}/favorite", postId)
+            .requestAttr("memberId", memberId))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("CREATED"));
+
+    verify(postService, times(1)).registerPostFavoriteProcess(any());
+  }
+
+  @Test
   @DisplayName("게시글 목록 필터 조회 API 호출 테스트")
   void 게시글_목록_필터_조회_API를_호출할_수_있다() throws Exception {
     // given

--- a/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
+++ b/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -93,6 +94,23 @@ class PostControllerTest {
         .andExpect(jsonPath("$.result").value("CREATED"));
 
     verify(postService, times(1)).registerPostFavoriteProcess(any());
+  }
+
+  @Test
+  @DisplayName("게시글 좋아요 해제 API 호출 테스트")
+  void 게시글_좋아요_해제_API를_호출할_수_있다() throws Exception {
+    // given
+    Long postId = 1L;
+    UUID memberId = UUID.randomUUID();
+
+    // when & then
+    mvc.perform(delete("/posts/{postId}/favorite", postId)
+            .requestAttr("memberId", memberId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("DELETED"));
+
+    verify(postService, times(1)).unregisterPostFavoriteProcess(any());
   }
 
   @Test


### PR DESCRIPTION
### #️⃣연관된 이슈
> #35 

### 📜 작업 내용
- [x] 게시글 좋아요 등록 기능 구현
- [x] 게시글 좋아요 해제 기능 구현
- [x] 회원이 좋아하는 게시글 목록 조회
- [x] 기존 게시글 상세 조회 기능의 좋아요 여부 매핑

### ⚠️ 종료할 이슈
this closes #35 
