### PR TITLE
feat#39: 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/bob/domain/post/repository/PostFavoriteRepository.java
@@ -11,9 +11,11 @@ public interface PostFavoriteRepository extends CrudRepository<PostFavorite, Lon
 
   Optional<PostFavorite> findByMemberIdAndPostId(UUID memberId, Long postId);
 
-  Boolean existsByMemberIdAndPostId(UUID memberId, Long postId);
-
   List<PostFavorite> findByMemberIdOrderByCreatedAtDesc(UUID memberId, Pageable pageable);
 
   Long countByMemberId(UUID memberId);
+
+  Boolean existsByMemberIdAndPostId(UUID memberId, Long postId);
+
+  void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
+++ b/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
@@ -35,14 +35,14 @@ public class PostFavoriteService {
     postFavoriteRepository.delete(favorite);
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public boolean isFavorite(UUID memberId, Long postId) {
     return postFavoriteRepository.existsByMemberIdAndPostId(memberId, postId);
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public PostFavoritesResponse readMemberFavoritePosts(UUID memberId, Pageable pageable) {
-    List<PostFavorite> postFavorites = postFavoriteRepository.findByMemberIdOrderByCreatedAtDesc(memberId, pageable);
+    List<PostFavorite> postFavorites = postFavoriteReader.readFavoritePostsByMemberId(memberId, pageable);
     Long totalCount = postFavoriteRepository.countByMemberId(memberId);
     return PostFavoritesResponse.of(totalCount, postFavorites);
   }

--- a/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
+++ b/src/main/java/com/bob/domain/post/service/PostFavoriteService.java
@@ -46,4 +46,9 @@ public class PostFavoriteService {
     Long totalCount = postFavoriteRepository.countByMemberId(memberId);
     return PostFavoritesResponse.of(totalCount, postFavorites);
   }
+
+  @Transactional
+  public void removePostFavoriteProcess(Long postId) {
+    postFavoriteRepository.deleteAllByPostId(postId);
+  }
 }

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -11,6 +11,7 @@ import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
+import com.bob.domain.post.service.dto.command.RemovePostCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
@@ -98,6 +99,14 @@ public class PostService {
     Post post = postReader.readPostById(command.postId());
     verifyPostOwner(command.memberId(), post.getSeller().getId());
     post.updateOptionalFields(command.sellPrice(), command.bookStatus(), command.description());
+  }
+
+  @Transactional
+  public void removePostProcess(RemovePostCommand command) {
+    Post post = postReader.readPostById(command.postId());
+    verifyPostOwner(command.memberId(), post.getSeller().getId());
+    postFavoriteService.removePostFavoriteProcess(post.getId());
+    postRepository.deleteById(post.getId());
   }
 
   private void verifyPostOwner(UUID requestMemberId, UUID postMemberId) {

--- a/src/main/java/com/bob/domain/post/service/dto/command/RemovePostCommand.java
+++ b/src/main/java/com/bob/domain/post/service/dto/command/RemovePostCommand.java
@@ -1,0 +1,10 @@
+package com.bob.domain.post.service.dto.command;
+
+import java.util.UUID;
+
+public record RemovePostCommand(
+    UUID memberId,
+    Long postId
+) {
+
+}

--- a/src/main/java/com/bob/domain/post/service/reader/PostFavoriteReader.java
+++ b/src/main/java/com/bob/domain/post/service/reader/PostFavoriteReader.java
@@ -4,8 +4,10 @@ import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.repository.PostFavoriteRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,5 +21,9 @@ public class PostFavoriteReader {
   public PostFavorite readFavoritePostByMemberIdAndPostId(UUID memberId, Long postId) {
     return postFavoriteRepository.findByMemberIdAndPostId(memberId, postId)
         .orElseThrow(() -> new ApplicationException(ApplicationError.INVALID_POST_FAVORITE));
+  }
+
+  public List<PostFavorite> readFavoritePostsByMemberId(UUID memberId, Pageable pageable) {
+    return postFavoriteRepository.findByMemberIdOrderByCreatedAtDesc(memberId, pageable);
   }
 }

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -15,6 +15,7 @@ import com.bob.web.common.symbol.ResponseSymbol;
 import com.bob.web.post.request.ChangePostRequest;
 import com.bob.web.post.request.CreatePostRequest;
 import com.bob.web.post.request.ReadFilteredPostsRequest;
+import com.bob.web.post.request.RemovePostRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -58,16 +59,6 @@ public class PostController {
     return new CommonResponse<>(true, CREATED);
   }
 
-  @DeleteMapping("/{postId}/favorite")
-  @ResponseStatus(HttpStatus.OK)
-  public CommonResponse<ResponseSymbol> handleUnregisterFavoritePost(
-      @PathVariable Long postId,
-      @AuthenticationId UUID memberId
-  ) {
-    postService.unregisterPostFavoriteProcess(toCommand(memberId, postId));
-    return new CommonResponse<>(true, DELETED);
-  }
-
   @GetMapping
   public ResponseEntity<PostsResponse> handleReadFilteredPosts(
       ReadFilteredPostsRequest request,
@@ -92,5 +83,23 @@ public class PostController {
   ) {
     postService.changePostProcess(request.toCommand(postId, memberId));
     return new CommonResponse<>(true, OK);
+  }
+
+  @DeleteMapping("/{postId}/favorite")
+  public CommonResponse<ResponseSymbol> handleUnregisterFavoritePost(
+      @PathVariable Long postId,
+      @AuthenticationId UUID memberId
+  ) {
+    postService.unregisterPostFavoriteProcess(toCommand(memberId, postId));
+    return new CommonResponse<>(true, DELETED);
+  }
+
+  @DeleteMapping("/{postId}")
+  public CommonResponse<ResponseSymbol> handleRemovePost(
+      @PathVariable Long postId,
+      @AuthenticationId UUID memberId
+  ) {
+    postService.removePostProcess(RemovePostRequest.toCommand(memberId, postId));
+    return new CommonResponse<>(true, DELETED);
   }
 }

--- a/src/main/java/com/bob/web/post/request/RemovePostRequest.java
+++ b/src/main/java/com/bob/web/post/request/RemovePostRequest.java
@@ -1,0 +1,13 @@
+package com.bob.web.post.request;
+
+import com.bob.domain.post.service.dto.command.RemovePostCommand;
+import java.util.UUID;
+
+public record RemovePostRequest(
+
+) {
+
+  public static RemovePostCommand toCommand(UUID memberId, Long postId) {
+    return new RemovePostCommand(memberId, postId);
+  }
+}

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -279,6 +279,7 @@ INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365
 INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-0c5f1dbe9c59'), 'otherReader@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'otherReader');
 
 INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 213, CURDATE());
+INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-0c5f1dbe9c59'), 213, CURDATE());
 
 INSERT INTO books (isbn13, title, author, description, price_standard, cover, pub_date) VALUES
 ('9788994492032', '자바의 정석', '남궁성', '자바 기초 입문서', 15000, 'https://cover/1.png', '2020-01-01'),

--- a/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
@@ -150,4 +150,17 @@ class PostFavoriteServiceTest {
     then(postFavoriteReader).should().readFavoritePostsByMemberId(memberId, pageable);
     then(postFavoriteRepository).should().countByMemberId(memberId);
   }
+
+  @Test
+  @DisplayName("게시글 삭제 시 - 해당 게시글의 모든 좋아요를 삭제한다")
+  void 게시글을_삭제하면_해당_게시글의_좋아요가_모두_삭제된다() {
+    // given
+    Long postId = 1L;
+
+    // when
+    postFavoriteService.removePostFavoriteProcess(postId);
+
+    // then
+    then(postFavoriteRepository).should(times(1)).deleteAllByPostId(postId);
+  }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostFavoriteServiceTest.java
@@ -3,7 +3,6 @@ package com.bob.domain.post.service;
 import static com.bob.global.exception.response.ApplicationError.ALREADY_POST_FAVORITE;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
 import static com.bob.support.fixture.domain.PostFavoriteFixture.DEFAULT_MOCK_POST_FAVORITES;
-import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_FAVORITE_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -138,7 +137,7 @@ class PostFavoriteServiceTest {
   void 사용자의_즐겨찾기_게시글_목록을_조회할_수_있다() {
     // given
     UUID memberId = UUID.randomUUID();
-    given(postFavoriteRepository.findByMemberIdOrderByCreatedAtDesc(memberId, pageable)).willReturn(DEFAULT_MOCK_POST_FAVORITES());
+    given(postFavoriteReader.readFavoritePostsByMemberId(memberId, pageable)).willReturn(DEFAULT_MOCK_POST_FAVORITES());
     given(postFavoriteRepository.countByMemberId(memberId)).willReturn((long) DEFAULT_MOCK_POST_FAVORITES().size());
 
     // when
@@ -148,7 +147,7 @@ class PostFavoriteServiceTest {
     assertThat(response.totalCount()).isEqualTo(2L);
     assertThat(response.postFavorites()).hasSize(2);
 
-    then(postFavoriteRepository).should().findByMemberIdOrderByCreatedAtDesc(memberId, pageable);
+    then(postFavoriteReader).should().readFavoritePostsByMemberId(memberId, pageable);
     then(postFavoriteRepository).should().countByMemberId(memberId);
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/reader/PostFavoriteReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/reader/PostFavoriteReaderTest.java
@@ -2,6 +2,8 @@ package com.bob.domain.post.service.reader;
 
 import static com.bob.global.exception.response.ApplicationError.INVALID_POST_FAVORITE;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static com.bob.support.fixture.domain.PostFavoriteFixture.DEFAULT_MOCK_POST_FAVORITES;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
@@ -12,6 +14,7 @@ import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.repository.PostFavoriteRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +22,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PostFavoriteReader 테스트")
@@ -33,13 +38,16 @@ class PostFavoriteReaderTest {
   @Mock
   private Post post;
 
+  private Pageable pageable = PageRequest.of(0, 12);
+
   @Test
   @DisplayName("좋아요 게시글 조회 - 성공 테스트")
   void 좋아요가_존재하면_PostFavorite를_반환한다() {
     // given
     Member member = defaultIdMember();
     PostFavorite postFavorite = PostFavorite.create(member, post);
-    given(postFavoriteRepository.findByMemberIdAndPostId(member.getId(), post.getId())).willReturn(Optional.of(postFavorite));
+    given(postFavoriteRepository.findByMemberIdAndPostId(member.getId(), post.getId())).willReturn(
+        Optional.of(postFavorite));
 
     // when
     PostFavorite result = postFavoriteReader.readFavoritePostByMemberIdAndPostId(member.getId(), post.getId());
@@ -62,5 +70,20 @@ class PostFavoriteReaderTest {
     )
         .isInstanceOf(ApplicationException.class)
         .hasMessage(INVALID_POST_FAVORITE.getMessage());
+  }
+
+  @Test
+  @DisplayName("좋아요 게시글 목록 조회 테스트")
+  void 사용자가_좋아요_한_게시글_목록을_조회한다() {
+    // given
+    Member member = defaultIdMember();
+    given(postFavoriteRepository.findByMemberIdOrderByCreatedAtDesc(member.getId(), pageable)).willReturn(DEFAULT_MOCK_POST_FAVORITES());
+
+    // when
+    List<PostFavorite> result = postFavoriteReader.readFavoritePostsByMemberId(member.getId(), pageable);
+
+    // then
+    then(postFavoriteRepository).should().findByMemberIdOrderByCreatedAtDesc(member.getId(), pageable);
+    assertThat(result).hasSize(2);
   }
 }

--- a/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
+++ b/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
@@ -199,4 +199,21 @@ class PostControllerTest {
 
     verify(postService, times(1)).changePostProcess(any());
   }
+
+  @Test
+  @DisplayName("게시글 삭제 API 호출 테스트")
+  void 게시글_삭제_API를_호출할_수_있다() throws Exception {
+    // given
+    Long postId = 1L;
+    UUID memberId = UUID.randomUUID();
+
+    // when & then
+    mvc.perform(delete("/posts/{postId}", postId)
+            .requestAttr("memberId", memberId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("DELETED"));
+
+    verify(postService, times(1)).removePostProcess(any());
+  }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #39 

### 📜 작업 내용
- [x] 게시글 삭제 기능 구현
- [x] 게시글 관련 좋아요 데이터 삭제 기능 구현 
- [x] 게시글 좋아요 조회 시 reader 사용으로 변경

### ⚠️ 종료할 이슈
this closes #39 
