### PR TITLE
fix#54: 게시글 조회 응답 필드, 가격 필터 수정 및 정렬 key 오타 정정

### DIFF
--- a/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
@@ -86,7 +86,8 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
   }
 
   private BooleanExpression priceCondition(SearchPrice price) {
-    return price == null ? null : post.sellPrice.loe(price.getMaxPrice());
+    if (price == null) return null;
+    return post.sellPrice.goe(price.getMinPrice()).and(post.sellPrice.loe(price.getMaxPrice()));
   }
 
   private BooleanExpression tradeStatusCondition(String status) {

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -109,11 +109,10 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
     postRepository.increaseViewCount(query.postId());
     Post post = postReader.readPostById(query.postId());
     PostMemberSummaryResponse memberSummary = memberPort.readPostMemberSummary(post.getSellerId());
-    PostAreaSummaryResponse areaSummary = areaPort.readPostAreaSummary(post.getSellerId());
     PostFileSummaryResponse fileSummary = filePort.readPostFileSummaries(post.getId());
     boolean isOwner = query.memberId() != null && post.getSellerId().equals(query.memberId());
     boolean isFavorite = postFavoriteService.isFavorite(query.memberId(), post.getId());
-    return PostDetailResponse.from(post, memberSummary, areaSummary, fileSummary, isFavorite, isOwner);
+    return PostDetailResponse.from(post, memberSummary, fileSummary, isFavorite, isOwner);
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/post/service/dto/query/condition/SearchPrice.java
+++ b/src/main/java/com/bob/domain/post/service/dto/query/condition/SearchPrice.java
@@ -7,18 +7,18 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SearchPrice {
-  UNDER_5000(5_000),
-  UNDER_10000(10_000),
-  UNDER_20000(20_000),
-  ALL(1_000_000);
+  UNDER_5000(0, 5_000),
+  BETWEEN_5000_AND_10000(5_000, 10_000),
+  BETWEEN_10000_AND_20000(10_000, 20_000),
+  OVER_20000(20_000, Integer.MAX_VALUE);
 
-  private final Integer maxPrice;
+  private final int minPrice;
+  private final int maxPrice;
 
   public static Optional<SearchPrice> fromIndex(Integer index) {
     if (index == null || index < 0 || index >= values().length) {
-      return Optional.of(values()[3]);
+      return Optional.empty();
     }
-
     return Optional.of(values()[index]);
   }
 }

--- a/src/main/java/com/bob/domain/post/service/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/bob/domain/post/service/dto/response/PostDetailResponse.java
@@ -30,7 +30,6 @@ public record PostDetailResponse(
   public static PostDetailResponse from(
       Post post,
       PostMemberSummaryResponse memberSummary,
-      PostAreaSummaryResponse areaSummary,
       PostFileSummaryResponse fileSummary,
       boolean isFavorite,
       boolean isOwner
@@ -47,9 +46,7 @@ public record PostDetailResponse(
         .description(post.getDescription())
         .images(fileSummary.images())
         .writer(WriterInfo.of(
-            post.getSellerId(),
-            memberSummary.nickname(), memberSummary.profileImageUrl(),
-            areaSummary.emdName(), areaSummary.siggName()
+            post.getSellerId(), memberSummary.nickname(), post.getRegistrationAreaId(), memberSummary.profileImageUrl()
         ))
         .scrapCount(post.getScrapCount())
         .viewCount(post.getViewCount())
@@ -83,15 +80,15 @@ public record PostDetailResponse(
   public record WriterInfo(
       UUID memberId,
       String nickname,
-      String activityArea,
+      Integer emdId,
       String profileUrl
   ) {
 
-    public static WriterInfo of(UUID memberId, String nickname, String profileUrl, String emdName, String siggName) {
+    public static WriterInfo of(UUID memberId, String nickname, Integer registrationAreaId, String profileUrl) {
       return WriterInfo.builder()
           .memberId(memberId)
           .nickname(nickname)
-          .activityArea(String.format("%s %s", siggName, emdName))
+          .emdId(registrationAreaId)
           .profileUrl(profileUrl)
           .build();
     }

--- a/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
+++ b/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
@@ -25,7 +25,7 @@ public record ReadFilteredPostsRequest(
         .memberId(memberId)
         .emdId(emdId)
         .categoryId(categoryId)
-        .price(SearchPrice.fromIndex(price).orElse(SearchPrice.ALL))
+        .price(SearchPrice.fromIndex(price).orElse(null))
         .postStatus(postStatus)
         .bookStatus(bookStatus)
         .sortKey(SortKey.from(sortKey).orElse(SortKey.RECENT))

--- a/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
+++ b/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
@@ -15,7 +15,7 @@ public record ReadFilteredPostsRequest(
     Integer price,
     String postStatus,
     String bookStatus,
-    String sortKey
+    String sort
 ) {
 
   public ReadFilteredPostsQuery toQuery() {
@@ -28,7 +28,7 @@ public record ReadFilteredPostsRequest(
         .price(SearchPrice.fromIndex(price).orElse(null))
         .postStatus(postStatus)
         .bookStatus(bookStatus)
-        .sortKey(SortKey.from(sortKey).orElse(SortKey.RECENT))
+        .sortKey(SortKey.from(sort).orElse(SortKey.RECENT))
         .build();
   }
 }

--- a/src/test/intg/java/com/bob/BookBridgeApplicationTest.java
+++ b/src/test/intg/java/com/bob/BookBridgeApplicationTest.java
@@ -1,9 +1,13 @@
 package com.bob;
 
 import com.bob.support.TestContainerSupport;
+import com.bob.support.redis.RedisContainerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
+
+@Import(RedisContainerConfig.class)
 @SpringBootTest
 class BookBridgeApplicationTest extends TestContainerSupport {
 

--- a/src/test/intg/java/com/bob/domain/area/service/AreaServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/area/service/AreaServiceIntgTest.java
@@ -24,7 +24,6 @@ import com.bob.domain.area.service.reader.ActivityAreaReader;
 import com.bob.domain.area.service.reader.EmdAreaReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.support.TestContainerSupport;
-import com.bob.support.redis.RedisContainerConfig;
 import java.time.LocalDate;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -35,11 +34,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("위치 서비스 통합 테스트")
-@Import(RedisContainerConfig.class)
 @Transactional
 @SpringBootTest
 class AreaServiceIntgTest extends TestContainerSupport {

--- a/src/test/intg/java/com/bob/domain/file/service/FileServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/file/service/FileServiceIntgTest.java
@@ -26,7 +26,6 @@ import com.bob.domain.file.service.reader.FileReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.utils.image.ImageUtils;
 import com.bob.support.TestContainerSupport;
-import com.bob.support.redis.RedisContainerConfig;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -34,11 +33,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
-@Import(RedisContainerConfig.class)
 @Transactional
 @SpringBootTest
 class FileServiceIntgTest extends TestContainerSupport {

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -29,18 +29,15 @@ import com.bob.domain.member.service.port.out.MemberRedisPort;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
-import com.bob.support.redis.RedisContainerConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @DisplayName("사용자 서비스 통합 테스트")
-@Import(RedisContainerConfig.class)
 @Transactional
 @SpringBootTest
 class MemberServiceIntgTest extends TestContainerSupport {

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -9,6 +9,7 @@ import static com.bob.support.fixture.command.CreatePostCommandFixture.FILE_NAME
 import static com.bob.support.fixture.command.CreatePostCommandFixture.defaultCreatePostCommand;
 import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
 import static com.bob.support.fixture.query.PostQueryFixture.searchAuthorQuery;
+import static com.bob.support.fixture.query.PostQueryFixture.searchBetween_5000_10000_PriceQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchBookStatusQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchCategoryQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchHighPriceQuery;
@@ -17,7 +18,7 @@ import static com.bob.support.fixture.query.PostQueryFixture.searchNewestQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchOldestQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchTitleQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchTradeStatusQuery;
-import static com.bob.support.fixture.query.PostQueryFixture.searchUnderPriceQuery;
+import static com.bob.support.fixture.query.PostQueryFixture.searchUnder5000PriceQuery;
 import static com.bob.support.fixture.response.PostAreaSummaryResponseFixture.DEFAULT_POST_AREA_SUMMARY;
 import static com.bob.support.fixture.response.PostFileSummaryResponseFixture.DEFAULT_POST_FILE_SUMMARIES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -276,12 +277,23 @@ class PostServiceIntgTest extends TestContainerSupport {
   @Test
   @DisplayName("가격 필터 - 5000원 이하 게시글 조회")
   void 가격이_5000원이하인_게시글만_조회할_수_있다() {
-    ReadFilteredPostsQuery query = searchUnderPriceQuery();
+    ReadFilteredPostsQuery query = searchUnder5000PriceQuery();
     PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::sellPrice)
         .allMatch(price -> price <= 5000);
+  }
+
+  @Test
+  @DisplayName("가격 필터 - 5000원 이상, 10000원 이하 게시글 조회")
+  void 가격이_5000원이상_10000원이하인_게시글만_조회할_수_있다() {
+    ReadFilteredPostsQuery query = searchBetween_5000_10000_PriceQuery();
+    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+
+    assertThat(result.posts())
+        .extracting(PostSummary::sellPrice)
+        .allMatch(price -> price >= 5000 && price <= 10000);
   }
 
   @Test

--- a/src/test/intg/java/com/bob/support/redis/RedisContainerConfig.java
+++ b/src/test/intg/java/com/bob/support/redis/RedisContainerConfig.java
@@ -5,7 +5,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
@@ -33,7 +37,27 @@ public class RedisContainerConfig {
 
   @Bean
   @Primary
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory connectionFactory
+  ) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    return container;
+  }
+
+  @Bean
+  @Primary
   public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
     return new StringRedisTemplate(redisConnectionFactory);
+  }
+
+  @Bean
+  @Primary
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    return template;
   }
 }

--- a/src/test/intg/resources/application-intg.yml
+++ b/src/test/intg/resources/application-intg.yml
@@ -32,3 +32,7 @@ jwt:
   access-token-expire-time: 1
   refresh-token-expire-time: 1
   cookie-name: cname
+
+sse:
+  heartbeat-interval: 10
+  default-timeout: 60000

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -292,7 +292,6 @@ class PostServiceTest {
     ReadPostDetailQuery query = new ReadPostDetailQuery(MEMBER_ID, post.getId());
     given(postReader.readPostById(post.getId())).willReturn(post);
     given(memberPort.readPostMemberSummary(MEMBER_ID)).willReturn(DEFAULT_MEMBER_SUMMARY);
-    given(areaPort.readPostAreaSummary(MEMBER_ID)).willReturn(DEFAULT_POST_AREA_SUMMARY);
     given(filePort.readPostFileSummaries(post.getId())).willReturn(DEFAULT_POST_FILE_SUMMARIES);
     willDoNothing().given(postRepository).increaseViewCount(post.getId());
 
@@ -316,7 +315,6 @@ class PostServiceTest {
     ReadPostDetailQuery query = new ReadPostDetailQuery(otherMemberId, post.getId());
     given(postReader.readPostById(post.getId())).willReturn(post);
     given(memberPort.readPostMemberSummary(MEMBER_ID)).willReturn(DEFAULT_MEMBER_SUMMARY);
-    given(areaPort.readPostAreaSummary(MEMBER_ID)).willReturn(DEFAULT_POST_AREA_SUMMARY);
     given(filePort.readPostFileSummaries(post.getId())).willReturn(DEFAULT_POST_FILE_SUMMARIES);
     willDoNothing().given(postRepository).increaseViewCount(post.getId());
 

--- a/src/test/unit/java/com/bob/support/fixture/query/PostQueryFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/query/PostQueryFixture.java
@@ -42,9 +42,16 @@ public class PostQueryFixture {
         .build();
   }
 
-  public static ReadFilteredPostsQuery searchUnderPriceQuery() {
+  public static ReadFilteredPostsQuery searchUnder5000PriceQuery() {
     return ReadFilteredPostsQuery.builder()
         .price(SearchPrice.UNDER_5000)
+        .sortKey(SortKey.RECENT)
+        .build();
+  }
+
+  public static ReadFilteredPostsQuery searchBetween_5000_10000_PriceQuery() {
+    return ReadFilteredPostsQuery.builder()
+        .price(SearchPrice.BETWEEN_5000_AND_10000)
         .sortKey(SortKey.RECENT)
         .build();
   }

--- a/src/test/unit/java/com/bob/support/fixture/response/PostResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/PostResponseFixture.java
@@ -54,7 +54,7 @@ public class PostResponseFixture {
         .writer(WriterInfo.builder()
             .memberId(UUID.fromString("018e0df5-b7ec-7f36-b67f-80f3e4f49895"))
             .nickname("booklover")
-            .activityArea("사하구 하단동")
+            .emdId(309)
             .profileUrl("https://s3.bucket.com/default.jpg")
             .build())
         .scrapCount(2)

--- a/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
+++ b/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
@@ -129,7 +129,7 @@ class PostControllerTest {
             .param("price", "0")
             .param("postStatus", "미거래")
             .param("bookStatus", "최상")
-            .param("sortKey", "RECENT")
+            .param("sort", "RECENT")
             .param("page", "0")
             .param("size", "12")
         )


### PR DESCRIPTION
### #️⃣연관된 이슈
#54 

### 📜 작업 내용
- [x] 게시글 상세 조회 응답 값의 주소지를 지역 id로 변경
- [x] 게시글 목록 조회 가격 필터링 수정 : 기존 price under -> between(price1, price2)
- [x] 게시글 목록 조회 request의 정렬 필드 이름의 오타 수정 : sortKey -> sort
- [x] redis 테스트 컨테이너 누락 설정 값 추가

### ⚠️ 종료할 이슈
this closes #54 
