### PR TITLE
feat#68: 거래 목록 조회 및 상태 변경 기능 구현

### DIFF
--- a/src/main/java/com/bob/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/bob/domain/chat/service/ChatMessageService.java
@@ -41,6 +41,11 @@ public class ChatMessageService {
   }
 
   @Transactional
+  public ChatMessage createSystemChatMessageProcess(CreateChatMessageCommand command) {
+    return chatMessageRepository.save(command.toSystemChatMessage());
+  }
+
+  @Transactional
   public void updateReadStatusProcess(EnterChatRoomCommand command) {
     List<ChatMessage> messages = chatMessageRepository.findUnreadMessages(command.chatRoomId(), command.memberId());
     for (ChatMessage message : messages) {

--- a/src/main/java/com/bob/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/bob/domain/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.bob.domain.chat.service;
 
 import static com.bob.domain.chat.entity.type.ChatMessageType.TEXT;
+import static com.bob.domain.chat.service.dto.command.CreateChatMessageCommand.*;
 import static com.bob.domain.chat.service.dto.command.CreateChatMessageCommand.IS_FAR_MEMBER;
 import static com.bob.domain.chat.service.dto.response.ChatMemberResponse.from;
 import static com.bob.domain.chat.service.dto.response.ChatPostResponse.from;
@@ -12,11 +13,11 @@ import static com.bob.global.utils.stream.StreamUtils.sortByDesc;
 import com.bob.domain.chat.entity.ChatMessage;
 import com.bob.domain.chat.entity.ChatRoom;
 import com.bob.domain.chat.entity.ChatRoomMember;
-import com.bob.domain.chat.repository.ChatMessageRepository;
 import com.bob.domain.chat.repository.ChatRoomRepository;
 import com.bob.domain.chat.service.dto.command.CreateChatMessageCommand;
 import com.bob.domain.chat.service.dto.command.CreateChatRoomCommand;
 import com.bob.domain.chat.service.dto.command.CreateChatRoomMembersCommand;
+import com.bob.domain.chat.service.dto.command.CreateSystemMessageCommand;
 import com.bob.domain.chat.service.dto.command.EnterChatRoomCommand;
 import com.bob.domain.chat.service.dto.command.ExitChatRoomCommand;
 import com.bob.domain.chat.service.dto.command.ReEnterChatRoomCommand;
@@ -68,7 +69,6 @@ public class ChatRoomService implements ChatRoomWriteUseCase, ChatRoomReadUseCas
   private final ChatRoomMemberReader chatRoomMemberReader;
 
   private final ChatMessageService chatMessageService;
-  private final ChatMessageRepository chatMessageRepository;
   private final ChatMessageReader chatMessageReader;
 
   private final ChatPostPort postPort;
@@ -100,8 +100,8 @@ public class ChatRoomService implements ChatRoomWriteUseCase, ChatRoomReadUseCas
         List.of(post.sellerId(), command.buyerId())
     ));
     if (command.isFar()) {
-      chatMessageRepository.save(CreateChatMessageCommand.of(
-          chatRoom.getId(), command.buyerId(), IS_FAR_MEMBER, null).toSystemChatMessage()
+      chatMessageService.createSystemChatMessageProcess(
+          of(chatRoom.getId(), command.buyerId(), IS_FAR_MEMBER, null)
       );
     }
     return CreateChatRoomResponse.of(chatRoom.getId());
@@ -128,6 +128,17 @@ public class ChatRoomService implements ChatRoomWriteUseCase, ChatRoomReadUseCas
         message.getContent(), command.fileNames(), message.getType() != TEXT
     ));
     return ChatMessageSendResponse.of(message.getIsRead());
+  }
+
+  @Transactional
+  public void createChatRoomSystemMessageProcess(CreateSystemMessageCommand command) {
+    Long postId = Long.valueOf(command.refId());
+    Long chatRoomId = chatRoomReader.readExistingChatRoom(postId, command.senderId(), command.partnerId()).get();
+    ChatMessage message = chatMessageService.createSystemChatMessageProcess(of(chatRoomId, command.senderId(), command.body(), null));
+    eventPublisher.publishEvent(NotiEvent.toTradeNotiEvent(
+        "CHAT", chatRoomId.toString(),
+        message.getId().toString(), command.senderId(), command.partnerId(), message.getContent()
+    ));
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatMessageCommand.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatMessageCommand.java
@@ -1,9 +1,9 @@
 package com.bob.domain.chat.service.dto.command;
 
 import static com.bob.domain.chat.entity.type.ChatMessageType.IMAGE;
-import static com.bob.domain.chat.entity.type.ChatMessageType.TEXT;
 import static com.bob.domain.chat.entity.type.ChatMessageType.MIX;
 import static com.bob.domain.chat.entity.type.ChatMessageType.SYSTEM;
+import static com.bob.domain.chat.entity.type.ChatMessageType.TEXT;
 
 import com.bob.domain.chat.entity.ChatMessage;
 import com.bob.domain.chat.entity.type.ChatMessageType;
@@ -20,6 +20,8 @@ public record CreateChatMessageCommand(
 ) {
 
   public static final String IS_FAR_MEMBER = "거리가 먼 사용자와의 채팅입니다.";
+  public static final String CHANGED_TRADE_STATUS_PREFIX = "거래 상태가 ";
+  public static final String CHANGED_TRADE_STATUS_SUFFIX = " 상태로 변경되었습니다.";
 
   public static CreateChatMessageCommand of(Long chatRoomId, UUID memberId, String content, List<String> fileNames) {
     return CreateChatMessageCommand.builder()
@@ -28,6 +30,10 @@ public record CreateChatMessageCommand(
         .content(content)
         .fileNames(fileNames)
         .build();
+  }
+
+  public static String changedTradeStatusMessage(String tradeStatus) {
+    return CHANGED_TRADE_STATUS_PREFIX + tradeStatus + CHANGED_TRADE_STATUS_SUFFIX;
   }
 
   public ChatMessage toChatMessage() {
@@ -43,7 +49,7 @@ public record CreateChatMessageCommand(
     return ChatMessage.builder()
         .chatRoomId(chatRoomId)
         .senderId(memberId)
-        .content(content)
+        .content(changedTradeStatusMessage(content))
         .type(SYSTEM)
         .isRead(true)
         .build();

--- a/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatMessageCommand.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/command/CreateChatMessageCommand.java
@@ -32,8 +32,11 @@ public record CreateChatMessageCommand(
         .build();
   }
 
-  public static String changedTradeStatusMessage(String tradeStatus) {
-    return CHANGED_TRADE_STATUS_PREFIX + tradeStatus + CHANGED_TRADE_STATUS_SUFFIX;
+  public static String convertSystemMessage(String body) {
+    if (body.equals(IS_FAR_MEMBER)) {
+      return body;
+    }
+    return CHANGED_TRADE_STATUS_PREFIX + body + CHANGED_TRADE_STATUS_SUFFIX;
   }
 
   public ChatMessage toChatMessage() {
@@ -49,7 +52,7 @@ public record CreateChatMessageCommand(
     return ChatMessage.builder()
         .chatRoomId(chatRoomId)
         .senderId(memberId)
-        .content(changedTradeStatusMessage(content))
+        .content(convertSystemMessage(content))
         .type(SYSTEM)
         .isRead(true)
         .build();

--- a/src/main/java/com/bob/domain/chat/service/dto/command/CreateSystemMessageCommand.java
+++ b/src/main/java/com/bob/domain/chat/service/dto/command/CreateSystemMessageCommand.java
@@ -1,0 +1,16 @@
+package com.bob.domain.chat.service.dto.command;
+
+import java.util.UUID;
+
+public record CreateSystemMessageCommand(
+    String domain,
+    String refId,
+    UUID senderId,
+    UUID partnerId,
+    String body
+) {
+
+  public static CreateSystemMessageCommand of(String domain, String refId, UUID senderId, UUID partnerId, String body) {
+    return new CreateSystemMessageCommand(domain, refId, senderId, partnerId, body);
+  }
+}

--- a/src/main/java/com/bob/domain/chat/service/event/ChatMessageEventHandler.java
+++ b/src/main/java/com/bob/domain/chat/service/event/ChatMessageEventHandler.java
@@ -1,0 +1,25 @@
+package com.bob.domain.chat.service.event;
+
+import static com.bob.domain.chat.service.dto.command.CreateSystemMessageCommand.of;
+
+import com.bob.domain.chat.service.ChatRoomService;
+import com.bob.domain.chat.service.dto.command.CreateSystemMessageCommand;
+import com.bob.global.event.application.dto.SystemChatMessageEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageEventHandler {
+
+  private final ChatRoomService chatRoomService;
+
+  @EventListener
+  public void handleSystemChatMessageEvent(SystemChatMessageEvent event) {
+    CreateSystemMessageCommand command = of(
+        event.domain(), event.refId(), event.memberId(), event.partnerId(), event.body()
+    );
+    chatRoomService.createChatRoomSystemMessageProcess(command);
+  }
+}

--- a/src/main/java/com/bob/domain/notification/service/NotiService.java
+++ b/src/main/java/com/bob/domain/notification/service/NotiService.java
@@ -35,13 +35,13 @@ public class NotiService {
   }
 
   private boolean isChatNoti(NotificationType type) {
-    return type != CHAT;
+    return type == CHAT;
   }
 
   private void redisPublish(CreateNotiCommand command, NotiMemberResponse sender) {
     redisPort.publish(
         command.receiverId(), command.type().name(), command.refId(), command.childId(), command.body(), command.fileNames(),
-        command.normalize(), sender.memberId(), sender.nickname(), sender.profile()
+        command.isSystem(), command.normalize(), sender.memberId(), sender.nickname(), sender.profile()
     );
   }
 }

--- a/src/main/java/com/bob/domain/notification/service/NotiService.java
+++ b/src/main/java/com/bob/domain/notification/service/NotiService.java
@@ -4,6 +4,7 @@ import static com.bob.domain.notification.entity.NotificationType.CHAT;
 import static com.bob.domain.notification.service.dto.response.NotiMemberResponse.from;
 
 import com.bob.domain.notification.entity.Notification;
+import com.bob.domain.notification.entity.NotificationType;
 import com.bob.domain.notification.repository.NotiRepository;
 import com.bob.domain.notification.service.dto.command.CreateNotiCommand;
 import com.bob.domain.notification.service.dto.response.NotiMemberResponse;
@@ -25,17 +26,19 @@ public class NotiService {
 
   @Transactional
   public void createNotificationProcess(CreateNotiCommand command) {
-    if (command.type() == CHAT) {
-      redisPublish(command);
-      return;
+    NotiMemberResponse sender = from(memberPort.readNotiMemberProfile(command.senderId()));
+    if (!isChatNoti(command.type())) {
+      Notification notification = command.toTradeNotiEntity(sender.nickname());
+      notiRepository.save(notification);
     }
-    Notification notification = command.toEntity();
-    notiRepository.save(notification);
-    redisPublish(command);
+    redisPublish(command, sender);
   }
 
-  private void redisPublish(CreateNotiCommand command) {
-    NotiMemberResponse sender = from(memberPort.readNotiMemberProfile(command.senderId()));
+  private boolean isChatNoti(NotificationType type) {
+    return type != CHAT;
+  }
+
+  private void redisPublish(CreateNotiCommand command, NotiMemberResponse sender) {
     redisPort.publish(
         command.receiverId(), command.type().name(), command.refId(), command.childId(), command.body(), command.fileNames(),
         command.normalize(), sender.memberId(), sender.nickname(), sender.profile()

--- a/src/main/java/com/bob/domain/notification/service/dto/command/CreateNotiCommand.java
+++ b/src/main/java/com/bob/domain/notification/service/dto/command/CreateNotiCommand.java
@@ -34,12 +34,12 @@ public record CreateNotiCommand(
         .build();
   }
 
-  public Notification toEntity() {
+  public Notification toTradeNotiEntity(String sender) {
     return Notification.builder()
         .referenceId(refId)
         .type(type)
         .receiverId(receiverId)
-        .body(body)
+        .body(sender + "님 과의 거래 상태가 '" + body + "'상태로 변경되었습니다.")
         .build();
   }
 }

--- a/src/main/java/com/bob/domain/notification/service/dto/command/CreateNotiCommand.java
+++ b/src/main/java/com/bob/domain/notification/service/dto/command/CreateNotiCommand.java
@@ -15,12 +15,13 @@ public record CreateNotiCommand(
     UUID receiverId,
     String body,
     List<String> fileNames,
+    boolean isSystem,
     boolean normalize
 ) {
 
   public static CreateNotiCommand of(
       String type, String refId, String childId, UUID senderId, UUID receiverId,
-      String body, List<String> fileNames, boolean normalize
+      String body, List<String> fileNames, boolean isSystem, boolean normalize
   ) {
     return CreateNotiCommand.builder()
         .refId(refId)
@@ -30,6 +31,7 @@ public record CreateNotiCommand(
         .receiverId(receiverId)
         .body(body)
         .fileNames(fileNames)
+        .isSystem(isSystem)
         .normalize(normalize)
         .build();
   }
@@ -39,7 +41,7 @@ public record CreateNotiCommand(
         .referenceId(refId)
         .type(type)
         .receiverId(receiverId)
-        .body(sender + "님 과의 거래 상태가 '" + body + "'상태로 변경되었습니다.")
+        .body(sender + "님과의 거래 상태가 '" + body + "'상태로 변경되었습니다.")
         .build();
   }
 }

--- a/src/main/java/com/bob/domain/notification/service/event/NotiEventHandler.java
+++ b/src/main/java/com/bob/domain/notification/service/event/NotiEventHandler.java
@@ -19,7 +19,7 @@ public class NotiEventHandler {
   public void handleNotiEvent(NotiEvent event) {
     CreateNotiCommand command = CreateNotiCommand.of(
         event.type(), event.refId(), event.childId(),
-        event.senderId(), event.receiverId(), event.body(), event.fileNames(), event.normalize()
+        event.senderId(), event.receiverId(), event.body(), event.fileNames(), event.isSystem(), event.normalize()
     );
     notiService.createNotificationProcess(command);
   }

--- a/src/main/java/com/bob/domain/notification/service/port/NotiRedisPort.java
+++ b/src/main/java/com/bob/domain/notification/service/port/NotiRedisPort.java
@@ -7,6 +7,6 @@ public interface NotiRedisPort {
 
   void publish(
       UUID receiverId, String type, String refId, String childId, String body, List<String> fileNames,
-      boolean normalize, UUID sId, String sNickname, String sProfile
+      boolean isSystem, boolean normalize, UUID sId, String sNickname, String sProfile
   );
 }

--- a/src/main/java/com/bob/domain/post/entity/Post.java
+++ b/src/main/java/com/bob/domain/post/entity/Post.java
@@ -80,4 +80,8 @@ public class Post extends BaseTime {
     Optional.ofNullable(bookStatus).ifPresent(b -> this.bookStatus = BookStatus.from(b));
     Optional.ofNullable(description).ifPresent(d -> this.description = d);
   }
+
+  public void updatePostStatus(PostStatus status) {
+    this.postStatus = status;
+  }
 }

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.bob.domain.post.service;
 
+import static com.bob.domain.post.entity.status.PostStatus.*;
 import static com.bob.domain.post.service.dto.response.PostFileSummaryResponse.from;
 
 import com.bob.domain.book.entity.Book;
@@ -7,8 +8,10 @@ import com.bob.domain.book.service.BookService;
 import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.service.reader.CategoryReader;
 import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.status.PostStatus;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
+import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.command.RemovePostCommand;
@@ -122,6 +125,12 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
     Post post = postReader.readPostById(command.postId());
     verifyPostOwner(command.memberId(), post.getSellerId());
     post.updateOptionalFields(command.sellPrice(), command.bookStatus(), command.description());
+  }
+
+  @Transactional
+  public void changePostStatusProcess(ChangePostStatusCommand command) {
+    Post post = postReader.readPostById(command.postId());
+    post.updatePostStatus(valueOf(command.status()));
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/post/service/dto/command/ChangePostStatusCommand.java
+++ b/src/main/java/com/bob/domain/post/service/dto/command/ChangePostStatusCommand.java
@@ -1,0 +1,8 @@
+package com.bob.domain.post.service.dto.command;
+
+public record ChangePostStatusCommand(
+    Long postId,
+    String status
+) {
+
+}

--- a/src/main/java/com/bob/domain/post/usecase/PostModifyUseCase.java
+++ b/src/main/java/com/bob/domain/post/usecase/PostModifyUseCase.java
@@ -1,7 +1,11 @@
 package com.bob.domain.post.usecase;
 
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
+import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 
 public interface PostModifyUseCase {
+
   void changePostProcess(ChangePostCommand command);
+
+  void changePostStatusProcess(ChangePostStatusCommand command);
 }

--- a/src/main/java/com/bob/domain/trade/entity/Trade.java
+++ b/src/main/java/com/bob/domain/trade/entity/Trade.java
@@ -45,4 +45,9 @@ public class Trade extends BaseTime {
 
   @Column(nullable = false)
   private LocalDateTime updatedAt;
+
+  public void updateTradeStatus(TradeStatus status, LocalDateTime now) {
+    this.tradeStatus = status;
+    this.updatedAt = now;
+  }
 }

--- a/src/main/java/com/bob/domain/trade/entity/status/TradeStatus.java
+++ b/src/main/java/com/bob/domain/trade/entity/status/TradeStatus.java
@@ -1,5 +1,31 @@
 package com.bob.domain.trade.entity.status;
 
+import java.util.Optional;
+
 public enum TradeStatus {
-  REQUESTED, RESERVED, COMPLETED, CANCELED;
+  REQUESTED,
+  RESERVED,
+  COMPLETED,
+  CANCELED;
+
+  public boolean isProcessed() {
+    return this == RESERVED || this == COMPLETED;
+  }
+
+  public String toPostStatusValue() {
+    return switch (this) {
+      case REQUESTED, CANCELED -> "READY";
+      case RESERVED -> "IN_PROGRESS";
+      case COMPLETED -> "COMPLETED";
+    };
+  }
+
+  public String toSystemMessage() {
+    return switch (this) {
+      case REQUESTED -> "대기";
+      case RESERVED -> "예약";
+      case COMPLETED -> "완료";
+      case CANCELED -> "취소";
+    };
+  }
 }

--- a/src/main/java/com/bob/domain/trade/entity/status/TradeStatus.java
+++ b/src/main/java/com/bob/domain/trade/entity/status/TradeStatus.java
@@ -1,10 +1,15 @@
 package com.bob.domain.trade.entity.status;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum TradeStatus {
-  REQUESTED,
-  RESERVED,
-  COMPLETED,
-  CANCELED;
+  REQUESTED("대기"),
+  RESERVED("예약"),
+  COMPLETED("완료"),
+  CANCELED("취소");
+
+  private final String value;
 
   public boolean isProcessed() {
     return this == RESERVED || this == COMPLETED;
@@ -18,12 +23,7 @@ public enum TradeStatus {
     };
   }
 
-  public String toValue() {
-    return switch (this) {
-      case REQUESTED -> "대기";
-      case RESERVED -> "예약";
-      case COMPLETED -> "완료";
-      case CANCELED -> "취소";
-    };
+  public String value() {
+    return value;
   }
 }

--- a/src/main/java/com/bob/domain/trade/entity/status/TradeStatus.java
+++ b/src/main/java/com/bob/domain/trade/entity/status/TradeStatus.java
@@ -1,7 +1,5 @@
 package com.bob.domain.trade.entity.status;
 
-import java.util.Optional;
-
 public enum TradeStatus {
   REQUESTED,
   RESERVED,
@@ -20,7 +18,7 @@ public enum TradeStatus {
     };
   }
 
-  public String toSystemMessage() {
+  public String toValue() {
     return switch (this) {
       case REQUESTED -> "대기";
       case RESERVED -> "예약";

--- a/src/main/java/com/bob/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/bob/domain/trade/repository/TradeRepository.java
@@ -1,8 +1,22 @@
 package com.bob.domain.trade.repository;
 
 import com.bob.domain.trade.entity.Trade;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface TradeRepository extends CrudRepository<Trade, Long> {
 
+  @Query("""
+      SELECT t FROM Trade t
+      WHERE t.postId = :postId
+      ORDER BY
+        CASE t.tradeStatus
+          WHEN com.bob.domain.trade.entity.status.TradeStatus.COMPLETED THEN 0
+          WHEN com.bob.domain.trade.entity.status.TradeStatus.RESERVED THEN 1
+          WHEN com.bob.domain.trade.entity.status.TradeStatus.REQUESTED THEN 2
+          WHEN com.bob.domain.trade.entity.status.TradeStatus.CANCELED THEN 3
+        END
+      """)
+  List<Trade> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -1,6 +1,7 @@
 package com.bob.domain.trade.service;
 
 import static com.bob.domain.trade.entity.status.TradeStatus.CANCELED;
+import static com.bob.domain.trade.entity.status.TradeStatus.REQUESTED;
 import static com.bob.domain.trade.entity.status.TradeStatus.valueOf;
 import static com.bob.domain.trade.service.dto.response.TradesResponse.of;
 import static com.bob.global.exception.response.ApplicationError.TRADE_ACCESS_DENIED;
@@ -25,6 +26,7 @@ import com.bob.domain.trade.usecase.TradeModifyUseCase;
 import com.bob.domain.trade.usecase.TradeReadUseCase;
 import com.bob.domain.trade.usecase.TradeWriteUseCase;
 import com.bob.global.event.application.dto.NotiEvent;
+import com.bob.global.event.application.dto.SystemChatMessageEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -83,16 +85,22 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeM
     TradeStatus status = valueOf(command.status());
     trade.updateTradeStatus(status, now());
     postPort.changePostStatus(trade.getPostId(), status.toPostStatusValue());
-    sendTradeNotification(trade.getPostId(), status.toValue(), trade.getSellerId(), trade.getBuyerId());
+    sendTradeNotification(trade.getPostId(), status.value(), trade.getSellerId(), trade.getBuyerId());
+    publishSystemMessageEvent(trade.getPostId(), command.memberId(), command.buyerId(), status.value());
   }
 
-  private void sendTradeNotification(Long postId, String body, UUID sellerId, UUID buyerId) {
-    NotiEvent event = NotiEvent.toTradeNotiEvent("TRADE", String.valueOf(postId), sellerId, buyerId, body);
+  private void sendTradeNotification(Long postId, String body, UUID memberId, UUID buyerId) {
+    NotiEvent event = NotiEvent.toTradeNotiEvent("TRADE", String.valueOf(postId), null, memberId, buyerId, body);
+    eventPublisher.publishEvent(event);
+  }
+
+  private void publishSystemMessageEvent(Long postId, UUID memberId, UUID buyerId, String body) {
+    SystemChatMessageEvent event = SystemChatMessageEvent.of("TRADE", postId.toString(), memberId, buyerId, body);
     eventPublisher.publishEvent(event);
   }
 
   private void verifyRequestedOnly(Long postId, String status) {
-    if (valueOf(status) == CANCELED) {
+    if (valueOf(status) == CANCELED || valueOf(status) == REQUESTED) {
       return;
     }
     tradeReader.readTradesByPostId(postId).stream()

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -82,6 +82,7 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeM
     verifyTradeOwner(postPort.readTradePostOwnerId(trade.getPostId()), command.memberId());
     TradeStatus status = valueOf(command.status());
     trade.updateTradeStatus(status, now());
+    postPort.changePostStatus(trade.getPostId(), status.toPostStatusValue());
   }
 
   private void verifyRequestedOnly(Long postId, String status) {

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -24,7 +24,7 @@ import com.bob.domain.trade.service.reader.TradeReader;
 import com.bob.domain.trade.usecase.TradeModifyUseCase;
 import com.bob.domain.trade.usecase.TradeReadUseCase;
 import com.bob.domain.trade.usecase.TradeWriteUseCase;
-import com.bob.global.event.application.dto.SystemChatMessageEvent;
+import com.bob.global.event.application.dto.NotiEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -83,10 +83,18 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeM
     TradeStatus status = valueOf(command.status());
     trade.updateTradeStatus(status, now());
     postPort.changePostStatus(trade.getPostId(), status.toPostStatusValue());
+    sendTradeNotification(trade.getPostId(), status.toValue(), trade.getSellerId(), trade.getBuyerId());
+  }
+
+  private void sendTradeNotification(Long postId, String body, UUID sellerId, UUID buyerId) {
+    NotiEvent event = NotiEvent.toTradeNotiEvent("TRADE", String.valueOf(postId), sellerId, buyerId, body);
+    eventPublisher.publishEvent(event);
   }
 
   private void verifyRequestedOnly(Long postId, String status) {
-    if (valueOf(status) == CANCELED) return;
+    if (valueOf(status) == CANCELED) {
+      return;
+    }
     tradeReader.readTradesByPostId(postId).stream()
         .filter(t -> t.getTradeStatus().isProcessed())
         .findAny()

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -1,9 +1,16 @@
 package com.bob.domain.trade.service;
 
+import static com.bob.domain.trade.entity.status.TradeStatus.CANCELED;
+import static com.bob.domain.trade.entity.status.TradeStatus.valueOf;
 import static com.bob.domain.trade.service.dto.response.TradesResponse.of;
+import static com.bob.global.exception.response.ApplicationError.TRADE_ACCESS_DENIED;
+import static com.bob.global.exception.response.ApplicationError.TRADE_ALREADY_PROCESSED;
+import static java.time.LocalDateTime.now;
 
 import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.entity.status.TradeStatus;
 import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
@@ -14,24 +21,28 @@ import com.bob.domain.trade.service.dto.response.internal.TradeSummary;
 import com.bob.domain.trade.service.port.out.TradeMemberPort;
 import com.bob.domain.trade.service.port.out.TradePostPort;
 import com.bob.domain.trade.service.reader.TradeReader;
+import com.bob.domain.trade.usecase.TradeModifyUseCase;
 import com.bob.domain.trade.usecase.TradeReadUseCase;
 import com.bob.domain.trade.usecase.TradeWriteUseCase;
+import com.bob.global.event.application.dto.SystemChatMessageEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
-import com.bob.global.exception.response.ApplicationError;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-public class TradeService implements TradeWriteUseCase, TradeReadUseCase {
+public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeModifyUseCase {
 
   private final TradeRepository tradeRepository;
   private final TradeReader tradeReader;
 
   private final TradeMemberPort memberPort;
   private final TradePostPort postPort;
+
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public Long createTradeProcess(CreateTradeCommand command) {
@@ -48,12 +59,6 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase {
     ).toList());
   }
 
-  private void verifyTradeOwner(UUID ownerId, UUID memberId) {
-    if (!ownerId.equals(memberId)) {
-      throw new ApplicationException(ApplicationError.TRADE_ACCESS_DENIED);
-    }
-  }
-
   @Transactional(readOnly = true)
   public TradeDetailResponse readTradeDetailProcess(ReadTradeDetailQuery query) {
     Trade trade = tradeReader.readTradeById(query.tradeId());
@@ -66,7 +71,32 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase {
     UUID buyerId = trade.getBuyerId();
 
     if (!memberId.equals(sellerId) && !memberId.equals(buyerId)) {
-      throw new ApplicationException(ApplicationError.TRADE_ACCESS_DENIED);
+      throw new ApplicationException(TRADE_ACCESS_DENIED);
+    }
+  }
+
+  @Transactional
+  public void changeTradeStatusProcess(ChangeTradeStatusCommand command) {
+    Trade trade = tradeReader.readTradeById(command.tradeId());
+    verifyRequestedOnly(trade.getPostId(), command.status());
+    verifyTradeOwner(postPort.readTradePostOwnerId(trade.getPostId()), command.memberId());
+    TradeStatus status = valueOf(command.status());
+    trade.updateTradeStatus(status, now());
+  }
+
+  private void verifyRequestedOnly(Long postId, String status) {
+    if (valueOf(status) == CANCELED) return;
+    tradeReader.readTradesByPostId(postId).stream()
+        .filter(t -> t.getTradeStatus().isProcessed())
+        .findAny()
+        .ifPresent(t -> {
+          throw new ApplicationException(TRADE_ALREADY_PROCESSED);
+        });
+  }
+
+  private void verifyTradeOwner(UUID ownerId, UUID memberId) {
+    if (!ownerId.equals(memberId)) {
+      throw new ApplicationException(TRADE_ACCESS_DENIED);
     }
   }
 }

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -1,10 +1,18 @@
 package com.bob.domain.trade.service;
 
+import static com.bob.domain.trade.service.dto.response.TradesResponse.of;
+
 import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.repository.TradeRepository;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradesResponse;
+import com.bob.domain.trade.service.dto.response.internal.TradeMemberSummary;
+import com.bob.domain.trade.service.dto.response.internal.TradeSummary;
+import com.bob.domain.trade.service.port.out.TradeMemberPort;
+import com.bob.domain.trade.service.port.out.TradePostPort;
 import com.bob.domain.trade.service.reader.TradeReader;
 import com.bob.domain.trade.usecase.TradeReadUseCase;
 import com.bob.domain.trade.usecase.TradeWriteUseCase;
@@ -22,10 +30,28 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase {
   private final TradeRepository tradeRepository;
   private final TradeReader tradeReader;
 
+  private final TradeMemberPort memberPort;
+  private final TradePostPort postPort;
+
   @Transactional
   public Long createTradeProcess(CreateTradeCommand command) {
     Trade trade = tradeRepository.save(command.toTrade());
     return trade.getId();
+  }
+
+  @Transactional(readOnly = true)
+  public TradesResponse readTradesProcess(ReadTradesQuery query) {
+    UUID ownerId = postPort.readTradePostOwnerId(query.postId());
+    verifyTradeOwner(ownerId, query.memberId());
+    return of(tradeReader.readTradesByPostId(query.postId()).stream().map(trade -> TradeSummary
+        .from(trade, TradeMemberSummary.from(memberPort.readTradeMemberProfile(trade.getBuyerId())))
+    ).toList());
+  }
+
+  private void verifyTradeOwner(UUID ownerId, UUID memberId) {
+    if (!ownerId.equals(memberId)) {
+      throw new ApplicationException(ApplicationError.TRADE_ACCESS_DENIED);
+    }
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bob/domain/trade/service/dto/command/ChangeTradeStatusCommand.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/command/ChangeTradeStatusCommand.java
@@ -1,0 +1,13 @@
+package com.bob.domain.trade.service.dto.command;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ChangeTradeStatusCommand(
+    UUID memberId,
+    Long tradeId,
+    String status
+) {
+
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/command/ChangeTradeStatusCommand.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/command/ChangeTradeStatusCommand.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 public record ChangeTradeStatusCommand(
     UUID memberId,
     Long tradeId,
+    UUID buyerId,
     String status
 ) {
 

--- a/src/main/java/com/bob/domain/trade/service/dto/query/ReadTradesQuery.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/query/ReadTradesQuery.java
@@ -1,0 +1,10 @@
+package com.bob.domain.trade.service.dto.query;
+
+import java.util.UUID;
+
+public record ReadTradesQuery(
+    Long postId,
+    UUID memberId
+) {
+
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/response/TradesResponse.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/TradesResponse.java
@@ -1,0 +1,13 @@
+package com.bob.domain.trade.service.dto.response;
+
+import com.bob.domain.trade.service.dto.response.internal.TradeSummary;
+import java.util.List;
+
+public record TradesResponse(
+    List<TradeSummary> trades
+) {
+
+  public static TradesResponse of(List<TradeSummary> trades) {
+    return new TradesResponse(trades);
+  }
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeMemberSummary.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeMemberSummary.java
@@ -1,16 +1,19 @@
 package com.bob.domain.trade.service.dto.response.internal;
 
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record TradeMemberSummary(
+    UUID id,
     String nickname,
     String profile
 ) {
 
   public static TradeMemberSummary from(MemberProfileResponse response) {
     return TradeMemberSummary.builder()
+        .id(response.memberId())
         .nickname(response.nickname())
         .profile(response.profileImageUrl())
         .build();

--- a/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeMemberSummary.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeMemberSummary.java
@@ -1,0 +1,18 @@
+package com.bob.domain.trade.service.dto.response.internal;
+
+import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import lombok.Builder;
+
+@Builder
+public record TradeMemberSummary(
+    String nickname,
+    String profile
+) {
+
+  public static TradeMemberSummary from(MemberProfileResponse response) {
+    return TradeMemberSummary.builder()
+        .nickname(response.nickname())
+        .profile(response.profileImageUrl())
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeSummary.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeSummary.java
@@ -1,0 +1,29 @@
+package com.bob.domain.trade.service.dto.response.internal;
+
+import com.bob.domain.trade.entity.Trade;
+import lombok.Builder;
+
+@Builder
+public record TradeSummary(
+    Long tradeId,
+    String tradeStatus,
+    Buyer buyer
+) {
+
+  public static TradeSummary from(Trade trade, TradeMemberSummary member) {
+    return TradeSummary.builder()
+        .tradeId(trade.getId())
+        .tradeStatus(trade.getTradeStatus().name())
+        .buyer(Buyer.of(member.nickname(), member.profile()))
+        .build();
+  }
+
+  public record Buyer(
+      String nickname,
+      String profile
+  ) {
+    public static Buyer of(String nickname, String profile) {
+      return new Buyer(nickname, profile);
+    }
+  }
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeSummary.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeSummary.java
@@ -1,6 +1,7 @@
 package com.bob.domain.trade.service.dto.response.internal;
 
 import com.bob.domain.trade.entity.Trade;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
@@ -14,16 +15,17 @@ public record TradeSummary(
     return TradeSummary.builder()
         .tradeId(trade.getId())
         .tradeStatus(trade.getTradeStatus().name())
-        .buyer(Buyer.of(member.nickname(), member.profile()))
+        .buyer(Buyer.of(member.id(), member.nickname(), member.profile()))
         .build();
   }
 
   public record Buyer(
+      UUID id,
       String nickname,
       String profile
   ) {
-    public static Buyer of(String nickname, String profile) {
-      return new Buyer(nickname, profile);
+    public static Buyer of(UUID id, String nickname, String profile) {
+      return new Buyer(id, nickname, profile);
     }
   }
 }

--- a/src/main/java/com/bob/domain/trade/service/port/out/TradeMemberPort.java
+++ b/src/main/java/com/bob/domain/trade/service/port/out/TradeMemberPort.java
@@ -1,0 +1,9 @@
+package com.bob.domain.trade.service.port.out;
+
+import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import java.util.UUID;
+
+public interface TradeMemberPort {
+
+  MemberProfileResponse readTradeMemberProfile(UUID memberId);
+}

--- a/src/main/java/com/bob/domain/trade/service/port/out/TradePostPort.java
+++ b/src/main/java/com/bob/domain/trade/service/port/out/TradePostPort.java
@@ -1,0 +1,8 @@
+package com.bob.domain.trade.service.port.out;
+
+import java.util.UUID;
+
+public interface TradePostPort {
+
+  UUID readTradePostOwnerId(Long postId);
+}

--- a/src/main/java/com/bob/domain/trade/service/port/out/TradePostPort.java
+++ b/src/main/java/com/bob/domain/trade/service/port/out/TradePostPort.java
@@ -5,4 +5,6 @@ import java.util.UUID;
 public interface TradePostPort {
 
   UUID readTradePostOwnerId(Long postId);
+
+  void changePostStatus(Long postId, String status);
 }

--- a/src/main/java/com/bob/domain/trade/service/reader/TradeReader.java
+++ b/src/main/java/com/bob/domain/trade/service/reader/TradeReader.java
@@ -16,12 +16,12 @@ public class TradeReader {
 
   private final TradeRepository tradeRepository;
 
-  public List<Trade> readTradesByPostId(Long postId) {
-    return tradeRepository.findAllByPostId(postId);
-  }
-
   public Trade readTradeById(Long id) {
     return tradeRepository.findById(id)
         .orElseThrow(() -> new ApplicationException(ApplicationError.NOT_EXISTS_TRADE));
+  }
+
+  public List<Trade> readTradesByPostId(Long postId) {
+    return tradeRepository.findAllByPostId(postId);
   }
 }

--- a/src/main/java/com/bob/domain/trade/service/reader/TradeReader.java
+++ b/src/main/java/com/bob/domain/trade/service/reader/TradeReader.java
@@ -4,6 +4,7 @@ import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.repository.TradeRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class TradeReader {
 
   private final TradeRepository tradeRepository;
+
+  public List<Trade> readTradesByPostId(Long postId) {
+    return tradeRepository.findAllByPostId(postId);
+  }
 
   public Trade readTradeById(Long id) {
     return tradeRepository.findById(id)

--- a/src/main/java/com/bob/domain/trade/usecase/TradeModifyUseCase.java
+++ b/src/main/java/com/bob/domain/trade/usecase/TradeModifyUseCase.java
@@ -1,0 +1,8 @@
+package com.bob.domain.trade.usecase;
+
+import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
+
+public interface TradeModifyUseCase {
+
+  void changeTradeStatusProcess(ChangeTradeStatusCommand command);
+}

--- a/src/main/java/com/bob/domain/trade/usecase/TradeReadUseCase.java
+++ b/src/main/java/com/bob/domain/trade/usecase/TradeReadUseCase.java
@@ -1,9 +1,13 @@
 package com.bob.domain.trade.usecase;
 
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradesResponse;
 
 public interface TradeReadUseCase {
+
+  TradesResponse readTradesProcess(ReadTradesQuery query);
 
   TradeDetailResponse readTradeDetailProcess(ReadTradeDetailQuery query);
 }

--- a/src/main/java/com/bob/global/event/application/dto/NotiEvent.java
+++ b/src/main/java/com/bob/global/event/application/dto/NotiEvent.java
@@ -28,4 +28,17 @@ public record NotiEvent(
         .normalize(normalize)
         .build();
   }
+
+  public static NotiEvent toTradeNotiEvent(String type, String refId, UUID senderId, UUID receiverId, String body) {
+    return NotiEvent.builder()
+        .type(type)
+        .refId(refId)
+        .childId(null)
+        .senderId(senderId)
+        .receiverId(receiverId)
+        .body(body)
+        .fileNames(null)
+        .normalize(false)
+        .build();
+  }
 }

--- a/src/main/java/com/bob/global/event/application/dto/NotiEvent.java
+++ b/src/main/java/com/bob/global/event/application/dto/NotiEvent.java
@@ -13,6 +13,7 @@ public record NotiEvent(
     UUID receiverId,
     String body,
     List<String> fileNames,
+    boolean isSystem,
     boolean normalize
 ) {
 
@@ -29,15 +30,16 @@ public record NotiEvent(
         .build();
   }
 
-  public static NotiEvent toTradeNotiEvent(String type, String refId, UUID senderId, UUID receiverId, String body) {
+  public static NotiEvent toTradeNotiEvent(String type, String refId, String childId, UUID senderId, UUID receiverId, String body) {
     return NotiEvent.builder()
         .type(type)
         .refId(refId)
-        .childId(null)
+        .childId(childId)
         .senderId(senderId)
         .receiverId(receiverId)
         .body(body)
-        .fileNames(null)
+        .fileNames(List.of())
+        .isSystem(true)
         .normalize(false)
         .build();
   }

--- a/src/main/java/com/bob/global/event/application/dto/SystemChatMessageEvent.java
+++ b/src/main/java/com/bob/global/event/application/dto/SystemChatMessageEvent.java
@@ -1,0 +1,16 @@
+package com.bob.global.event.application.dto;
+
+import java.util.UUID;
+
+public record SystemChatMessageEvent(
+    String domain,
+    String refId,
+    UUID memberId,
+    UUID partnerId,
+    String body
+) {
+
+  public static SystemChatMessageEvent of(String domain, String refId, UUID memberId, UUID partnerId, String body) {
+    return new SystemChatMessageEvent(domain, refId, memberId, partnerId, body);
+  }
+}

--- a/src/main/java/com/bob/global/event/sse/manager/dto/ChatMessageEmitEvent.java
+++ b/src/main/java/com/bob/global/event/sse/manager/dto/ChatMessageEmitEvent.java
@@ -14,11 +14,15 @@ public record ChatMessageEmitEvent(
     LocalDateTime sentAt
 ) {
 
-  public static ChatMessageEmitEvent of(String id, String content, List<String> fileNames, LocalDateTime sentAt) {
-    return new ChatMessageEmitEvent(Long.parseLong(id), resolveMessageType(content, fileNames), content, withSequence(fileNames), sentAt);
+  public static ChatMessageEmitEvent of(boolean isSystem, String id, String content, List<String> fileNames, LocalDateTime sentAt) {
+    return new ChatMessageEmitEvent(Long.parseLong(id), resolveMessageType(isSystem, content, fileNames), content, withSequence(fileNames), sentAt);
   }
 
-  private static String resolveMessageType(String content, List<String> fileNames) {
+  private static String resolveMessageType(boolean isSystem, String content, List<String> fileNames) {
+    if (isSystem) {
+      return "SYSTEM";
+    }
+
     boolean hasMessage = content != null && !content.isBlank();
     boolean hasImage = fileNames != null && !fileNames.isEmpty();
 

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -51,7 +51,8 @@ public enum ApplicationError {
 
   // 거래 예외
   NOT_EXISTS_TRADE("E601", "거래를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
-  TRADE_ACCESS_DENIED("E602", "거래에 접근할 권한이 없습니다.", HttpStatus.BAD_REQUEST)
+  TRADE_ACCESS_DENIED("E602", "거래에 접근할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
+  TRADE_ALREADY_PROCESSED("E603", "다른 회원과 거래가 진행중이거나 완료된 상태입니다.", HttpStatus.CONFLICT),
   ;
 
   private String code;

--- a/src/main/java/com/bob/infra/redis/adapter/in/NotiRedisAdapter.java
+++ b/src/main/java/com/bob/infra/redis/adapter/in/NotiRedisAdapter.java
@@ -17,8 +17,8 @@ public class NotiRedisAdapter implements NotiRedisPort {
   @Override
   public void publish(
       UUID rId, String type, String refId, String childId, String body, List<String> fileNames,
-      boolean normalize, UUID sId, String sNickname, String sProfile
+      boolean isSystem, boolean normalize, UUID sId, String sNickname, String sProfile
   ) {
-    publisher.publish(RedisRecord.of(rId, type, refId, childId, body, fileNames, normalize, sId, sNickname, sProfile));
+    publisher.publish(RedisRecord.of(rId, type, refId, childId, body, fileNames, isSystem,normalize, sId, sNickname, sProfile));
   }
 }

--- a/src/main/java/com/bob/infra/redis/record/RedisRecord.java
+++ b/src/main/java/com/bob/infra/redis/record/RedisRecord.java
@@ -13,6 +13,7 @@ public record RedisRecord(
     String childId,
     String body,
     List<String> fileNames,
+    boolean isSystem,
     boolean normalize,
     Sender sender,
     LocalDateTime sentAt
@@ -20,7 +21,7 @@ public record RedisRecord(
 
   public static RedisRecord of(
       UUID receiverId, String type, String refId, String childId, String body, List<String> fileNames,
-      boolean normalize, UUID senderId, String senderNickname, String senderProfile
+      boolean isSystem, boolean normalize, UUID senderId, String senderNickname, String senderProfile
   ) {
     return RedisRecord.builder()
         .receiverId(receiverId)
@@ -29,6 +30,7 @@ public record RedisRecord(
         .childId(childId)
         .body(body)
         .fileNames(fileNames)
+        .isSystem(isSystem)
         .normalize(normalize)
         .sender(Sender.of(senderId, senderNickname, senderProfile))
         .sentAt(LocalDateTime.now())

--- a/src/main/java/com/bob/infra/redis/subscriber/RedisSubscriber.java
+++ b/src/main/java/com/bob/infra/redis/subscriber/RedisSubscriber.java
@@ -47,15 +47,15 @@ public class RedisSubscriber implements MessageListener {
   }
 
   private void handleChatEvent(RedisRecord record) {
-    if (sendChatMessageNoti(record)) {
+    if (sendChatMessage(record)) {
       return;
     }
     sendChatNoti(record);
   }
 
-  private boolean sendChatMessageNoti(RedisRecord record) {
+  private boolean sendChatMessage(RedisRecord record) {
     ChatEmitterKey chatKey = ChatEmitterKey.of(Long.valueOf(record.refId()), record.receiverId());
-    ChatMessageEmitEvent event = ChatMessageEmitEvent.of(record.childId(), record.body(), record.fileNames(), record.sentAt());
+    ChatMessageEmitEvent event = ChatMessageEmitEvent.of(record.isSystem(), record.childId(), record.body(), record.fileNames(), record.sentAt());
     boolean sent = notify(EmitterType.CHAT, chatKey, CHAT_MESSAGE, event);
     logResult("NOTI_CHAT_MESSAGE", sent, record.refId(), record.receiverId());
     return sent;
@@ -74,7 +74,7 @@ public class RedisSubscriber implements MessageListener {
 
   private void handleTradeEvent(RedisRecord record) {
     NotiEmitterKey notiKey = NotiEmitterKey.of(record.receiverId());
-    String body = record.sender().nickname() + "님 과의 거래 상태가 '" + record.body() + "'상태로 변경되었습니다.";
+    String body = record.sender().nickname() + "님과의 거래 상태가 '" + record.body() + "'상태로 변경되었습니다.";
     NotiEmitEvent event = NotiEmitEvent.of(record.type(), record.refId(), body, null, record.sentAt());
     boolean sent = notify(EmitterType.NOTIFICATION, notiKey, NOTIFICATION, event);
     logResult("NOTI_TRADE", sent, record.refId(), record.receiverId());

--- a/src/main/java/com/bob/infra/redis/subscriber/RedisSubscriber.java
+++ b/src/main/java/com/bob/infra/redis/subscriber/RedisSubscriber.java
@@ -74,7 +74,8 @@ public class RedisSubscriber implements MessageListener {
 
   private void handleTradeEvent(RedisRecord record) {
     NotiEmitterKey notiKey = NotiEmitterKey.of(record.receiverId());
-    NotiEmitEvent event = NotiEmitEvent.of("TRADE", record.refId(), record.body(), null, record.sentAt());
+    String body = record.sender().nickname() + "님 과의 거래 상태가 '" + record.body() + "'상태로 변경되었습니다.";
+    NotiEmitEvent event = NotiEmitEvent.of(record.type(), record.refId(), body, null, record.sentAt());
     boolean sent = notify(EmitterType.NOTIFICATION, notiKey, NOTIFICATION, event);
     logResult("NOTI_TRADE", sent, record.refId(), record.receiverId());
   }

--- a/src/main/java/com/bob/web/member/adapter/in/TradeMemberAdapter.java
+++ b/src/main/java/com/bob/web/member/adapter/in/TradeMemberAdapter.java
@@ -1,0 +1,21 @@
+package com.bob.web.member.adapter.in;
+
+import com.bob.domain.member.service.dto.query.ReadProfileQuery;
+import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import com.bob.domain.member.usecase.MemberReadUseCase;
+import com.bob.domain.trade.service.port.out.TradeMemberPort;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TradeMemberAdapter implements TradeMemberPort {
+
+  private final MemberReadUseCase readUseCase;
+
+  @Override
+  public MemberProfileResponse readTradeMemberProfile(UUID memberId) {
+    return readUseCase.readProfileProcess(ReadProfileQuery.of(memberId));
+  }
+}

--- a/src/main/java/com/bob/web/post/adapter/in/TradePostAdapter.java
+++ b/src/main/java/com/bob/web/post/adapter/in/TradePostAdapter.java
@@ -1,0 +1,22 @@
+package com.bob.web.post.adapter.in;
+
+import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
+import com.bob.domain.post.service.dto.response.PostDetailResponse;
+import com.bob.domain.post.usecase.PostReadUseCase;
+import com.bob.domain.trade.service.port.out.TradePostPort;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class TradePostAdapter implements TradePostPort {
+
+  private final PostReadUseCase readUseCase;
+
+  @Override
+  public UUID readTradePostOwnerId(Long postId) {
+    PostDetailResponse response = readUseCase.readPostDetailProcess(ReadPostDetailQuery.of(null, postId, false));
+    return response.sellerId();
+  }
+}

--- a/src/main/java/com/bob/web/post/adapter/in/TradePostAdapter.java
+++ b/src/main/java/com/bob/web/post/adapter/in/TradePostAdapter.java
@@ -1,7 +1,9 @@
 package com.bob.web.post.adapter.in;
 
+import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
+import com.bob.domain.post.usecase.PostModifyUseCase;
 import com.bob.domain.post.usecase.PostReadUseCase;
 import com.bob.domain.trade.service.port.out.TradePostPort;
 import java.util.UUID;
@@ -13,10 +15,17 @@ import org.springframework.stereotype.Component;
 public class TradePostAdapter implements TradePostPort {
 
   private final PostReadUseCase readUseCase;
+  private final PostModifyUseCase modifyUseCase;
 
   @Override
   public UUID readTradePostOwnerId(Long postId) {
     PostDetailResponse response = readUseCase.readPostDetailProcess(ReadPostDetailQuery.of(null, postId, false));
     return response.sellerId();
+  }
+
+  @Override
+  public void changePostStatus(Long postId, String status) {
+    ChangePostStatusCommand command = new ChangePostStatusCommand(postId, status);
+    modifyUseCase.changePostStatusProcess(command);
   }
 }

--- a/src/main/java/com/bob/web/trade/controller/TradeController.java
+++ b/src/main/java/com/bob/web/trade/controller/TradeController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,7 +40,7 @@ public class TradeController {
   @PatchMapping("/{tradeId}")
   public CommonResponse<ResponseSymbol> handleModifyTradeStatus(
       @PathVariable Long tradeId,
-      @Valid ChangeTradeStatusRequest request,
+      @Valid @RequestBody ChangeTradeStatusRequest request,
       @AuthenticationId UUID memberId
   ) {
     modifyUseCase.changeTradeStatusProcess(request.toCommand(memberId, tradeId));

--- a/src/main/java/com/bob/web/trade/controller/TradeController.java
+++ b/src/main/java/com/bob/web/trade/controller/TradeController.java
@@ -1,0 +1,29 @@
+package com.bob.web.trade.controller;
+
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
+import com.bob.domain.trade.service.dto.response.TradesResponse;
+import com.bob.domain.trade.usecase.TradeReadUseCase;
+import com.bob.web.common.AuthenticationId;
+import com.bob.web.trade.request.ReadFilteredTradesRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/trades")
+public class TradeController {
+
+  private final TradeReadUseCase readUseCase;
+
+  @GetMapping
+  public ResponseEntity<TradesResponse> handleReadTrades(
+      ReadFilteredTradesRequest request,
+      @AuthenticationId UUID memberId
+  ) {
+    return ResponseEntity.ok(readUseCase.readTradesProcess(request.toQuery(memberId)));
+  }
+}

--- a/src/main/java/com/bob/web/trade/controller/TradeController.java
+++ b/src/main/java/com/bob/web/trade/controller/TradeController.java
@@ -1,14 +1,22 @@
 package com.bob.web.trade.controller;
 
-import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
+import static com.bob.web.common.symbol.ResponseSymbol.UPDATED;
+
 import com.bob.domain.trade.service.dto.response.TradesResponse;
+import com.bob.domain.trade.usecase.TradeModifyUseCase;
 import com.bob.domain.trade.usecase.TradeReadUseCase;
 import com.bob.web.common.AuthenticationId;
+import com.bob.web.common.CommonResponse;
+import com.bob.web.common.symbol.ResponseSymbol;
+import com.bob.web.trade.request.ChangeTradeStatusRequest;
 import com.bob.web.trade.request.ReadFilteredTradesRequest;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TradeController {
 
   private final TradeReadUseCase readUseCase;
+  private final TradeModifyUseCase modifyUseCase;
 
   @GetMapping
   public ResponseEntity<TradesResponse> handleReadTrades(
@@ -25,5 +34,15 @@ public class TradeController {
       @AuthenticationId UUID memberId
   ) {
     return ResponseEntity.ok(readUseCase.readTradesProcess(request.toQuery(memberId)));
+  }
+
+  @PatchMapping("/{tradeId}")
+  public CommonResponse<ResponseSymbol> handleModifyTradeStatus(
+      @PathVariable Long tradeId,
+      @Valid ChangeTradeStatusRequest request,
+      @AuthenticationId UUID memberId
+  ) {
+    modifyUseCase.changeTradeStatusProcess(request.toCommand(memberId, tradeId));
+    return new CommonResponse<>(true, UPDATED);
   }
 }

--- a/src/main/java/com/bob/web/trade/request/ChangeTradeStatusRequest.java
+++ b/src/main/java/com/bob/web/trade/request/ChangeTradeStatusRequest.java
@@ -1,0 +1,17 @@
+package com.bob.web.trade.request;
+
+import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
+import java.util.UUID;
+
+public record ChangeTradeStatusRequest(
+    String status
+) {
+
+  public ChangeTradeStatusCommand toCommand(UUID memberId, Long tradeId) {
+    return ChangeTradeStatusCommand.builder()
+        .memberId(memberId)
+        .tradeId(tradeId)
+        .status(status)
+        .build();
+  }
+}

--- a/src/main/java/com/bob/web/trade/request/ChangeTradeStatusRequest.java
+++ b/src/main/java/com/bob/web/trade/request/ChangeTradeStatusRequest.java
@@ -1,9 +1,15 @@
 package com.bob.web.trade.request;
 
 import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record ChangeTradeStatusRequest(
+    @NotNull(message = "구매자 ID는 필수입니다.")
+    UUID buyerId,
+
+    @NotBlank(message = "거래 상태는 필수입니다.")
     String status
 ) {
 
@@ -11,6 +17,7 @@ public record ChangeTradeStatusRequest(
     return ChangeTradeStatusCommand.builder()
         .memberId(memberId)
         .tradeId(tradeId)
+        .buyerId(buyerId)
         .status(status)
         .build();
   }

--- a/src/main/java/com/bob/web/trade/request/ReadFilteredTradesRequest.java
+++ b/src/main/java/com/bob/web/trade/request/ReadFilteredTradesRequest.java
@@ -1,0 +1,14 @@
+package com.bob.web.trade.request;
+
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ReadFilteredTradesRequest(
+    Long postId
+) {
+
+  public ReadTradesQuery toQuery(UUID memberId) {
+    return new ReadTradesQuery(postId, memberId);
+  }
+}

--- a/src/test/intg/java/com/bob/domain/chat/service/ChatRoomServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/chat/service/ChatRoomServiceIntgTest.java
@@ -308,7 +308,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(6);
     Long chatRoomId = chatRoomService.createChatRoomProcess(CreateChatRoomCommandFixture.of(post.getId(), buyer.getId())).chatRoomId();
-    Thread.sleep(100);
+    Thread.sleep(1000);
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, buyer.getId()));
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, seller.getId()));
 

--- a/src/test/intg/java/com/bob/domain/noti/service/NotiServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/noti/service/NotiServiceIntgTest.java
@@ -1,8 +1,10 @@
 package com.bob.domain.noti.service;
 
-import static com.bob.domain.notification.entity.NotificationType.CHAT;
 import static com.bob.domain.notification.entity.NotificationType.TRADE;
+import static com.bob.support.fixture.command.CreateNotiCommandFixture.DEFAULT_TEXT_CHAT_NOTI;
+import static com.bob.support.fixture.command.CreateNotiCommandFixture.DEFAULT_TRADE_NOTI;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -52,18 +54,14 @@ class NotiServiceIntgTest extends TestContainerSupport {
     // given
     Member sender = memberRepository.findById(SENDER_ID).orElseThrow();
     Member receiver = memberRepository.findById(RECEIVER_ID).orElseThrow();
-
-    CreateNotiCommand command = new CreateNotiCommand(
-        CHAT, "1", "1", sender.getId(), receiver.getId(), "안녕", null, false
-    );
+    CreateNotiCommand command = DEFAULT_TEXT_CHAT_NOTI(sender.getId(), receiver.getId());
 
     // when
     notiService.createNotificationProcess(command);
 
     // then
     assertThat(notiRepository.findAll()).isEmpty();
-    verify(redisSubscriber, timeout(2000).times(1))
-        .onMessage(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    verify(redisSubscriber, timeout(2000).times(1)).onMessage(any(), any());
   }
 
   @Test
@@ -72,10 +70,7 @@ class NotiServiceIntgTest extends TestContainerSupport {
     // given
     Member sender = memberRepository.findById(SENDER_ID).orElseThrow();
     Member receiver = memberRepository.findById(RECEIVER_ID).orElseThrow();
-
-    CreateNotiCommand command = new CreateNotiCommand(
-        TRADE, "1", "1", sender.getId(), receiver.getId(), "거래 완료", null, false
-    );
+    CreateNotiCommand command = DEFAULT_TRADE_NOTI(sender.getId(), receiver.getId());
 
     // when
     notiService.createNotificationProcess(command);
@@ -85,7 +80,8 @@ class NotiServiceIntgTest extends TestContainerSupport {
     assertThat(saved.getType()).isEqualTo(TRADE);
     assertThat(saved.getReferenceId()).isEqualTo("1");
     assertThat(saved.getReceiverId()).isEqualTo(RECEIVER_ID);
-    verify(redisSubscriber, timeout(2000).times(1))
-        .onMessage(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    String expectedBody = sender.getNickname() + "님과의 거래 상태가 '" + command.body() + "'상태로 변경되었습니다.";
+    assertThat(saved.getBody()).isEqualTo(expectedBody);
+    verify(redisSubscriber, timeout(2000).times(1)).onMessage(any(), any());
   }
 }

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -32,9 +32,11 @@ import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.repository.CategoryRepository;
 import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.PostFavorite;
+import com.bob.domain.post.entity.status.PostStatus;
 import com.bob.domain.post.repository.PostFavoriteRepository;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
+import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.command.RemovePostCommand;
@@ -428,7 +430,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   }
 
   @Test
-  @DisplayName("게시글 수정 - 성공 케이스")
+  @DisplayName("게시글 수정 - 성공 테스트")
   void 게시글_정보를_성공적으로_수정할_수_있다() {
     // given
     UUID writerId = UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0");
@@ -458,6 +460,22 @@ class PostServiceIntgTest extends TestContainerSupport {
         .isInstanceOf(ApplicationException.class)
         .hasMessageContaining(NOT_POST_OWNER.getMessage());
   }
+
+  @Test
+  @DisplayName("게시글 상태 수정 - 성공 테스트")
+  void 게시글_상태를_성공적으로_수정할_수_있다() {
+    // given
+    Post post = postRepository.findAll().iterator().next();
+    ChangePostStatusCommand command = new ChangePostStatusCommand(post.getId(), "IN_PROGRESS");
+
+    // when
+    postService.changePostStatusProcess(command);
+
+    // then
+    Post updated = postRepository.findById(post.getId()).orElseThrow();
+    assertThat(updated.getPostStatus()).isEqualTo(PostStatus.IN_PROGRESS);
+  }
+
 
   @Test
   @DisplayName("게시글 삭제 - 작성자 본인이 삭제하면 게시글과 좋아요가 모두 삭제된다")

--- a/src/test/intg/java/com/bob/domain/trade/service/TradeServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/trade/service/TradeServiceIntgTest.java
@@ -1,0 +1,143 @@
+package com.bob.domain.trade.service;
+
+import static com.bob.support.fixture.response.MemberProfileResponseFixture.CUSTOM_MEMBER_PROFILE_RESPONSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.bob.domain.trade.entity.Trade;
+import com.bob.domain.trade.entity.status.TradeStatus;
+import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
+import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradesResponse;
+import com.bob.domain.trade.service.port.out.TradeMemberPort;
+import com.bob.domain.trade.service.port.out.TradePostPort;
+import com.bob.domain.trade.service.reader.TradeReader;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import com.bob.support.TestContainerSupport;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("거래 서비스 통합 테스트")
+@Transactional
+@SpringBootTest
+class TradeServiceIntgTest extends TestContainerSupport {
+
+  @Autowired
+  private TradeService tradeService;
+
+  @Autowired
+  private TradeRepository tradeRepository;
+
+  @Autowired
+  private TradeReader tradeReader;
+
+  @MockitoBean
+  private TradeMemberPort memberPort;
+
+  @MockitoBean
+  private TradePostPort postPort;
+
+  private Long postId = 1L;
+  private UUID sellerId = UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0");
+  private UUID buyerId1 = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca1");
+  private UUID buyerId2 = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca2");
+  private UUID buyerId3 = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca3");
+
+  @BeforeEach
+  void setUp() {
+    tradeRepository.save(createTrade(buyerId1, TradeStatus.REQUESTED));
+    tradeRepository.save(createTrade(buyerId2, TradeStatus.RESERVED));
+    tradeRepository.save(createTrade(buyerId3, TradeStatus.REQUESTED));
+  }
+
+  @Test
+  @DisplayName("거래 목록 조회 - 성공 테스트")
+  void 판매자는_거래_목록을_정상_조회할_수_있다() {
+    // given
+    ReadTradesQuery query = new ReadTradesQuery(postId, sellerId);
+
+    given(postPort.readTradePostOwnerId(postId)).willReturn(sellerId);
+    given(memberPort.readTradeMemberProfile(any(UUID.class)))
+        .willAnswer(invocation -> CUSTOM_MEMBER_PROFILE_RESPONSE(invocation.getArgument(0)));
+
+    // when
+    TradesResponse response = tradeService.readTradesProcess(query);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.trades()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("거래 목록 조회 - 실패 테스트 (판매자 X)")
+  void 판매자가_아니면_거래_목록_조회_시_예외가_발생한다() {
+    // given
+    UUID otherUser = UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59");
+    ReadTradesQuery query = new ReadTradesQuery(postId, otherUser);
+
+    given(postPort.readTradePostOwnerId(postId)).willReturn(sellerId);
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.readTradesProcess(query))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.TRADE_ACCESS_DENIED.getMessage());
+  }
+
+  @Test
+  @DisplayName("거래 상세 조회 - 성공 테스트")
+  void 거래_상세조회_시_판매자인_경우_성공한다() {
+    // given
+    Trade trade = tradeRepository.findAllByPostId(1L).get(0);
+    UUID sellerId = trade.getSellerId();
+    Long tradeId = trade.getId();
+
+    ReadTradeDetailQuery query = new ReadTradeDetailQuery(tradeId, sellerId);
+
+    // when
+    TradeDetailResponse response = tradeService.readTradeDetailProcess(query);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.id()).isEqualTo(tradeId);
+    assertThat(response.sellerId()).isEqualTo(sellerId);
+  }
+
+  @Test
+  @DisplayName("거래 상세 조회 - 실패 테스트 (거래 참여자 X)")
+  void 거래_상세조회_비참여자라면_예외발생() {
+    // given
+    Trade trade = tradeRepository.findAllByPostId(1L).get(0);
+    Long tradeId = trade.getId();
+    UUID nonParticipantId = UUID.randomUUID();
+
+    ReadTradeDetailQuery query = new ReadTradeDetailQuery(tradeId, nonParticipantId);
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.readTradeDetailProcess(query))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.TRADE_ACCESS_DENIED.getMessage());
+  }
+
+
+  private Trade createTrade(UUID buyerId, TradeStatus status) {
+    return Trade.builder()
+        .postId(postId)
+        .sellerId(sellerId)
+        .buyerId(buyerId)
+        .tradeStatus(status)
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/intg/java/com/bob/domain/trade/service/TradeServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/trade/service/TradeServiceIntgTest.java
@@ -1,14 +1,21 @@
 package com.bob.domain.trade.service;
 
+import static com.bob.domain.trade.entity.status.TradeStatus.REQUESTED;
+import static com.bob.domain.trade.entity.status.TradeStatus.RESERVED;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.CUSTOM_MEMBER_PROFILE_RESPONSE;
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.bob.domain.chat.entity.ChatRoom;
+import com.bob.domain.chat.repository.ChatRoomRepository;
+import com.bob.domain.chat.service.reader.ChatRoomReader;
 import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.entity.status.TradeStatus;
 import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
@@ -19,8 +26,9 @@ import com.bob.domain.trade.service.reader.TradeReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
-import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,11 +51,21 @@ class TradeServiceIntgTest extends TestContainerSupport {
   @Autowired
   private TradeReader tradeReader;
 
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
+
   @MockitoBean
   private TradeMemberPort memberPort;
 
   @MockitoBean
   private TradePostPort postPort;
+
+  @MockitoBean
+  private ChatRoomReader chatRoomReader;
+
+  private Trade testTrade;
+
+  private ChatRoom chatRoom;
 
   private Long postId = 1L;
   private UUID sellerId = UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0");
@@ -57,9 +75,17 @@ class TradeServiceIntgTest extends TestContainerSupport {
 
   @BeforeEach
   void setUp() {
-    tradeRepository.save(createTrade(buyerId1, TradeStatus.REQUESTED));
-    tradeRepository.save(createTrade(buyerId2, TradeStatus.RESERVED));
-    tradeRepository.save(createTrade(buyerId3, TradeStatus.REQUESTED));
+    testTrade = tradeRepository.save(createTrade(buyerId1, REQUESTED));
+    tradeRepository.save(createTrade(buyerId2, RESERVED));
+    tradeRepository.save(createTrade(buyerId3, REQUESTED));
+    chatRoom = createChatRoom(testTrade);
+    chatRoomRepository.save(chatRoom);
+  }
+
+  @AfterEach
+  void tearDown() {
+    tradeRepository.deleteAll();
+    chatRoomRepository.deleteAll();
   }
 
   @Test
@@ -130,6 +156,53 @@ class TradeServiceIntgTest extends TestContainerSupport {
         .hasMessage(ApplicationError.TRADE_ACCESS_DENIED.getMessage());
   }
 
+  @Test
+  @DisplayName("거래 상태 변경 - 성공 테스트")
+  void 거래_상태를_정상적으로_변경할_수_있다() {
+    // given
+    tradeRepository.findAllByPostId(postId).forEach(t -> t.updateTradeStatus(REQUESTED, now())); // 대기 상태로 변경
+    Trade trade = testTrade;
+    given(postPort.readTradePostOwnerId(trade.getPostId())).willReturn(sellerId);
+    given(chatRoomReader.readExistingChatRoom(postId, sellerId, buyerId1)).willReturn(Optional.of(chatRoom.getId()));
+    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(sellerId, trade.getId(), buyerId1, "RESERVED");
+
+    // when
+    tradeService.changeTradeStatusProcess(command);
+
+    // then
+    Trade updatedTrade = tradeRepository.findById(trade.getId()).orElseThrow();
+    assertThat(updatedTrade.getTradeStatus()).isEqualTo(RESERVED);
+  }
+
+  @Test
+  @DisplayName("거래 상태 변경 - 실패 테스트 (이미 처리된 거래 존재)")
+  void 거래_상태_변경시_이미_처리된_거래가_있으면_예외가_발생한다() {
+    // given
+    Trade trade = tradeRepository.findAllByPostId(postId).get(0);
+    given(postPort.readTradePostOwnerId(trade.getPostId())).willReturn(sellerId);
+    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(sellerId, trade.getId(), buyerId1, "RESERVED");
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.TRADE_ALREADY_PROCESSED.getMessage());
+  }
+
+  @Test
+  @DisplayName("거래 상태 변경 - 실패 테스트 (게시글 소유자 아님)")
+  void 거래_상태_변경시_게시글_소유자가_아니면_예외가_발생한다() {
+    // given
+    tradeRepository.findAllByPostId(postId).forEach(t -> t.updateTradeStatus(REQUESTED, now()));
+    Trade trade = tradeRepository.findAllByPostId(postId).get(0);
+    UUID otherUserId = UUID.fromString("0197365f-8074-7d24-a332-999999999999");
+    given(postPort.readTradePostOwnerId(trade.getPostId())).willReturn(sellerId);
+    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(otherUserId, trade.getId(), buyerId1, "RESERVED");
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.TRADE_ACCESS_DENIED.getMessage());
+  }
 
   private Trade createTrade(UUID buyerId, TradeStatus status) {
     return Trade.builder()
@@ -137,7 +210,15 @@ class TradeServiceIntgTest extends TestContainerSupport {
         .sellerId(sellerId)
         .buyerId(buyerId)
         .tradeStatus(status)
-        .updatedAt(LocalDateTime.now())
+        .updatedAt(now())
+        .build();
+  }
+
+  private ChatRoom createChatRoom(Trade trade) {
+    return ChatRoom.builder()
+        .postId(trade.getPostId())
+        .tradeId(trade.getId())
+        .titleSuffix("test")
         .build();
   }
 }

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -289,9 +289,15 @@ UPDATE emd_areas SET geom = ST_GeomFromText('POLYGON ((37.7410557 127.0741107, 3
 -- ========================
 INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 'postReader@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'PostReader');
 INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-0c5f1dbe9c59'), 'otherReader@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'otherReader');
+INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-ba91-0c5fc1b37ca1'), 'mock1@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'mockMember1');
+INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-ba91-0c5fc1b37ca2'), 'mock2@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'mockMember2');
+INSERT INTO members (id, email, password, nickname) VALUES (UUID_TO_BIN('0197365f-8074-7d24-ba91-0c5fc1b37ca3'), 'mock3@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'mockMember3');
 
 INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 213, CURDATE());
 INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-a332-0c5f1dbe9c59'), 213, CURDATE());
+INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-ba91-0c5fc1b37ca1'), 213, CURDATE());
+INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-ba91-0c5fc1b37ca2'), 213, CURDATE());
+INSERT INTO activity_areas (member_id, emd_area_id, authentication_at) VALUES (UUID_TO_BIN('0197365f-8074-7d24-ba91-0c5fc1b37ca3'), 213, CURDATE());
 
 INSERT INTO books (isbn13, title, author, description, price_standard, cover, pub_date) VALUES
 ('9788994492032', '자바의 정석', '남궁성', '자바 기초 입문서', 15000, 'https://cover/1.png', '2020-01-01'),

--- a/src/test/unit/java/com/bob/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/chat/service/ChatRoomServiceTest.java
@@ -167,15 +167,7 @@ class ChatRoomServiceTest {
     chatRoomService.createChatRoomProcess(command);
 
     // then
-    ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
-    then(chatMessageRepository).should(times(1)).save(captor.capture());
-
-    ChatMessage savedMessage = captor.getValue();
-    assertThat(savedMessage.getChatRoomId()).isEqualTo(1L);
-    assertThat(savedMessage.getSenderId()).isEqualTo(command.buyerId());
-    assertThat(savedMessage.getType()).isEqualTo(SYSTEM);
-    assertThat(savedMessage.getContent()).isEqualTo(IS_FAR_MEMBER);
-    assertThat(savedMessage.getIsRead()).isTrue();
+    then(chatMessageService).should(times(1)).createSystemChatMessageProcess(any());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/domain/chat/service/event/ChatMessageEventHandlerTest.java
+++ b/src/test/unit/java/com/bob/domain/chat/service/event/ChatMessageEventHandlerTest.java
@@ -1,0 +1,50 @@
+package com.bob.domain.chat.service.event;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import com.bob.domain.chat.service.ChatRoomService;
+import com.bob.domain.chat.service.dto.command.CreateSystemMessageCommand;
+import com.bob.global.event.application.dto.SystemChatMessageEvent;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("채팅 메시지 이벤트 핸들러 테스트")
+class ChatMessageEventHandlerTest {
+
+  @InjectMocks
+  private ChatMessageEventHandler chatMessageEventHandler;
+
+  @Mock
+  private ChatRoomService chatRoomService;
+
+  @Test
+  @DisplayName("SystemChatMessageEvent 이벤트 처리 - 성공 테스트")
+  void SystemChatMessageEvent_이벤트를_정상적으로_처리할_수_있다() {
+    // given
+    String domain = "TRADE";
+    String refId = "1";
+    UUID memberId = MEMBER_ID;
+    UUID partnerId = OTHER_MEMBER_ID;
+    String body = "예약";
+    SystemChatMessageEvent event = new SystemChatMessageEvent(domain, refId, memberId, partnerId, body);
+    CreateSystemMessageCommand expectedCommand = CreateSystemMessageCommand.of(
+        domain, refId, memberId, partnerId, body
+    );
+    willDoNothing().given(chatRoomService).createChatRoomSystemMessageProcess(expectedCommand);
+
+    // when
+    chatMessageEventHandler.handleSystemChatMessageEvent(event);
+
+    // then
+    then(chatRoomService).should().createChatRoomSystemMessageProcess(expectedCommand);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/notification/service/NotiServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/notification/service/NotiServiceTest.java
@@ -39,9 +39,11 @@ class NotiServiceTest {
 
   @Test
   @DisplayName("CHAT 알림 - 저장 없이 Redis publish만 수행")
-  void createNotificationProcess_CHAT이면_저장없이_redis발행() {
+  void createNotificationProcess_CHAT이면_DB저장없이_redis만_발행() {
     // given
-    CreateNotiCommand command = CreateNotiCommand.of("CHAT", "1", "1", MEMBER_ID, OTHER_MEMBER_ID, "메시지", null, false);
+    CreateNotiCommand command = CreateNotiCommand.of(
+        "CHAT", "1", "1", MEMBER_ID, OTHER_MEMBER_ID, "메시지", null, false, false
+    );
     given(memberPort.readNotiMemberProfile(MEMBER_ID)).willReturn(DEFAULT_MEMBER_PROFILE_RESPONSE);
 
     // when
@@ -57,6 +59,7 @@ class NotiServiceTest {
         eq("메시지"),
         eq(null),
         eq(false),
+        eq(false),
         eq(MEMBER_ID),
         eq("tester"),
         eq("http://image.url")
@@ -65,9 +68,11 @@ class NotiServiceTest {
 
   @Test
   @DisplayName("TRADE 알림 - 저장 후 Redis publish가 수행된다")
-  void createNotificationProcess_TRADE이면_DB저장_및_redis발행() {
+  void createNotificationProcess_TRADE이면_DB저장_및_redis_발행() {
     // given
-    CreateNotiCommand command = CreateNotiCommand.of("TRADE", "1", "1", MEMBER_ID, OTHER_MEMBER_ID, "거래 완료", null, false);
+    CreateNotiCommand command = CreateNotiCommand.of(
+        "TRADE", "1", "1", MEMBER_ID, OTHER_MEMBER_ID, "완료", null, false, false
+    );
     given(memberPort.readNotiMemberProfile(MEMBER_ID)).willReturn(DEFAULT_MEMBER_PROFILE_RESPONSE);
 
     // when
@@ -80,8 +85,9 @@ class NotiServiceTest {
         eq("TRADE"),
         eq("1"),
         eq("1"),
-        eq("거래 완료"),
+        eq("완료"),
         eq(null),
+        eq(false),
         eq(false),
         eq(MEMBER_ID),
         eq("tester"),

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -34,8 +34,10 @@ import com.bob.domain.book.service.BookService;
 import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.service.reader.CategoryReader;
 import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.status.PostStatus;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
+import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.command.RemovePostCommand;
@@ -359,6 +361,22 @@ class PostServiceTest {
         .isInstanceOf(ApplicationException.class)
         .hasMessage(ApplicationError.NOT_POST_OWNER.getMessage());
 
+    then(postReader).should().readPostById(post.getId());
+  }
+
+  @DisplayName("게시글 상태 수정 - 성공 테스트")
+  @Test
+  void 게시글_상태를_수정할_수_있다() {
+    // given
+    Post post = defaultPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID);
+    ChangePostStatusCommand command = new ChangePostStatusCommand(post.getId(), "IN_PROGRESS");
+    given(postReader.readPostById(post.getId())).willReturn(post);
+
+    // when
+    postService.changePostStatusProcess(command);
+
+    // then
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.IN_PROGRESS);
     then(postReader).should().readPostById(post.getId());
   }
 

--- a/src/test/unit/java/com/bob/domain/trade/entity/TradeTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/entity/TradeTest.java
@@ -1,0 +1,28 @@
+package com.bob.domain.trade.entity;
+
+import static com.bob.domain.trade.entity.status.TradeStatus.RESERVED;
+import static com.bob.support.fixture.domain.TradeFixture.TRADE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("거래 도메인 테스트")
+class TradeTest {
+
+  @Test
+  @DisplayName("거래 상태를 변경 테스트")
+  void 거래_상태를_변경하면_상태와_시간이_갱신된다() {
+    // given
+    Trade trade = TRADE(1L, 1L, RESERVED);
+    LocalDateTime now = LocalDateTime.now();
+
+    // when
+    trade.updateTradeStatus(RESERVED, now);
+
+    // then
+    assertThat(trade.getTradeStatus()).isEqualTo(RESERVED);
+    assertThat(trade.getUpdatedAt()).isEqualTo(now);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/trade/entity/status/TradeStatusTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/entity/status/TradeStatusTest.java
@@ -1,0 +1,61 @@
+package com.bob.domain.trade.entity.status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("거래 상태 Enum 테스트")
+class TradeStatusTest {
+
+  @ParameterizedTest(name = "{0} 상태의 isProcessed 결과는 {1}")
+  @MethodSource("isProcessedSource")
+  @DisplayName("거래 진행 여부 반환 테스트 ")
+  void isProcessed_테스트(TradeStatus status, boolean expected) {
+    assertThat(status.isProcessed()).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> isProcessedSource() {
+    return Stream.of(
+        Arguments.of(TradeStatus.REQUESTED, false),
+        Arguments.of(TradeStatus.RESERVED, true),
+        Arguments.of(TradeStatus.COMPLETED, true),
+        Arguments.of(TradeStatus.CANCELED, false)
+    );
+  }
+
+  @ParameterizedTest(name = "{0} → {1}")
+  @MethodSource("toPostStatusValueSource")
+  @DisplayName("거래 상태 -> 게시글 상태 값 변환 테스트")
+  void toPostStatusValue_테스트(TradeStatus status, String expected) {
+    assertThat(status.toPostStatusValue()).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> toPostStatusValueSource() {
+    return Stream.of(
+        Arguments.of(TradeStatus.REQUESTED, "READY"),
+        Arguments.of(TradeStatus.RESERVED, "IN_PROGRESS"),
+        Arguments.of(TradeStatus.COMPLETED, "COMPLETED"),
+        Arguments.of(TradeStatus.CANCELED, "READY")
+    );
+  }
+
+  @ParameterizedTest(name = "{0} → {1}")
+  @MethodSource("valueMethodSource")
+  @DisplayName("value() 메서드 테스트")
+  void value_메서드_테스트(TradeStatus status, String expected) {
+    assertThat(status.value()).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> valueMethodSource() {
+    return Stream.of(
+        Arguments.of(TradeStatus.REQUESTED, "대기"),
+        Arguments.of(TradeStatus.RESERVED, "예약"),
+        Arguments.of(TradeStatus.COMPLETED, "완료"),
+        Arguments.of(TradeStatus.CANCELED, "취소")
+    );
+  }
+}

--- a/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
@@ -1,7 +1,10 @@
 package com.bob.domain.trade.service;
 
 import static com.bob.support.fixture.command.CreateTradeCommandFixture.DEFAULT_CREATE_TRADE_COMMAND;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_ID_TRADE;
+import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_TRADES;
+import static com.bob.support.fixture.response.MemberProfileResponseFixture.CUSTOM_MEMBER_PROFILE_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -13,9 +16,14 @@ import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.repository.TradeRepository;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradesResponse;
+import com.bob.domain.trade.service.port.out.TradeMemberPort;
+import com.bob.domain.trade.service.port.out.TradePostPort;
 import com.bob.domain.trade.service.reader.TradeReader;
 import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +45,12 @@ class TradeServiceTest {
   @Mock
   private TradeReader tradeReader;
 
+  @Mock
+  private TradeMemberPort memberPort;
+
+  @Mock
+  private TradePostPort postPort;
+
   @Test
   @DisplayName("거래 생성 시 ID가 반환된다")
   void 거래가_생성되면_거래_ID를_반환한다() {
@@ -52,6 +66,49 @@ class TradeServiceTest {
     // then
     assertThat(tradeId).isEqualTo(1L);
     then(tradeRepository).should(times(1)).save(any(Trade.class));
+  }
+
+  @Test
+  @DisplayName("거래 목록 조회 - 성공 테스트")
+  void 게시글_소유자는_거래_목록을_정상_조회할_수_있다() {
+    // given
+    UUID requesterId = MEMBER_ID;
+    Long postId = 1L;
+    ReadTradesQuery query = new ReadTradesQuery(postId, requesterId);
+    given(postPort.readTradePostOwnerId(postId)).willReturn(MEMBER_ID);
+    given(tradeReader.readTradesByPostId(postId)).willReturn(DEFAULT_TRADES());
+    given(memberPort.readTradeMemberProfile(any(UUID.class)))
+        .willAnswer(invocation -> CUSTOM_MEMBER_PROFILE_RESPONSE(invocation.getArgument(0)));
+
+    // when
+    TradesResponse response = tradeService.readTradesProcess(query);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.trades()).hasSize(3);
+    then(postPort).should(times(1)).readTradePostOwnerId(postId);
+    then(tradeReader).should(times(1)).readTradesByPostId(postId);
+    then(memberPort).should(times(3)).readTradeMemberProfile(any(UUID.class));
+  }
+
+  @Test
+  @DisplayName("거래 목록 조회 - 실패 테스트 (게시글 소유자가 아님)")
+  void 게시글_소유자가_아니면_거래_목록_조회_시_예외가_발생한다() {
+    // given
+    UUID postOwnerId = MEMBER_ID;
+    UUID requesterId = UUID.randomUUID();
+    Long postId = 1L;
+    ReadTradesQuery query = new ReadTradesQuery(postId, requesterId);
+    given(postPort.readTradePostOwnerId(postId)).willReturn(postOwnerId);
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.readTradesProcess(query))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.TRADE_ACCESS_DENIED.getMessage());
+
+    then(postPort).should(times(1)).readTradePostOwnerId(postId);
+    then(tradeReader).shouldHaveNoInteractions();
+    then(memberPort).shouldHaveNoInteractions();
   }
 
   @Test
@@ -105,7 +162,7 @@ class TradeServiceTest {
 
     ReadTradeDetailQuery query = new ReadTradeDetailQuery(tradeId, nonParticipantId);
 
-    // expect
+    // when & then
     assertThatThrownBy(() -> tradeService.readTradeDetailProcess(query))
         .isInstanceOf(ApplicationException.class)
         .hasMessageContaining("거래에 접근할 권한이 없습니다");

--- a/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
@@ -1,9 +1,11 @@
 package com.bob.domain.trade.service;
 
+import static com.bob.support.fixture.command.ChangeTradeStatusCommandFixture.DEFAULT_CHANGE_STATUS_COMMAND;
 import static com.bob.support.fixture.command.CreateTradeCommandFixture.DEFAULT_CREATE_TRADE_COMMAND;
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_ID_TRADE;
 import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_TRADES;
+import static com.bob.support.fixture.domain.TradeFixture.REQUESTED_TRADE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.CUSTOM_MEMBER_PROFILE_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -14,6 +16,7 @@ import static org.mockito.Mockito.times;
 
 import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.repository.TradeRepository;
+import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
@@ -24,6 +27,7 @@ import com.bob.domain.trade.service.port.out.TradePostPort;
 import com.bob.domain.trade.service.reader.TradeReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @DisplayName("거래 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +55,9 @@ class TradeServiceTest {
 
   @Mock
   private TradePostPort postPort;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @Test
   @DisplayName("거래 생성 시 ID가 반환된다")
@@ -168,5 +176,63 @@ class TradeServiceTest {
         .hasMessageContaining("거래에 접근할 권한이 없습니다");
 
     then(tradeReader).should(times(1)).readTradeById(tradeId);
+  }
+
+  @DisplayName("거래 상태 변경 - 성공 테스트")
+  @Test
+  void 거래_상태를_정상적으로_변경할_수_있다() {
+    // given
+    ChangeTradeStatusCommand command = DEFAULT_CHANGE_STATUS_COMMAND("RESERVED");
+    Trade requestTrade = REQUESTED_TRADE(1L, 1L);
+    given(tradeReader.readTradeById(command.tradeId())).willReturn(requestTrade);
+    given(postPort.readTradePostOwnerId(requestTrade.getPostId())).willReturn(command.memberId());
+    given(tradeReader.readTradesByPostId(requestTrade.getPostId()))
+        .willReturn(List.of(REQUESTED_TRADE(1L,1L), REQUESTED_TRADE(2L,1L))); // 대기중인 거래만 존재
+
+    // when
+    tradeService.changeTradeStatusProcess(command);
+
+    // then
+    then(tradeReader).should().readTradeById(command.tradeId());
+    then(postPort).should().readTradePostOwnerId(requestTrade.getPostId());
+    then(postPort).should().changePostStatus(requestTrade.getPostId(), "IN_PROGRESS");
+  }
+
+  @DisplayName("거래 상태 변경 - 실패 테스트 (이미 처리된 거래 존재)")
+  @Test
+  void 거래_상태_변경시_이미_처리된_거래가_있으면_예외가_발생한다() {
+    // given
+    ChangeTradeStatusCommand command = DEFAULT_CHANGE_STATUS_COMMAND("RESERVED");
+    Trade requestTrade = REQUESTED_TRADE(1L, 1L);
+
+    given(tradeReader.readTradeById(command.tradeId())).willReturn(requestTrade);
+    given(tradeReader.readTradesByPostId(requestTrade.getPostId())).willReturn(DEFAULT_TRADES()); // 예약된 거래 존재
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessageContaining("다른 회원과 거래가 진행중이거나 완료된 상태입니다.");
+
+    then(tradeReader).should().readTradeById(command.tradeId());
+    then(tradeReader).should().readTradesByPostId(requestTrade.getPostId());
+  }
+
+  @DisplayName("거래 상태 변경 - 실패 테스트 (게시글 소유자 아님)")
+  @Test
+  void 거래_상태_변경시_게시글_소유자가_아니면_예외가_발생한다() {
+    // given
+    ChangeTradeStatusCommand command = DEFAULT_CHANGE_STATUS_COMMAND("RESERVED");
+    Trade requestTrade = REQUESTED_TRADE(1L, 1L);
+
+    given(tradeReader.readTradeById(command.tradeId())).willReturn(requestTrade);
+    given(postPort.readTradePostOwnerId(requestTrade.getPostId())).willReturn(UUID.randomUUID());
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessageContaining("거래에 접근할 권한이 없습니다");
+
+    then(tradeReader).should().readTradeById(command.tradeId());
+    then(postPort).should().readTradePostOwnerId(requestTrade.getPostId());
   }
 }

--- a/src/test/unit/java/com/bob/domain/trade/service/reader/TradeReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/service/reader/TradeReaderTest.java
@@ -2,6 +2,7 @@ package com.bob.domain.trade.service.reader;
 
 import static com.bob.support.fixture.command.CreateTradeCommandFixture.DEFAULT_CREATE_TRADE_COMMAND;
 import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_ID_TRADE;
+import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_TRADES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -12,6 +13,7 @@ import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.repository.TradeRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,5 +63,20 @@ class TradeReaderTest {
         .hasMessage(ApplicationError.NOT_EXISTS_TRADE.getMessage());
 
     verify(tradeRepository, times(1)).findById(tradeId);
+  }
+
+  @Test
+  @DisplayName("거래 목록 조회 (조회 조건: postId) - 성공 테스트")
+  void 게시글ID로_거래_목록을_조회한다() {
+    // given
+    Long postId = 1L;
+    given(tradeRepository.findAllByPostId(postId)).willReturn(DEFAULT_TRADES());
+
+    // when
+    List<Trade> result = tradeReader.readTradesByPostId(postId);
+
+    // then
+    assertThat(result).hasSize(3);
+    verify(tradeRepository, times(1)).findAllByPostId(postId);
   }
 }

--- a/src/test/unit/java/com/bob/infra/redis/adapter/in/NotiRedisAdapterTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/adapter/in/NotiRedisAdapterTest.java
@@ -33,7 +33,7 @@ class NotiRedisAdapterTest {
     // when
     notiRedisAdapter.publish(
         record.receiverId(), record.type(), record.refId(), record.childId(), record.body(), record.fileNames(),
-        record.normalize(), record.sender().id(), record.sender().nickname(), record.sender().profile()
+        record.isSystem(), record.normalize(), record.sender().id(), record.sender().nickname(), record.sender().profile()
     );
 
     // then

--- a/src/test/unit/java/com/bob/infra/redis/publisher/RedisPublisherTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/publisher/RedisPublisherTest.java
@@ -57,7 +57,7 @@ class RedisPublisherTest {
     // given
     String invalidType = "UNKNOWN";
     RedisRecord event = RedisRecord.of(
-        MEMBER_ID, invalidType, "id", "id", "유효하지 않은 메시지 타입",null, false,
+        MEMBER_ID, invalidType, "id", "id", "유효하지 않은 메시지 타입",null, false, false,
         OTHER_MEMBER_ID, "TESTER", "Profile"
     );
 

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeTradeStatusCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeTradeStatusCommandFixture.java
@@ -1,0 +1,13 @@
+package com.bob.support.fixture.command;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
+
+import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
+
+public class ChangeTradeStatusCommandFixture {
+
+  public static ChangeTradeStatusCommand DEFAULT_CHANGE_STATUS_COMMAND(String status) {
+    return new ChangeTradeStatusCommand(MEMBER_ID, 1L, OTHER_MEMBER_ID, status);
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/command/CreateNotiCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/CreateNotiCommandFixture.java
@@ -1,0 +1,37 @@
+package com.bob.support.fixture.command;
+
+import com.bob.domain.notification.entity.NotificationType;
+import com.bob.domain.notification.service.dto.command.CreateNotiCommand;
+import java.util.List;
+import java.util.UUID;
+
+public class CreateNotiCommandFixture {
+
+  public static CreateNotiCommand DEFAULT_TEXT_CHAT_NOTI(UUID senderId, UUID receiverId) {
+    return CreateNotiCommand.builder()
+        .type(NotificationType.CHAT)
+        .refId("1")
+        .childId("1")
+        .senderId(senderId)
+        .receiverId(receiverId)
+        .body("안녕")
+        .fileNames(List.of())
+        .isSystem(false)
+        .normalize(false)
+        .build();
+  }
+
+  public static CreateNotiCommand DEFAULT_TRADE_NOTI(UUID senderId, UUID receiverId) {
+    return CreateNotiCommand.builder()
+        .type(NotificationType.TRADE)
+        .refId("1")
+        .childId("1")
+        .senderId(senderId)
+        .receiverId(receiverId)
+        .body("예약")
+        .fileNames(List.of())
+        .isSystem(true)
+        .normalize(false)
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/domain/TradeFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/TradeFixture.java
@@ -1,9 +1,13 @@
 package com.bob.support.fixture.domain;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
 import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.entity.status.TradeStatus;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 public class TradeFixture {
 
@@ -16,5 +20,36 @@ public class TradeFixture {
         .tradeStatus(TradeStatus.REQUESTED)
         .updatedAt(LocalDateTime.now())
         .build();
+  }
+
+  public static Trade TRADE(Long id, Long postId, TradeStatus status) {
+    return Trade.builder()
+        .id(id)
+        .postId(postId)
+        .sellerId(MEMBER_ID)
+        .buyerId(UUID.randomUUID())
+        .tradeStatus(status)
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
+  public static Trade REQUESTED_TRADE(Long id, Long postId) {
+    return TRADE(id, postId, TradeStatus.REQUESTED);
+  }
+
+  public static Trade RESERVED_TRADE(Long id, Long postId) {
+    return TRADE(id, postId, TradeStatus.RESERVED);
+  }
+
+  public static Trade COMPLETED_TRADE(Long id, Long postId) {
+    return TRADE(id, postId, TradeStatus.COMPLETED);
+  }
+
+  public static Trade CANCELED_TRADE(Long id, Long postId) {
+    return TRADE(id, postId, TradeStatus.CANCELED);
+  }
+
+  public static List<Trade> DEFAULT_TRADES() {
+    return List.of(REQUESTED_TRADE(1L, 1L), REQUESTED_TRADE(2L, 1L), RESERVED_TRADE(3L, 1L));
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/response/MemberProfileResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/MemberProfileResponseFixture.java
@@ -5,6 +5,7 @@ import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
 
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import java.time.LocalDate;
+import java.util.UUID;
 
 public class MemberProfileResponseFixture {
 
@@ -23,4 +24,14 @@ public class MemberProfileResponseFixture {
           .profileImageUrl("http://image.url")
           .area(new MemberProfileResponse.Area(1, true, LocalDate.now()))
           .build();
+
+  public static MemberProfileResponse CUSTOM_MEMBER_PROFILE_RESPONSE(UUID memberId) {
+    return MemberProfileResponse.builder()
+        .memberId(memberId)
+        .nickname("custom")
+        .profileImageUrl("http://image.url")
+        .area(new MemberProfileResponse.Area(1, true, LocalDate.now()))
+        .build();
+  }
+
 }

--- a/src/test/unit/java/com/bob/support/fixture/response/TradesResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/TradesResponseFixture.java
@@ -4,25 +4,26 @@ import com.bob.domain.trade.service.dto.response.TradesResponse;
 import com.bob.domain.trade.service.dto.response.internal.TradeSummary;
 import com.bob.domain.trade.service.dto.response.internal.TradeSummary.Buyer;
 import java.util.List;
+import java.util.UUID;
 
 public class TradesResponseFixture {
 
   public static TradeSummary FIRST_TRADE = TradeSummary.builder()
       .tradeId(1L)
       .tradeStatus("REQUESTED")
-      .buyer(Buyer.of("tester1", "/profile/test.png"))
+      .buyer(Buyer.of(UUID.randomUUID(), "tester1", "/profile/test.png"))
       .build();
 
   public static TradeSummary SECOND_TRADE = TradeSummary.builder()
       .tradeId(2L)
       .tradeStatus("REQUESTED")
-      .buyer(Buyer.of("tester2", "/profile/test.png"))
+      .buyer(Buyer.of(UUID.randomUUID(), "tester2", "/profile/test.png"))
       .build();
 
   public static TradeSummary THIRD_TRADE = TradeSummary.builder()
       .tradeId(3L)
       .tradeStatus("REQUESTED")
-      .buyer(Buyer.of("tester3", "/profile/test.png"))
+      .buyer(Buyer.of(UUID.randomUUID(), "tester3", "/profile/test.png"))
       .build();
 
   public static TradesResponse DEFAULT_TRADES_RESPONSE() {

--- a/src/test/unit/java/com/bob/support/fixture/response/TradesResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/TradesResponseFixture.java
@@ -1,0 +1,31 @@
+package com.bob.support.fixture.response;
+
+import com.bob.domain.trade.service.dto.response.TradesResponse;
+import com.bob.domain.trade.service.dto.response.internal.TradeSummary;
+import com.bob.domain.trade.service.dto.response.internal.TradeSummary.Buyer;
+import java.util.List;
+
+public class TradesResponseFixture {
+
+  public static TradeSummary FIRST_TRADE = TradeSummary.builder()
+      .tradeId(1L)
+      .tradeStatus("REQUESTED")
+      .buyer(Buyer.of("tester1", "/profile/test.png"))
+      .build();
+
+  public static TradeSummary SECOND_TRADE = TradeSummary.builder()
+      .tradeId(2L)
+      .tradeStatus("REQUESTED")
+      .buyer(Buyer.of("tester2", "/profile/test.png"))
+      .build();
+
+  public static TradeSummary THIRD_TRADE = TradeSummary.builder()
+      .tradeId(3L)
+      .tradeStatus("REQUESTED")
+      .buyer(Buyer.of("tester3", "/profile/test.png"))
+      .build();
+
+  public static TradesResponse DEFAULT_TRADES_RESPONSE() {
+    return new TradesResponse(List.of(FIRST_TRADE, SECOND_TRADE, THIRD_TRADE));
+  }
+}

--- a/src/test/unit/java/com/bob/web/member/adapter/in/TradeMemberAdapterTest.java
+++ b/src/test/unit/java/com/bob/web/member/adapter/in/TradeMemberAdapterTest.java
@@ -1,0 +1,44 @@
+package com.bob.web.member.adapter.in;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.response.MemberProfileResponseFixture.DEFAULT_MEMBER_PROFILE_RESPONSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bob.domain.member.service.dto.query.ReadProfileQuery;
+import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import com.bob.domain.member.usecase.MemberReadUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeMemberAdapterTest 테스트")
+class TradeMemberAdapterTest {
+
+  @InjectMocks
+  private TradeMemberAdapter tradeMemberAdapter;
+
+  @Mock
+  private MemberReadUseCase readUseCase;
+
+  @Test
+  @DisplayName("회원 ID를 통한 게시글 작성자 정보 조회 기능 호출 테스트")
+  void 게시글_작성자_정보를_조회한다() {
+    // given
+    ReadProfileQuery query = ReadProfileQuery.of(MEMBER_ID);
+    given(readUseCase.readProfileProcess(query)).willReturn(DEFAULT_MEMBER_PROFILE_RESPONSE);
+
+    // when
+    MemberProfileResponse response = tradeMemberAdapter.readTradeMemberProfile(MEMBER_ID);
+
+    // then
+    assertThat(response.memberId()).isEqualTo(MEMBER_ID);
+    assertThat(response.nickname()).isEqualTo("tester");
+    then(readUseCase).should().readProfileProcess(query);
+  }
+}

--- a/src/test/unit/java/com/bob/web/post/adapter/in/TradePostAdapterTest.java
+++ b/src/test/unit/java/com/bob/web/post/adapter/in/TradePostAdapterTest.java
@@ -1,0 +1,44 @@
+package com.bob.web.post.adapter.in;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POST_DETAIL_RESPONSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
+import com.bob.domain.post.service.dto.response.PostDetailResponse;
+import com.bob.domain.post.usecase.PostReadUseCase;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradePostAdapterTest 테스트")
+class TradePostAdapterTest {
+
+  @InjectMocks
+  private TradePostAdapter tradePostAdapter;
+
+  @Mock
+  private PostReadUseCase readUseCase;
+
+  @Test
+  @DisplayName("게시글 ID를 통한 게시글 작성자 ID 조회 호출 테스트")
+  void 게시글_작성자의_ID를_조회한다() {
+    // given
+    Long postId = 1L;
+    PostDetailResponse expect = DEFAULT_POST_DETAIL_RESPONSE(postId);
+    given(readUseCase.readPostDetailProcess(any(ReadPostDetailQuery.class))).willReturn(expect);
+
+    // when
+    UUID result = tradePostAdapter.readTradePostOwnerId(postId);
+
+    // then
+    assertThat(result).isEqualTo(MEMBER_ID);
+  }
+}

--- a/src/test/unit/java/com/bob/web/post/adapter/in/TradePostAdapterTest.java
+++ b/src/test/unit/java/com/bob/web/post/adapter/in/TradePostAdapterTest.java
@@ -5,9 +5,12 @@ import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POST_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
+import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
+import com.bob.domain.post.usecase.PostModifyUseCase;
 import com.bob.domain.post.usecase.PostReadUseCase;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -27,8 +30,11 @@ class TradePostAdapterTest {
   @Mock
   private PostReadUseCase readUseCase;
 
+  @Mock
+  private PostModifyUseCase modifyUseCase;
+
   @Test
-  @DisplayName("게시글 ID를 통한 게시글 작성자 ID 조회 호출 테스트")
+  @DisplayName("게시글 ID를 통한 게시글 작성자 ID 조회 기능 호출 테스트")
   void 게시글_작성자의_ID를_조회한다() {
     // given
     Long postId = 1L;
@@ -40,5 +46,20 @@ class TradePostAdapterTest {
 
     // then
     assertThat(result).isEqualTo(MEMBER_ID);
+  }
+
+  @Test
+  @DisplayName("게시글 상태 변경 기능 호출 테스트")
+  void 게시글_상태를_변경할_수_있다() {
+    // given
+    Long postId = 1L;
+    String status = "COMPLETED";
+
+    // when
+    tradePostAdapter.changePostStatus(postId, status);
+
+    // then
+    ChangePostStatusCommand expectedCommand = new ChangePostStatusCommand(postId, status);
+    then(modifyUseCase).should().changePostStatusProcess(expectedCommand);
   }
 }

--- a/src/test/unit/java/com/bob/web/trade/controller/TradeControllerTest.java
+++ b/src/test/unit/java/com/bob/web/trade/controller/TradeControllerTest.java
@@ -1,0 +1,46 @@
+package com.bob.web.trade.controller;
+
+import static com.bob.support.fixture.response.TradesResponseFixture.DEFAULT_TRADES_RESPONSE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
+import com.bob.domain.trade.usecase.TradeReadUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("거래 목록 조회 API 테스트")
+@ExtendWith(MockitoExtension.class)
+class TradeControllerTest {
+
+  @InjectMocks
+  private TradeController tradeController;
+
+  @Mock
+  private TradeReadUseCase tradeReadUseCase;
+
+  @Test
+  @DisplayName("거래 목록 조회 API 호출 테스트")
+  void 거래_목록을_조회할_수_있다() throws Exception {
+    // given
+    MockMvc mvc = standaloneSetup(tradeController).build();
+    given(tradeReadUseCase.readTradesProcess(any(ReadTradesQuery.class))).willReturn(DEFAULT_TRADES_RESPONSE());
+
+    // when & then
+    mvc.perform(get("/trades")
+            .param("postId", "1"))
+        .andExpect(status().isOk());
+
+    verify(tradeReadUseCase, times(1)).readTradesProcess(any(ReadTradesQuery.class));
+  }
+}

--- a/src/test/unit/java/com/bob/web/trade/controller/TradeControllerTest.java
+++ b/src/test/unit/java/com/bob/web/trade/controller/TradeControllerTest.java
@@ -1,23 +1,29 @@
 package com.bob.web.trade.controller;
 
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.response.TradesResponseFixture.DEFAULT_TRADES_RESPONSE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
+import com.bob.domain.trade.usecase.TradeModifyUseCase;
 import com.bob.domain.trade.usecase.TradeReadUseCase;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @DisplayName("거래 목록 조회 API 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -29,11 +35,20 @@ class TradeControllerTest {
   @Mock
   private TradeReadUseCase tradeReadUseCase;
 
+  @Mock
+  private TradeModifyUseCase tradeModifyUseCase;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    mvc = MockMvcBuilders.standaloneSetup(tradeController).build();
+  }
+
   @Test
   @DisplayName("거래 목록 조회 API 호출 테스트")
   void 거래_목록을_조회할_수_있다() throws Exception {
     // given
-    MockMvc mvc = standaloneSetup(tradeController).build();
     given(tradeReadUseCase.readTradesProcess(any(ReadTradesQuery.class))).willReturn(DEFAULT_TRADES_RESPONSE());
 
     // when & then
@@ -42,5 +57,30 @@ class TradeControllerTest {
         .andExpect(status().isOk());
 
     verify(tradeReadUseCase, times(1)).readTradesProcess(any(ReadTradesQuery.class));
+  }
+
+  @Test
+  @DisplayName("거래 상태 변경 API 호출 테스트")
+  void 거래_상태를_변경할_수_있다() throws Exception {
+    // given
+    Long tradeId = 1L;
+    String json = """
+        {
+          "buyerId": "00000000-0000-0000-0000-000000000000",
+          "status": "RESERVED"
+        }
+        """;
+
+    // when & then
+    mvc.perform(patch("/trades/{tradeId}", tradeId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)
+            .requestAttr("memberId", MEMBER_ID)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("UPDATED"));
+    // then
+    verify(tradeModifyUseCase, times(1)).changeTradeStatusProcess(any());
   }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #68 

### 📜 작업 내용
- [x] 거래 목록 조회 기능 구현
- [x] 거래 상태 변경 기능 구현
- [x] 거래 상태 변경 시 알림 저장 및 발송
- [x] 거래 상태 변경 시 시스템 메시지 생성 및 메시지 발송
- [x] 단위, 통합 테스트 코드 작성

### 📄 참고
거래 상태 변경이 성공하면 시스템 알림 서버 이벤트, 채팅 메시지 수신 이벤트 발생

### ⚠️ 종료할 이슈
this closes #68 
