### PR TITLE
feat#42: 채팅방 생성 기능 구현

### DIFF
--- a/src/main/java/com/bob/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/bob/domain/chat/entity/ChatMessage.java
@@ -1,24 +1,21 @@
 package com.bob.domain.chat.entity;
 
+import com.bob.domain.chat.entity.type.ChatMessageType;
+import com.bob.global.audit.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import com.bob.domain.chat.entity.type.ChatMessageType;
-import com.bob.domain.member.entity.Member;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,19 +23,17 @@ import com.bob.domain.member.entity.Member;
 @Builder
 @Entity
 @Table(name = "chat_messages")
-public class ChatMessage {
+public class ChatMessage extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "chat_room_id", nullable = false)
-  private ChatRoom chatRoom;
+  @Column(nullable = false)
+  private Long chatRoomId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "sender_id", nullable = false)
-  private Member sender;
+  @Column(nullable = false)
+  private UUID senderId;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
@@ -53,7 +48,4 @@ public class ChatMessage {
   @Column(nullable = false)
   @Builder.Default
   private Boolean isRead = false;
-
-  @Column(nullable = false)
-  private LocalDateTime sentAt;
 }

--- a/src/main/java/com/bob/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/bob/domain/chat/entity/ChatRoom.java
@@ -1,20 +1,13 @@
 package com.bob.domain.chat.entity;
 
-import com.bob.domain.trade.entity.Trade;
 import com.bob.global.audit.BaseTime;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,19 +26,18 @@ public class ChatRoom extends BaseTime {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "trade_id", nullable = false)
-  private Trade trade;
+  @Column(nullable = false)
+  private Long postId;
+
+  @Column(nullable = false)
+  private Long tradeId;
 
   @Column(length = 100, nullable = false)
   private String titleSuffix;
 
   @Column(nullable = false)
-  private Boolean status;
+  private Boolean enableStatus;
 
   @Column(nullable = false)
   private LocalDateTime lastChatAt;
-
-  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<ChatRoomMember> members;
 }

--- a/src/main/java/com/bob/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/bob/domain/chat/entity/ChatRoomMember.java
@@ -1,16 +1,13 @@
 package com.bob.domain.chat.entity;
 
-import com.bob.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,9 +29,8 @@ public class ChatRoomMember {
   @Column(nullable = false)
   private Long chatRoomId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id", nullable = false)
-  private Member member;
+  @Column(nullable = false)
+  private UUID memberId;
 
   private LocalDateTime exitedAt;
 }

--- a/src/main/java/com/bob/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/bob/domain/chat/entity/ChatRoomMember.java
@@ -29,19 +29,12 @@ public class ChatRoomMember {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "chat_room_id", nullable = false)
-  private ChatRoom chatRoom;
+  @Column(nullable = false)
+  private Long chatRoomId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
-  @Column(nullable = false)
-  private Boolean isExited;
-
   private LocalDateTime exitedAt;
-
-  @Column(nullable = false)
-  private Boolean status;
 }

--- a/src/main/java/com/bob/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/bob/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,10 @@
+package com.bob.domain.chat.repository;
+
+import com.bob.domain.chat.entity.ChatRoomMember;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ChatRoomMemberRepository extends CrudRepository<ChatRoomMember, Long> {
+
+  List<ChatRoomMember> findByChatRoomId(Long chatRoomId);
+}

--- a/src/main/java/com/bob/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/bob/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,24 @@
+package com.bob.domain.chat.repository;
+
+import com.bob.domain.chat.entity.ChatRoom;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ChatRoomRepository extends CrudRepository<ChatRoom, Long> {
+
+  @Query("""
+        SELECT crm.chatRoomId
+        FROM ChatRoomMember crm
+        WHERE crm.chatRoomId IN (
+            SELECT cr.id
+            FROM ChatRoom cr
+            WHERE cr.postId = :postId
+        )
+        AND crm.memberId IN (:sellerId, :buyerId)
+        GROUP BY crm.chatRoomId
+        HAVING COUNT(DISTINCT crm.memberId) = 2
+      """)
+  Optional<Long> findExistingChatRoom(Long postId, UUID sellerId, UUID buyerId);
+}

--- a/src/main/java/com/bob/domain/chat/service/ChatRoomMemberService.java
+++ b/src/main/java/com/bob/domain/chat/service/ChatRoomMemberService.java
@@ -1,0 +1,22 @@
+package com.bob.domain.chat.service;
+
+import com.bob.domain.chat.entity.ChatRoomMember;
+import com.bob.domain.chat.repository.ChatRoomMemberRepository;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomMembersCommand;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ChatRoomMemberService {
+
+  private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+  @Transactional
+  public void registerChatRoomMembers(CreateChatRoomMembersCommand command) {
+    List<ChatRoomMember> chatRoomMembers = command.toChatRoomMembers();
+    chatRoomMemberRepository.saveAll(chatRoomMembers);
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/bob/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,59 @@
+package com.bob.domain.chat.service;
+
+import com.bob.domain.chat.entity.ChatRoom;
+import com.bob.domain.chat.repository.ChatRoomRepository;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomCommand;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomMembersCommand;
+import com.bob.domain.chat.service.dto.response.ChatPostResponse;
+import com.bob.domain.chat.service.dto.response.CreateChatRoomResponse;
+import com.bob.domain.chat.service.port.out.ChatPostPort;
+import com.bob.domain.chat.service.port.out.ChatTradePort;
+import com.bob.domain.chat.service.reader.ChatRoomReader;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ChatRoomService {
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatRoomReader chatRoomReader;
+
+  private final ChatRoomMemberService chatRoomMemberService;
+
+  private final ChatPostPort postPort;
+  private final ChatTradePort tradePort;
+
+  @Transactional
+  public CreateChatRoomResponse createChatRoomProcess(CreateChatRoomCommand command) {
+    ChatPostResponse post = postPort.readChatPostSummary(command.postId());
+    verifyBuyer(post.sellerId(), command.buyerId());
+
+    return chatRoomReader.readExistingChatRoom(post.postId(), post.sellerId(), command.buyerId())
+        .map(CreateChatRoomResponse::of)
+        .orElseGet(() -> createNewChatRoom(command, post));
+  }
+
+  private CreateChatRoomResponse createNewChatRoom(CreateChatRoomCommand command, ChatPostResponse post) {
+    Long tradeId = tradePort.createTrade(post.postId(), post.sellerId(), command.buyerId());
+    ChatRoom chatRoom = command.toChatRoom(tradeId, post.title());
+    chatRoomRepository.save(chatRoom);
+    chatRoomMemberService.registerChatRoomMembers(CreateChatRoomMembersCommand.of(
+        chatRoom.getId(),
+        List.of(post.sellerId(), command.buyerId())
+    ));
+    return CreateChatRoomResponse.of(chatRoom.getId());
+  }
+
+  private void verifyBuyer(UUID sellerId, UUID buyerId) {
+    if (Objects.equals(sellerId, buyerId)) {
+      throw new ApplicationException(ApplicationError.IS_SAME_CHAT_MEMBER);
+    }
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatRoomCommand.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatRoomCommand.java
@@ -1,0 +1,21 @@
+package com.bob.domain.chat.service.dto.command;
+
+import com.bob.domain.chat.entity.ChatRoom;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateChatRoomCommand(
+    Long postId,
+    UUID buyerId
+) {
+
+  public ChatRoom toChatRoom(Long tradeId, String titleSuffix) {
+    return ChatRoom.builder()
+        .postId(postId)
+        .tradeId(tradeId)
+        .titleSuffix(titleSuffix)
+        .enableStatus(false)
+        .lastChatAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatRoomMembersCommand.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatRoomMembersCommand.java
@@ -1,0 +1,25 @@
+package com.bob.domain.chat.service.dto.command;
+
+import com.bob.domain.chat.entity.ChatRoomMember;
+import java.util.List;
+import java.util.UUID;
+
+public record CreateChatRoomMembersCommand(
+    Long chatRoomId,
+    List<UUID> memberIds
+) {
+
+  public static CreateChatRoomMembersCommand of(Long chatRoomID, List<UUID> memberIds) {
+    return new CreateChatRoomMembersCommand(chatRoomID, memberIds);
+  }
+
+  public List<ChatRoomMember> toChatRoomMembers() {
+    return memberIds.stream()
+        .map((memberId) -> ChatRoomMember
+            .builder()
+            .chatRoomId(chatRoomId)
+            .memberId(memberId)
+            .build()
+        ).toList();
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/dto/query/ReadPostSummaryQuery.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/query/ReadPostSummaryQuery.java
@@ -1,0 +1,10 @@
+package com.bob.domain.chat.service.dto.query;
+
+public record ReadPostSummaryQuery(
+    Long postId
+) {
+
+  public static ReadPostSummaryQuery of(Long postId) {
+    return new ReadPostSummaryQuery(postId);
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/dto/response/ChatPostResponse.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/response/ChatPostResponse.java
@@ -1,0 +1,14 @@
+package com.bob.domain.chat.service.dto.response;
+
+import java.util.UUID;
+
+public record ChatPostResponse(
+    Long postId,
+    UUID sellerId,
+    String title
+) {
+
+  public static ChatPostResponse of(Long postId, UUID sellerId, String title) {
+    return new ChatPostResponse(postId, sellerId, title);
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/dto/response/CreateChatRoomResponse.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/response/CreateChatRoomResponse.java
@@ -1,0 +1,10 @@
+package com.bob.domain.chat.service.dto.response;
+
+public record CreateChatRoomResponse(
+    Long chatRoomId
+) {
+
+  public static CreateChatRoomResponse of(Long chatRoomId) {
+    return new CreateChatRoomResponse(chatRoomId);
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/port/out/ChatPostPort.java
+++ b/src/main/java/com/bob/domain/chat/service/port/out/ChatPostPort.java
@@ -1,0 +1,7 @@
+package com.bob.domain.chat.service.port.out;
+
+import com.bob.domain.chat.service.dto.response.ChatPostResponse;
+
+public interface ChatPostPort {
+  ChatPostResponse readChatPostSummary(Long postId);
+}

--- a/src/main/java/com/bob/domain/chat/service/port/out/ChatTradePort.java
+++ b/src/main/java/com/bob/domain/chat/service/port/out/ChatTradePort.java
@@ -1,0 +1,8 @@
+package com.bob.domain.chat.service.port.out;
+
+import java.util.UUID;
+
+public interface ChatTradePort {
+
+  Long createTrade(Long postId, UUID sellerId, UUID buyerId);
+}

--- a/src/main/java/com/bob/domain/chat/service/reader/ChatRoomReader.java
+++ b/src/main/java/com/bob/domain/chat/service/reader/ChatRoomReader.java
@@ -1,0 +1,21 @@
+package com.bob.domain.chat.service.reader;
+
+import com.bob.domain.chat.entity.ChatRoom;
+import com.bob.domain.chat.repository.ChatRoomRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ChatRoomReader {
+
+  private final ChatRoomRepository chatRoomRepository;
+
+  public Optional<Long> readExistingChatRoom(Long postId, UUID sellerId, UUID buyerId) {
+    return chatRoomRepository.findExistingChatRoom(postId, sellerId, buyerId);
+  }
+}

--- a/src/main/java/com/bob/domain/post/adapter/PostAdapter.java
+++ b/src/main/java/com/bob/domain/post/adapter/PostAdapter.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class PostProvider implements PostSearcher {
+public class PostAdapter implements PostSearcher {
 
   private final PostService postService;
 

--- a/src/main/java/com/bob/domain/post/adapter/PostAdapter.java
+++ b/src/main/java/com/bob/domain/post/adapter/PostAdapter.java
@@ -1,9 +1,13 @@
 package com.bob.domain.post.adapter;
 
+import com.bob.domain.chat.service.dto.response.ChatPostResponse;
+import com.bob.domain.chat.service.port.out.ChatPostPort;
 import com.bob.domain.member.service.port.PostSearcher;
 import com.bob.domain.post.service.PostService;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
+import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
+import com.bob.domain.post.service.dto.response.PostDetailResponse;
 import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import java.util.UUID;
@@ -13,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class PostAdapter implements PostSearcher {
+public class PostAdapter implements PostSearcher, ChatPostPort {
 
   private final PostService postService;
 
@@ -25,5 +29,11 @@ public class PostAdapter implements PostSearcher {
   @Override
   public PostFavoritesResponse readMemberFavoritePostsSummary(UUID memberId, Pageable pageable) {
     return postService.readMemberFavoritePostsProcess(ReadMemberFavoritePostsQuery.of(memberId), pageable);
+  }
+
+  @Override
+  public ChatPostResponse readChatPostSummary(Long postId) {
+    PostDetailResponse detail = postService.readPostDetailProcess(ReadPostDetailQuery.of(null, postId));
+    return ChatPostResponse.of(detail.postId(), detail.sellerId(), detail.book().title());
   }
 }

--- a/src/main/java/com/bob/domain/post/entity/Post.java
+++ b/src/main/java/com/bob/domain/post/entity/Post.java
@@ -80,9 +80,6 @@ public class Post extends BaseTime {
   @Builder.Default
   private Integer scrapCount = 0;
 
-  @OneToMany(mappedBy = "post")
-  private final List<Trade> trades = new ArrayList<>();
-
   public void updateOptionalFields(Integer sellPrice, String bookStatus, String description) {
     Optional.ofNullable(sellPrice).ifPresent(s -> this.sellPrice = s);
     Optional.ofNullable(bookStatus).ifPresent(b -> this.bookStatus = BookStatus.from(b));

--- a/src/main/java/com/bob/domain/post/service/dto/query/ReadPostDetailQuery.java
+++ b/src/main/java/com/bob/domain/post/service/dto/query/ReadPostDetailQuery.java
@@ -7,4 +7,7 @@ public record ReadPostDetailQuery(
     Long postId
 ) {
 
+  public static ReadPostDetailQuery of(UUID memberId, Long postId) {
+    return new ReadPostDetailQuery(memberId, postId);
+  }
 }

--- a/src/main/java/com/bob/domain/post/service/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/bob/domain/post/service/dto/response/PostDetailResponse.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 @Builder
 public record PostDetailResponse(
     Long postId,
+    UUID sellerId,
     Integer sellPrice,
     String bookStatus,
     String postStatus,
@@ -27,6 +28,7 @@ public record PostDetailResponse(
   public static PostDetailResponse of(Post post, boolean isFavorite, boolean isOwner, List<String> images) {
     return PostDetailResponse.builder()
         .postId(post.getId())
+        .sellerId(post.getSeller().getId())
         .sellPrice(post.getSellPrice())
         .bookStatus(post.getBookStatus().name())
         .postStatus(post.getPostStatus().getStatus())

--- a/src/main/java/com/bob/domain/trade/adapter/TradeAdapter.java
+++ b/src/main/java/com/bob/domain/trade/adapter/TradeAdapter.java
@@ -1,0 +1,20 @@
+package com.bob.domain.trade.adapter;
+
+import com.bob.domain.chat.service.port.out.ChatTradePort;
+import com.bob.domain.trade.service.TradeService;
+import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TradeAdapter implements ChatTradePort {
+
+  private final TradeService tradeService;
+
+  @Override
+  public Long createTrade(Long postId, UUID sellerId, UUID buyerId) {
+    return tradeService.createTrade(CreateTradeCommand.of(postId, sellerId, buyerId));
+  }
+}

--- a/src/main/java/com/bob/domain/trade/entity/Trade.java
+++ b/src/main/java/com/bob/domain/trade/entity/Trade.java
@@ -1,26 +1,22 @@
 package com.bob.domain.trade.entity;
 
+import com.bob.domain.trade.entity.status.TradeStatus;
+import com.bob.global.audit.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import com.bob.domain.member.entity.Member;
-import com.bob.domain.post.entity.Post;
-import com.bob.domain.trade.entity.status.TradeStatus;
-import com.bob.global.audit.BaseTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,13 +30,14 @@ public class Trade extends BaseTime {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "post_id", nullable = false)
-  private Post post;
+  @Column(nullable = false)
+  private Long postId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "buyer_id", nullable = false)
-  private Member buyer;
+  @Column(nullable = false)
+  private UUID sellerId;
+
+  @Column(nullable = false)
+  private UUID buyerId;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)

--- a/src/main/java/com/bob/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/bob/domain/trade/repository/TradeRepository.java
@@ -1,0 +1,8 @@
+package com.bob.domain.trade.repository;
+
+import com.bob.domain.trade.entity.Trade;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TradeRepository extends CrudRepository<Trade, Long> {
+
+}

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -1,0 +1,21 @@
+package com.bob.domain.trade.service;
+
+import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class TradeService {
+
+  private final TradeRepository tradeRepository;
+
+  @Transactional
+  public Long createTrade(CreateTradeCommand command) {
+    Trade trade = tradeRepository.save(command.toTrade());
+    return trade.getId();
+  }
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/command/CreateTradeCommand.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/command/CreateTradeCommand.java
@@ -1,0 +1,27 @@
+package com.bob.domain.trade.service.dto.command;
+
+import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.entity.status.TradeStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateTradeCommand(
+    Long postId,
+    UUID sellerId,
+    UUID buyerId
+) {
+
+  public static CreateTradeCommand of(Long postId, UUID sellerId, UUID buyerId) {
+    return new CreateTradeCommand(postId, sellerId, buyerId);
+  }
+
+  public Trade toTrade() {
+    return Trade.builder()
+        .postId(postId)
+        .sellerId(sellerId)
+        .buyerId(buyerId)
+        .tradeStatus(TradeStatus.REQUESTED)
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -36,6 +36,9 @@ public enum ApplicationError {
   NOT_POST_OWNER("E303", "게시글 작성자가 아닙니다.", HttpStatus.FORBIDDEN),
   ALREADY_POST_FAVORITE("E304", "이미 좋아요한 게시글입니다.", HttpStatus.BAD_REQUEST),
   INVALID_POST_FAVORITE("E305", "좋아요 하지 않은 게시글입니다.", HttpStatus.BAD_REQUEST),
+
+  // 채팅 예외
+  IS_SAME_CHAT_MEMBER("E401", "자신과의 채팅은 불가능합니다.", HttpStatus.BAD_REQUEST)
   ;
 
   private String code;

--- a/src/main/java/com/bob/web/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/bob/web/chat/controller/ChatRoomController.java
@@ -1,0 +1,34 @@
+package com.bob.web.chat.controller;
+
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.bob.domain.chat.service.ChatRoomService;
+import com.bob.domain.chat.service.dto.response.CreateChatRoomResponse;
+import com.bob.web.chat.request.CreateChatRoomRequest;
+import com.bob.web.common.AuthenticationId;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/chatrooms")
+@RestController
+public class ChatRoomController {
+
+  private final ChatRoomService chatRoomService;
+
+  @PostMapping
+  public ResponseEntity<CreateChatRoomResponse> handleCreateChatRoom(
+      @Valid @RequestBody CreateChatRoomRequest request,
+      @AuthenticationId UUID memberId
+  ) {
+    CreateChatRoomResponse response = chatRoomService.createChatRoomProcess(request.toCommand(memberId));
+    return ResponseEntity.status(CREATED).body(response);
+  }
+}

--- a/src/main/java/com/bob/web/chat/request/CreateChatRoomRequest.java
+++ b/src/main/java/com/bob/web/chat/request/CreateChatRoomRequest.java
@@ -1,0 +1,15 @@
+package com.bob.web.chat.request;
+
+import com.bob.domain.chat.service.dto.command.CreateChatRoomCommand;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record CreateChatRoomRequest(
+    @NotNull(message = "게시글 ID는 필수입니다.")
+    Long postId
+) {
+
+  public CreateChatRoomCommand toCommand(UUID memberId) {
+    return new CreateChatRoomCommand(postId, memberId);
+  }
+}

--- a/src/test/intg/java/com/bob/domain/chat/service/ChatRoomServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/chat/service/ChatRoomServiceIntgTest.java
@@ -1,0 +1,113 @@
+package com.bob.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bob.domain.chat.entity.ChatRoom;
+import com.bob.domain.chat.entity.ChatRoomMember;
+import com.bob.domain.chat.repository.ChatRoomMemberRepository;
+import com.bob.domain.chat.repository.ChatRoomRepository;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomCommand;
+import com.bob.domain.chat.service.dto.response.CreateChatRoomResponse;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.repository.MemberRepository;
+import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.repository.PostRepository;
+import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import com.bob.support.TestContainerSupport;
+import com.bob.support.fixture.command.CreateChatRoomCommandFixture;
+import com.bob.support.fixture.domain.MemberFixture;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("채팅방 서비스 통합 테스트")
+@Transactional
+@SpringBootTest
+class ChatRoomServiceIntgTest extends TestContainerSupport {
+
+  @Autowired
+  private ChatRoomService chatRoomService;
+
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
+
+  @Autowired
+  private ChatRoomMemberRepository chatRoomMemberRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private PostRepository postRepository;
+
+  @Autowired
+  private TradeRepository tradeRepository;
+
+  @Test
+  @DisplayName("채팅방 생성 - 성공 테스트")
+  void 채팅방을_생성할_수_있다() {
+    // given
+    Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).get();
+    Member buyer = memberRepository.save(MemberFixture.otherMember());
+    Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
+    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+
+    // when
+    CreateChatRoomResponse response = chatRoomService.createChatRoomProcess(command);
+
+    // then
+    ChatRoom chatRoom = chatRoomRepository.findById(response.chatRoomId()).orElseThrow();
+    List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(chatRoom.getId());
+
+    assertThat(chatRoom.getPostId()).isEqualTo(post.getId());
+    assertThat(chatRoom.getTitleSuffix()).contains("자바의 정석");
+    assertThat(members).extracting(ChatRoomMember::getMemberId)
+        .containsExactlyInAnyOrder(seller.getId(), buyer.getId());
+
+    Trade trade = tradeRepository.findById(chatRoom.getTradeId()).orElseThrow();
+    assertThat(trade.getSellerId()).isEqualTo(seller.getId());
+    assertThat(trade.getBuyerId()).isEqualTo(buyer.getId());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 - 실패 테스트 (본인 게시글 요청)")
+  void 본인_게시글에는_채팅방을_생성할_수_없다() {
+    // given
+    Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).get();
+    Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
+    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), seller.getId());
+
+    // when & then
+    assertThatThrownBy(() -> chatRoomService.createChatRoomProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.IS_SAME_CHAT_MEMBER.getMessage());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 - 이미 존재하는 경우 기존 ID 반환")
+  void 이미_존재하는_채팅방이_있다면_ID를_반환한다() {
+    // given
+    Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).get();
+    Member buyer = memberRepository.save(MemberFixture.otherMember());
+    Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
+
+    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId()); // 최초 생성
+    CreateChatRoomResponse created = chatRoomService.createChatRoomProcess(command);
+
+    // when
+    CreateChatRoomResponse result = chatRoomService.createChatRoomProcess(command);
+
+    // then
+    assertThat(result.chatRoomId()).isEqualTo(created.chatRoomId());
+    assertThat(chatRoomRepository.findById(result.chatRoomId())).isNotNull();
+    assertThat(chatRoomMemberRepository.findByChatRoomId(result.chatRoomId())).hasSize(2);
+  }
+}

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -131,11 +131,13 @@ CREATE TABLE IF NOT EXISTS activity_areas (
 CREATE TABLE IF NOT EXISTS trades (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     post_id BIGINT NOT NULL,
+    seller_id BINARY(16) NOT NULL,
     buyer_id BINARY(16) NOT NULL,
     trade_status ENUM('REQUESTED', 'CANCELED', 'COMPLETED') NOT NULL,
     updated_at DATETIME NOT NULL,
     created_at DATETIME,
     FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (seller_id) REFERENCES members(id),
     FOREIGN KEY (buyer_id) REFERENCES members(id)
 );
 
@@ -144,12 +146,13 @@ CREATE TABLE IF NOT EXISTS trades (
 -- ========================
 CREATE TABLE IF NOT EXISTS chat_rooms (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    post_id BIGINT NOT NULL,
     trade_id BIGINT NOT NULL,
     title_suffix VARCHAR(100) NOT NULL,
+    enable_status BOOLEAN NOT NULL,
     last_chat_at DATETIME NOT NULL,
-    status BOOLEAN NOT NULL,
-    created_at DATETIME,
-    modified_at DATETIME,
+    created_at DATETIME NOT NULL,
+    FOREIGN KEY (post_id) REFERENCES posts(id),
     FOREIGN KEY (trade_id) REFERENCES trades(id)
 );
 
@@ -164,7 +167,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
     chat_message VARCHAR(500),
     chat_image_url VARCHAR(255),
     is_read BOOLEAN DEFAULT FALSE,
-    sent_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL,
     FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id),
     FOREIGN KEY (sender_id) REFERENCES members(id)
 );
@@ -176,9 +179,7 @@ CREATE TABLE IF NOT EXISTS chat_room_members (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     chat_room_id BIGINT NOT NULL,
     member_id BINARY(16) NOT NULL,
-    is_exited BOOLEAN NOT NULL,
     exited_at DATETIME,
-    status BOOLEAN NOT NULL,
     FOREIGN KEY (chat_room_id) REFERENCES chat_rooms(id),
     FOREIGN KEY (member_id) REFERENCES members(id)
 );

--- a/src/test/unit/java/com/bob/domain/chat/service/ChatRoomMemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/chat/service/ChatRoomMemberServiceTest.java
@@ -1,0 +1,49 @@
+package com.bob.domain.chat.service;
+
+import static com.bob.support.fixture.command.CreateChatRoomMembersCommandFixture.DEFAULT_CREATE_CHAT_ROOM_MEMBERS_COMMAND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bob.domain.chat.entity.ChatRoomMember;
+import com.bob.domain.chat.repository.ChatRoomMemberRepository;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomMembersCommand;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("채팅방 회원 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class ChatRoomMemberServiceTest {
+
+  @InjectMocks
+  private ChatRoomMemberService chatRoomMemberService;
+
+  @Mock
+  private ChatRoomMemberRepository chatRoomMemberRepository;
+
+  @Test
+  @DisplayName("채팅방 회원 등록 테스트")
+  void 채팅방에_회원을_등록할_수_있다() {
+    // given
+    CreateChatRoomMembersCommand command = DEFAULT_CREATE_CHAT_ROOM_MEMBERS_COMMAND();
+    ArgumentCaptor<List<ChatRoomMember>> captor = ArgumentCaptor.forClass(List.class);
+
+    // when
+    chatRoomMemberService.registerChatRoomMembers(command);
+
+    // then
+    then(chatRoomMemberRepository).should(times(1)).saveAll(captor.capture());
+
+    List<ChatRoomMember> savedMembers = captor.getValue();
+    assertThat(savedMembers).hasSize(2);
+    assertThat(savedMembers).allSatisfy(member ->
+        assertThat(command.memberIds()).contains(member.getMemberId())
+    );
+  }
+}

--- a/src/test/unit/java/com/bob/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/chat/service/ChatRoomServiceTest.java
@@ -1,0 +1,129 @@
+package com.bob.domain.chat.service;
+
+import static com.bob.support.fixture.command.CreateChatRoomCommandFixture.DEFAULT_CREATE_CHAT_ROOM_COMMAND;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
+import static com.bob.support.fixture.response.ChatPostResponseFixture.DEFAULT_CHAT_POST_RESPONSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.bob.domain.chat.entity.ChatRoom;
+import com.bob.domain.chat.repository.ChatRoomRepository;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomCommand;
+import com.bob.domain.chat.service.dto.command.CreateChatRoomMembersCommand;
+import com.bob.domain.chat.service.dto.response.ChatPostResponse;
+import com.bob.domain.chat.service.dto.response.CreateChatRoomResponse;
+import com.bob.domain.chat.service.port.out.ChatPostPort;
+import com.bob.domain.chat.service.port.out.ChatTradePort;
+import com.bob.domain.chat.service.reader.ChatRoomReader;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("채팅방 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+  @InjectMocks
+  private ChatRoomService chatRoomService;
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private ChatRoomReader chatRoomReader;
+
+  @Mock
+  private ChatRoomMemberService chatRoomMemberService;
+
+  @Mock
+  private ChatPostPort postPort;
+
+  @Mock
+  private ChatTradePort tradePort;
+
+  @Test
+  @DisplayName("채팅방 생성 - 성공 테스트")
+  void 채팅방을_생성할_수_있다() {
+    // given
+    CreateChatRoomCommand command = DEFAULT_CREATE_CHAT_ROOM_COMMAND(OTHER_MEMBER_ID); // 게시글 작성자는 기본 MEMBER_ID
+    ChatPostResponse post = DEFAULT_CHAT_POST_RESPONSE();
+
+    given(postPort.readChatPostSummary(command.postId())).willReturn(post);
+    given(chatRoomReader.readExistingChatRoom(post.postId(), post.sellerId(), command.buyerId())).willReturn(Optional.empty());
+    given(tradePort.createTrade(post.postId(), post.sellerId(), command.buyerId())).willReturn(1L);
+    given(chatRoomRepository.save(any(ChatRoom.class)))
+        .willAnswer(invocation -> {
+          ChatRoom chatRoom = invocation.getArgument(0);
+          ReflectionTestUtils.setField(chatRoom, "id", 1L);
+          return chatRoom;
+        });
+
+    // when
+    CreateChatRoomResponse response = chatRoomService.createChatRoomProcess(command);
+
+    // then
+    assertThat(response.chatRoomId()).isEqualTo(1L);
+    then(chatRoomMemberService).should().registerChatRoomMembers(
+        CreateChatRoomMembersCommand.of(1L, List.of(post.sellerId(), command.buyerId()))
+    );
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 - 이미 존재하는 채팅방 테스트")
+  void 기존_채팅방이_존재하면_해당_ID를_반환한다() {
+    // given
+    CreateChatRoomCommand command = DEFAULT_CREATE_CHAT_ROOM_COMMAND(OTHER_MEMBER_ID);
+    ChatPostResponse post = DEFAULT_CHAT_POST_RESPONSE();
+    Long existingRoomId = 1L;
+
+    given(postPort.readChatPostSummary(command.postId())).willReturn(post);
+    given(chatRoomReader.readExistingChatRoom(post.postId(), post.sellerId(), command.buyerId())).willReturn(
+        Optional.of(existingRoomId));
+
+    // when
+    CreateChatRoomResponse result = chatRoomService.createChatRoomProcess(command);
+
+    // then
+    assertThat(result.chatRoomId()).isEqualTo(existingRoomId);
+    then(chatRoomMemberService).should(never()).registerChatRoomMembers(any());
+    then(chatRoomRepository).shouldHaveNoInteractions();
+    then(tradePort).shouldHaveNoInteractions();
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 - 실패 테스트 (본인 게시글 채팅방 생성 요청)")
+  void 본인_게시글에는_채팅방을_생성할_수_없다() {
+    // given
+    CreateChatRoomCommand command = DEFAULT_CREATE_CHAT_ROOM_COMMAND(MEMBER_ID);
+    ChatPostResponse post = ChatPostResponse.of(
+        command.postId(),
+        command.buyerId(), // seller == buyer
+        "제목"
+    );
+
+    given(postPort.readChatPostSummary(command.postId())).willReturn(post);
+
+    // when & then
+    assertThatThrownBy(() -> chatRoomService.createChatRoomProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.IS_SAME_CHAT_MEMBER.getMessage());
+
+    then(chatRoomReader).shouldHaveNoInteractions();
+    then(tradePort).shouldHaveNoInteractions();
+    then(chatRoomRepository).shouldHaveNoInteractions();
+    then(chatRoomMemberService).shouldHaveNoInteractions();
+  }
+}

--- a/src/test/unit/java/com/bob/domain/chat/service/reader/ChatRoomReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/chat/service/reader/ChatRoomReaderTest.java
@@ -1,0 +1,48 @@
+package com.bob.domain.chat.service.reader;
+
+import static com.bob.support.fixture.command.CreateChatRoomMembersCommandFixture.CHAT_ROOM_ID;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bob.domain.chat.repository.ChatRoomRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("채팅방 Reader 테스트")
+@ExtendWith(MockitoExtension.class)
+class ChatRoomReaderTest {
+
+  @InjectMocks
+  private ChatRoomReader chatRoomReader;
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Test
+  @DisplayName("채팅방 ID 조회 테스트")
+  void 동일한_게시글_판매자_구매자의_경우_이미_존재하는_채팅방_ID를_반환한다() {
+    // given
+    Long postId = 1L;
+    UUID sellerId = MEMBER_ID;
+    UUID buyerId = OTHER_MEMBER_ID;
+
+    given(chatRoomRepository.findExistingChatRoom(postId, sellerId, buyerId)).willReturn(Optional.of(CHAT_ROOM_ID));
+
+    // when
+    Optional<Long> result = chatRoomReader.readExistingChatRoom(postId, sellerId, buyerId);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(CHAT_ROOM_ID);
+    then(chatRoomRepository).should().findExistingChatRoom(postId, sellerId, buyerId);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/post/adapter/PostAdapterTest.java
+++ b/src/test/unit/java/com/bob/domain/post/adapter/PostAdapterTest.java
@@ -4,12 +4,18 @@ import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.query.PostQueryFixture.defaultReadMemberFavoritePostsQuery;
 import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_FAVORITE_RESPONSE;
 import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POSTS_RESPONSE;
+import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POST_DETAIL_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
+import com.bob.domain.chat.service.dto.response.ChatPostResponse;
 import com.bob.domain.post.service.PostService;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadMemberFavoritePostsQuery;
+import com.bob.domain.post.service.dto.response.PostDetailResponse;
 import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
 import com.bob.domain.post.service.dto.response.PostsResponse;
 import java.util.UUID;
@@ -24,10 +30,10 @@ import org.springframework.data.domain.Pageable;
 
 @DisplayName("게시글 제공자 테스트")
 @ExtendWith(MockitoExtension.class)
-class PostProviderTest {
+class PostAdapterTest {
 
   @InjectMocks
-  private PostAdapter postProvider;
+  private PostAdapter postAdapter;
 
   @Mock
   private PostService postService;
@@ -42,7 +48,7 @@ class PostProviderTest {
     given(postService.readFilteredPostsProcess(ReadFilteredPostsQuery.of(memberId), pageable)).willReturn(DEFAULT_POSTS_RESPONSE());
 
     // when
-    PostsResponse result = postProvider.readMemberPostSummary(memberId, pageable);
+    PostsResponse result = postAdapter.readMemberPostSummary(memberId, pageable);
 
     // then
     assertThat(result.totalCount()).isEqualTo(2);
@@ -59,11 +65,29 @@ class PostProviderTest {
     given(postService.readMemberFavoritePostsProcess(query, pageable)).willReturn(DEFAULT_FAVORITE_RESPONSE());
 
     // when
-    PostFavoritesResponse response = postProvider.readMemberFavoritePostsSummary(memberId, pageable);
+    PostFavoritesResponse response = postAdapter.readMemberFavoritePostsSummary(memberId, pageable);
 
     // then
     assertThat(response.totalCount()).isEqualTo(2);
     assertThat(response.postFavorites().get(0).postTitle()).isEqualTo("객체지향의 사실과 오해");
     assertThat(response.postFavorites().get(1).postTitle()).isEqualTo("오브젝트");
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 시 사용하는 게시글 정보 조회 테스트")
+  void postId로_게시글_요약_정보를_조회할_수_있다() {
+    // given
+    Long postId = 1L;
+    PostDetailResponse expect = DEFAULT_POST_DETAIL_RESPONSE(postId);
+    given(postService.readPostDetailProcess(any())).willReturn(expect);
+
+    // when
+    ChatPostResponse response = postAdapter.readChatPostSummary(postId);
+
+    // then
+    assertThat(response.postId()).isEqualTo(expect.postId());
+    assertThat(response.sellerId()).isEqualTo(expect.sellerId());
+    assertThat(response.title()).isEqualTo(expect.book().title());
+    then(postService).should(times(1)).readPostDetailProcess(any());
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/adapter/PostProviderTest.java
+++ b/src/test/unit/java/com/bob/domain/post/adapter/PostProviderTest.java
@@ -27,7 +27,7 @@ import org.springframework.data.domain.Pageable;
 class PostProviderTest {
 
   @InjectMocks
-  private PostProvider postProvider;
+  private PostAdapter postProvider;
 
   @Mock
   private PostService postService;

--- a/src/test/unit/java/com/bob/domain/trade/adapter/TradeAdapterTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/adapter/TradeAdapterTest.java
@@ -1,0 +1,44 @@
+package com.bob.domain.trade.adapter;
+
+import static com.bob.support.fixture.command.CreateTradeCommandFixture.DEFAULT_CREATE_TRADE_COMMAND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bob.domain.trade.service.TradeService;
+import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("거래 Adapter 테스트")
+@ExtendWith(MockitoExtension.class)
+class TradeAdapterTest {
+
+  @InjectMocks
+  private TradeAdapter tradeAdapter;
+
+  @Mock
+  private TradeService tradeService;
+
+  @Test
+  @DisplayName("거래 생성 기능 호출 테스트")
+  void 거래가_생성되면_거래_ID가_반환된다() {
+    // given
+    Long expect = 1L;
+    CreateTradeCommand command = DEFAULT_CREATE_TRADE_COMMAND();
+    given(tradeService.createTrade(any(CreateTradeCommand.class))).willReturn(expect);
+
+    // when
+    Long tradeId = tradeAdapter.createTrade(command.postId(), command.sellerId(), command.buyerId());
+
+    // then
+    assertThat(tradeId).isEqualTo(expect);
+    then(tradeService).should(times(1)).createTrade(any(CreateTradeCommand.class));
+  }
+}

--- a/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
@@ -1,0 +1,47 @@
+package com.bob.domain.trade.service;
+
+import static com.bob.support.fixture.command.CreateTradeCommandFixture.DEFAULT_CREATE_TRADE_COMMAND;
+import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_ID_TRADE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("거래 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TradeServiceTest {
+
+  @InjectMocks
+  private TradeService tradeService;
+
+  @Mock
+  private TradeRepository tradeRepository;
+
+  @Test
+  @DisplayName("거래 생성 시 ID가 반환된다")
+  void 거래가_생성되면_거래_ID를_반환한다() {
+    // given
+    CreateTradeCommand command = DEFAULT_CREATE_TRADE_COMMAND();
+    Trade trade = DEFAULT_ID_TRADE(command);
+
+    given(tradeRepository.save(any(Trade.class))).willReturn(trade);
+
+    // when
+    Long tradeId = tradeService.createTrade(command);
+
+    // then
+    assertThat(tradeId).isEqualTo(1L);
+    then(tradeRepository).should(times(1)).save(any(Trade.class));
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/CreateChatRoomCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreateChatRoomCommandFixture.java
@@ -1,0 +1,15 @@
+package com.bob.support.fixture.command;
+
+import com.bob.domain.chat.service.dto.command.CreateChatRoomCommand;
+import java.util.UUID;
+
+public class CreateChatRoomCommandFixture {
+
+  public static CreateChatRoomCommand DEFAULT_CREATE_CHAT_ROOM_COMMAND(UUID memberId) {
+    return new CreateChatRoomCommand(1L, memberId);
+  }
+
+  public static CreateChatRoomCommand of(Long postId, UUID sellerId) {
+    return new CreateChatRoomCommand(postId, sellerId);
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/CreateChatRoomMembersCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreateChatRoomMembersCommandFixture.java
@@ -1,0 +1,16 @@
+package com.bob.support.fixture.command;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
+
+import com.bob.domain.chat.service.dto.command.CreateChatRoomMembersCommand;
+import java.util.List;
+
+public class CreateChatRoomMembersCommandFixture {
+
+  public static final Long CHAT_ROOM_ID = 1L;
+
+  public static CreateChatRoomMembersCommand DEFAULT_CREATE_CHAT_ROOM_MEMBERS_COMMAND() {
+    return CreateChatRoomMembersCommand.of(CHAT_ROOM_ID, List.of(MEMBER_ID, OTHER_MEMBER_ID));
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/CreateTradeCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreateTradeCommandFixture.java
@@ -1,0 +1,11 @@
+package com.bob.support.fixture.command;
+
+import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
+import java.util.UUID;
+
+public class CreateTradeCommandFixture {
+
+  public static CreateTradeCommand DEFAULT_CREATE_TRADE_COMMAND() {
+    return new CreateTradeCommand(1L, UUID.randomUUID(), UUID.randomUUID());
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public class MemberFixture {
 
   public static final UUID MEMBER_ID = UUID.randomUUID();
+  public static final UUID OTHER_MEMBER_ID = UUID.randomUUID();
 
   public static Member defaultMember() {
     return Member.builder()

--- a/src/test/unit/java/com/bob/support/fixture/domain/TradeFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/TradeFixture.java
@@ -1,0 +1,20 @@
+package com.bob.support.fixture.domain;
+
+import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.entity.status.TradeStatus;
+import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
+import java.time.LocalDateTime;
+
+public class TradeFixture {
+
+  public static Trade DEFAULT_ID_TRADE(CreateTradeCommand command) {
+    return Trade.builder()
+        .id(1L)
+        .postId(command.postId())
+        .sellerId(command.sellerId())
+        .buyerId(command.buyerId())
+        .tradeStatus(TradeStatus.REQUESTED)
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/request/CreateChatRoomRequestFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/request/CreateChatRoomRequestFixture.java
@@ -1,0 +1,12 @@
+package com.bob.support.fixture.request;
+
+public class CreateChatRoomRequestFixture {
+
+  public static String DEFAULT_CREATE_CHAT_ROOM_REQUEST() {
+    return """
+        {
+          "postId": 1
+        }
+        """;
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/response/ChatPostResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/ChatPostResponseFixture.java
@@ -1,0 +1,16 @@
+package com.bob.support.fixture.response;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
+import com.bob.domain.chat.service.dto.response.ChatPostResponse;
+
+public class ChatPostResponseFixture {
+
+  public static ChatPostResponse DEFAULT_CHAT_POST_RESPONSE() {
+    return ChatPostResponse.of(
+        1L,
+        MEMBER_ID,
+        "객체지향의 사실과 오해"
+    );
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/response/ChatRoomResponse.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/ChatRoomResponse.java
@@ -1,0 +1,12 @@
+package com.bob.support.fixture.response;
+
+import com.bob.domain.chat.service.dto.response.CreateChatRoomResponse;
+
+public class ChatRoomResponse {
+
+  public static final Long DEFAULT_CHATROOM_ID = 1L;
+
+  public static CreateChatRoomResponse DEFAULT_CREATE_CHATROOM_RESPONSE() {
+    return CreateChatRoomResponse.of(DEFAULT_CHATROOM_ID);
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/response/PostResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/PostResponseFixture.java
@@ -1,5 +1,6 @@
 package com.bob.support.fixture.response;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.PostFixture.DEFAULT_MOCK_POSTS;
 
 import com.bob.domain.post.entity.status.BookStatus;
@@ -39,6 +40,7 @@ public class PostResponseFixture {
   public static PostDetailResponse DEFAULT_POST_DETAIL_RESPONSE(Long postId) {
     return PostDetailResponse.builder()
         .postId(postId)
+        .sellerId(MEMBER_ID)
         .sellPrice(10000)
         .bookStatus("BEST")
         .postStatus("거래 대기")

--- a/src/test/unit/java/com/bob/web/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/unit/java/com/bob/web/chat/controller/ChatRoomControllerTest.java
@@ -1,0 +1,61 @@
+package com.bob.web.chat.controller;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.request.CreateChatRoomRequestFixture.DEFAULT_CREATE_CHAT_ROOM_REQUEST;
+import static com.bob.support.fixture.response.ChatRoomResponse.DEFAULT_CREATE_CHATROOM_RESPONSE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bob.domain.chat.service.ChatRoomService;
+import com.bob.domain.chat.service.dto.response.CreateChatRoomResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@DisplayName("채팅방 API 테스트")
+@ExtendWith(MockitoExtension.class)
+class ChatRoomControllerTest {
+
+  @InjectMocks
+  private ChatRoomController chatRoomController;
+
+  @Mock
+  private ChatRoomService chatRoomService;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    mvc = MockMvcBuilders.standaloneSetup(chatRoomController).build();
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 API를 호출할 수 있다")
+  void 채팅방_생성_API를_호출할_수_있다() throws Exception {
+    // given
+    String json = DEFAULT_CREATE_CHAT_ROOM_REQUEST();
+    given(chatRoomService.createChatRoomProcess(any())).willReturn(DEFAULT_CREATE_CHATROOM_RESPONSE());
+
+    // when & then
+    mvc.perform(post("/chatrooms")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)
+            .requestAttr("memberId", MEMBER_ID))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.chatRoomId").value(1L));
+
+    then(chatRoomService).should(times(1)).createChatRoomProcess(any());
+  }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈, Pull Request
> #42, #29

### 📜 작업 내용
- [x] 채팅방 생성 기능 구현
- [x] 거래 생성 기능 구현
- [x] JPA 연관관계 제거

### 📄 참고
이전 PR(#29)에서는 도메인 간 협력이 필요한 일부 서비스 로직에 Port-Adapter 패턴을 도입했지만, 서비스 계층에서의 의존관계만 해결할 뿐 여전히 도메인(Entity) 내부에서는 ManyToOne, OneToOne 등 JPA 연관관계를 통해 다른 도메인과 강하게 결합되어 있었습니다.

이번 PR에서는 JPA 연관관계를 제거하고, 채팅 도메인이 다른 도메인(Post, Trade 등)과 협력하는 과정에서 Port-Adapter 패턴을 일관되게 적용하여 관계의 주체가 되는 경우에도 도메인 객체 간 직접적인 참조 없이 Port를 통해 데이터를 교환하도록 변경하였습니다.

이미 구현되어 있는 회원, 게시글 도메인 간 협력 구조도 리팩토링을 통해 강결합 및 의존관계 문제를 해결할 예정이며, 결과적으로 프로젝트의 목표 중 하나인 객체지향 원칙을 준수할 수 있는 헥사고널 아키텍처 구조를 적용하고자 합니다.

### ⚠️ 종료할 이슈
this closes #42 
