### PR TITLE
feat#76: 채팅방을 나간 상대방의 채팅방 자동 재입장 처리

### DIFF
--- a/src/main/java/com/bob/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/bob/domain/chat/service/ChatRoomService.java
@@ -50,6 +50,7 @@ import com.bob.domain.chat.usecase.ChatRoomWriteUseCase;
 import com.bob.global.event.application.dto.NotiEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -115,6 +116,7 @@ public class ChatRoomService implements ChatRoomWriteUseCase, ChatRoomReadUseCas
     UUID partnerId = chatRoomMemberReader.readPartnerIdByRequesterId(command.chatRoomId(), command.memberId());
     ChatRoom chatRoom = chatRoomReader.readChatRoomById(command.chatRoomId());
     enableChatRoomIfDisabled(chatRoom);
+    reEnterChatRoomIfPartnerExited(chatRoom.getId(), partnerId);
     ChatMessage message = chatMessageService.createChatMessageProcess(command, partnerId);
     chatRoom.updateChatRoomLastMessageInfo(message.getContent(), message.getCreatedAt());
     publishChatMessageEvent(command, message, partnerId);
@@ -125,6 +127,12 @@ public class ChatRoomService implements ChatRoomWriteUseCase, ChatRoomReadUseCas
     if (!chatRoom.getEnableStatus()) {
       chatRoom.updateChatRoomStatus(true);
     }
+  }
+
+  private void reEnterChatRoomIfPartnerExited(Long chatRoomId, UUID partnerId) {
+    ChatRoomMember partner = chatRoomMemberReader.readChatRoomMember(chatRoomId, partnerId);
+    if (partner.getExitedAt() == null) return;
+    partner.reEnterChatRoom(LocalDateTime.now());
   }
 
   @Transactional

--- a/src/test/intg/java/com/bob/domain/chat/service/ChatRoomServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/chat/service/ChatRoomServiceIntgTest.java
@@ -3,6 +3,7 @@ package com.bob.domain.chat.service;
 import static com.bob.domain.chat.entity.type.ChatMessageType.SYSTEM;
 import static com.bob.domain.chat.service.dto.command.CreateChatMessageCommand.IS_FAR_MEMBER;
 import static com.bob.support.fixture.command.CreateChatMessageCommandFixture.CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND;
+import static com.bob.support.fixture.command.CreateChatRoomCommandFixture.of;
 import static com.bob.support.fixture.domain.MemberFixture.otherMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,7 +34,6 @@ import com.bob.domain.trade.repository.TradeRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
-import com.bob.support.fixture.command.CreateChatRoomCommandFixture;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -77,7 +77,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).get();
 
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command = of(post.getId(), buyer.getId());
 
     // when
     CreateChatRoomResponse response = chatRoomService.createChatRoomProcess(command);
@@ -126,7 +126,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     // given
     Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).get();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), seller.getId());
+    CreateChatRoomCommand command = of(post.getId(), seller.getId());
 
     // when & then
     assertThatThrownBy(() -> chatRoomService.createChatRoomProcess(command))
@@ -142,7 +142,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).get();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
 
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId()); // 최초 생성
+    CreateChatRoomCommand command = of(post.getId(), buyer.getId()); // 최초 생성
     CreateChatRoomResponse created = chatRoomService.createChatRoomProcess(command);
 
     // when
@@ -162,7 +162,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(5);
     CreateChatRoomResponse chatRoomResponse = chatRoomService.createChatRoomProcess(
-        CreateChatRoomCommandFixture.of(post.getId(), buyer.getId())
+        of(post.getId(), buyer.getId())
     );
     Long chatRoomId = chatRoomResponse.chatRoomId();
     CreateChatMessageCommand command = CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, buyer.getId());
@@ -179,6 +179,27 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     assertThat(saved.getType().name()).isEqualTo("MIX");
   }
 
+  @DisplayName("채팅 메시지 전송 - 성공 테스트 (상대방이 채팅방을 나간 경우)")
+  @Test
+  void 채팅_메시지_전송_시_상대방이_채팅방을_나간_경우_자동으로_채팅방_재입장_처리를_한다() {
+    // given
+    Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).orElseThrow();
+    Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
+    Post post = postRepository.findAllBySellerId(seller.getId()).get(5);
+    CreateChatRoomResponse chatRoomResponse = chatRoomService.createChatRoomProcess(of(post.getId(), buyer.getId()));
+    Long chatRoomId = chatRoomResponse.chatRoomId();
+    ChatRoomMember partner = chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, seller.getId()).get();
+    partner.updateExitedAt(LocalDateTime.now()); // 상대방 채팅방 나가기
+
+    CreateChatMessageCommand command = CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, buyer.getId());
+
+    // when
+    chatRoomService.createChatRoomMessageProcess(command); // 상대방이 채팅방을 나간 경우 채팅방 재입장 처리
+
+    // then
+    assertThat(partner.getExitedAt()).isNull(); // 채팅방 입장 여부는 나간 시각의 null 여부로 판단 (null = 입장 상태)
+  }
+
   @Test
   @DisplayName("채팅 메시지 전송 - 비활성화 된 채팅방 활성화 테스트")
   void 비활성화된_채팅방에_첫_메시지를_보내면_채팅방이_활성화된다() {
@@ -187,7 +208,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(4);
 
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command = of(post.getId(), buyer.getId());
     CreateChatRoomResponse response = chatRoomService.createChatRoomProcess(command);
     Long chatRoomId = response.chatRoomId();
 
@@ -211,9 +232,9 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).get();
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).get();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
-    CreateChatRoomCommand command1 = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command1 = of(post.getId(), buyer.getId());
     CreateChatRoomResponse response1 = chatRoomService.createChatRoomProcess(command1);
-    CreateChatRoomCommand command2 = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command2 = of(post.getId(), buyer.getId());
     chatRoomService.createChatRoomProcess(command2);
 
     ChatRoom enableChatRoom = chatRoomRepository.findById(response1.chatRoomId()).get();
@@ -238,9 +259,9 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).orElseThrow();
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
-    Long chatRoomId1 = chatRoomService.createChatRoomProcess(CreateChatRoomCommandFixture.of(post.getId(), buyer.getId())).chatRoomId();
+    Long chatRoomId1 = chatRoomService.createChatRoomProcess(of(post.getId(), buyer.getId())).chatRoomId();
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId1, seller.getId()));
-    Long chatRoomId2 = chatRoomService.createChatRoomProcess(CreateChatRoomCommandFixture.of(post.getId(), buyer.getId())).chatRoomId();
+    Long chatRoomId2 = chatRoomService.createChatRoomProcess(of(post.getId(), buyer.getId())).chatRoomId();
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId2, seller.getId()));
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId2, seller.getId()));
 
@@ -260,7 +281,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
 
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
 
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command = of(post.getId(), buyer.getId());
     CreateChatRoomResponse created = chatRoomService.createChatRoomProcess(command);
 
     ChatRoom chatRoom = chatRoomRepository.findById(created.chatRoomId()).orElseThrow();
@@ -287,7 +308,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member stranger = memberRepository.save(otherMember()); // 제3자
 
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command = of(post.getId(), buyer.getId());
     CreateChatRoomResponse created = chatRoomService.createChatRoomProcess(command);
 
     ChatRoom chatRoom = chatRoomRepository.findById(created.chatRoomId()).orElseThrow();
@@ -307,7 +328,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).orElseThrow();
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(6);
-    Long chatRoomId = chatRoomService.createChatRoomProcess(CreateChatRoomCommandFixture.of(post.getId(), buyer.getId())).chatRoomId();
+    Long chatRoomId = chatRoomService.createChatRoomProcess(of(post.getId(), buyer.getId())).chatRoomId();
     Thread.sleep(1000);
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, buyer.getId()));
     chatRoomService.createChatRoomMessageProcess(CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, seller.getId()));
@@ -330,7 +351,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member stranger = memberRepository.save(otherMember());
 
     Post post = postRepository.findAllBySellerId(seller.getId()).get(0);
-    Long chatRoomId = chatRoomService.createChatRoomProcess(CreateChatRoomCommandFixture.of(post.getId(), buyer.getId()))
+    Long chatRoomId = chatRoomService.createChatRoomProcess(of(post.getId(), buyer.getId()))
         .chatRoomId();
 
     ChatRoomMember exited = chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, buyer.getId()).orElseThrow();
@@ -349,7 +370,7 @@ class ChatRoomServiceIntgTest extends TestContainerSupport {
     Member seller = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-95c9ebd1f5c0")).orElseThrow();
     Member buyer = memberRepository.findById(UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59")).orElseThrow();
     Post post = postRepository.findAllBySellerId(seller.getId()).get(2);
-    CreateChatRoomCommand command = CreateChatRoomCommandFixture.of(post.getId(), buyer.getId());
+    CreateChatRoomCommand command = of(post.getId(), buyer.getId());
     CreateChatRoomResponse chatRoom = chatRoomService.createChatRoomProcess(command);
     Long chatRoomId = chatRoom.chatRoomId();
     CreateChatMessageCommand messageCommand = CUSTOM_WITH_IMAGE_CREATE_CHAT_MESSAGE_COMMAND(chatRoomId, seller.getId());

--- a/src/test/unit/java/com/bob/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/chat/service/ChatRoomServiceTest.java
@@ -15,11 +15,14 @@ import static com.bob.support.fixture.domain.chat.ChatRoomFixture.DEFAULT_CHAT_R
 import static com.bob.support.fixture.domain.chat.ChatRoomFixture.DISABLE_CHAT_ROOM_1;
 import static com.bob.support.fixture.domain.chat.ChatRoomFixture.customChatRoom;
 import static com.bob.support.fixture.domain.chat.ChatRoomMemberFixture.CHAT_ROOM_MEMBER_1;
+import static com.bob.support.fixture.domain.chat.ChatRoomMemberFixture.CHAT_ROOM_MEMBER_2;
+import static com.bob.support.fixture.domain.chat.ChatRoomMemberFixture.EXITED_CHAT_ROOM_MEMBER;
 import static com.bob.support.fixture.response.ChatFileSummaryResponseFixture.DEFAULT_READ_FILES_RESPONSE;
 import static com.bob.support.fixture.response.ChatPostResponseFixture.DEFAULT_CHAT_POST_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.OTHER_MEMBER_PROFILE_RESPONSE;
 import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POST_DETAIL_RESPONSE;
 import static com.bob.support.fixture.response.TradeDetailResponseFixture.DEFAULT_TRADE_DETAIL;
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -61,7 +64,6 @@ import com.bob.domain.chat.service.reader.ChatRoomReader;
 import com.bob.global.event.application.dto.NotiEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -239,6 +241,7 @@ class ChatRoomServiceTest {
     given(chatRoomReader.readChatRoomById(chatRoomId)).willReturn(DEFAULT_CHAT_ROOM_1());
     given(chatRoomMemberReader.readChatRoomMember(chatRoomId, MEMBER_ID)).willReturn(CHAT_ROOM_MEMBER_1());
     given(chatRoomMemberReader.readPartnerIdByRequesterId(chatRoomId, senderId)).willReturn(receiverId);
+    given(chatRoomMemberReader.readChatRoomMember(chatRoomId, receiverId)).willReturn(CHAT_ROOM_MEMBER_2());
     given(chatMessageService.createChatMessageProcess(command, receiverId)).willReturn(DEFAULT_TEXT_CHAT_MESSAGE());
 
     // when
@@ -249,6 +252,32 @@ class ChatRoomServiceTest {
     then(chatRoomMemberReader).should(times(1)).readChatRoomMember(chatRoomId, MEMBER_ID);
     then(chatRoomMemberReader).should(times(1)).readPartnerIdByRequesterId(chatRoomId, senderId);
     then(eventPublisher).should(times(1)).publishEvent(any(NotiEvent.class));
+  }
+
+  @DisplayName("채팅 메시지 전송 - 성공 테스트 (상대방이 채팅방을 나간 경우)")
+  @Test
+  void 채팅_메시지를_전송했을_때_상대방이_나간_경우_채팅방_재입장_처리를_한다() {
+    // given
+    Long chatRoomId = 1L;
+    UUID senderId = MEMBER_ID;
+    UUID receiverId = OTHER_MEMBER_ID;
+    CreateChatMessageCommand command = DEFAULT_CREATE_CHAT_MESSAGE_COMMAND();
+
+    ChatRoomMember sender = CHAT_ROOM_MEMBER_1();
+    ChatRoomMember receiver = EXITED_CHAT_ROOM_MEMBER();
+
+    given(chatRoomReader.readChatRoomById(chatRoomId)).willReturn(DEFAULT_CHAT_ROOM_1());
+    given(chatRoomMemberReader.readChatRoomMember(chatRoomId, senderId)).willReturn(sender);
+    given(chatRoomMemberReader.readPartnerIdByRequesterId(chatRoomId, senderId)).willReturn(receiverId);
+    given(chatRoomMemberReader.readChatRoomMember(chatRoomId, receiverId)).willReturn(receiver);
+    given(chatMessageService.createChatMessageProcess(command, receiverId)).willReturn(DEFAULT_TEXT_CHAT_MESSAGE());
+
+    // when
+    chatRoomService.createChatRoomMessageProcess(command);
+
+    // then
+    then(chatRoomMemberReader).should(times(1)).readChatRoomMember(chatRoomId, receiverId);
+    assertThat(receiver.getExitedAt()).isNull(); // 채팅방 입장 여부는 나간 시각의 null 여부로 판단 (null = 입장 상태)
   }
 
   @DisplayName("채팅 메시지 전송 - 메시지 타입이 IMAGE, MIX인 경우 normalize = true 테스트")
@@ -266,6 +295,7 @@ class ChatRoomServiceTest {
     given(chatRoomMemberReader.readChatRoomMember(chatRoomId, MEMBER_ID)).willReturn(CHAT_ROOM_MEMBER_1());
     given(chatMessageService.createChatMessageProcess(command, OTHER_MEMBER_ID)).willReturn(chatMessage);
     given(chatRoomMemberReader.readPartnerIdByRequesterId(chatRoomId, memberId)).willReturn(OTHER_MEMBER_ID);
+    given(chatRoomMemberReader.readChatRoomMember(chatRoomId, OTHER_MEMBER_ID)).willReturn(CHAT_ROOM_MEMBER_2());
 
     // when
     chatRoomService.createChatRoomMessageProcess(command);
@@ -293,6 +323,7 @@ class ChatRoomServiceTest {
     given(chatRoomMemberReader.readChatRoomMember(chatRoomId, MEMBER_ID)).willReturn(CHAT_ROOM_MEMBER_1());
     given(chatRoomMemberReader.readPartnerIdByRequesterId(chatRoomId, senderId)).willReturn(receiverId);
     given(chatMessageService.createChatMessageProcess(command, receiverId)).willReturn(DEFAULT_TEXT_CHAT_MESSAGE());
+    given(chatRoomMemberReader.readChatRoomMember(chatRoomId, OTHER_MEMBER_ID)).willReturn(CHAT_ROOM_MEMBER_2());
 
     // when
     chatRoomService.createChatRoomMessageProcess(command);
@@ -352,8 +383,8 @@ class ChatRoomServiceTest {
     UUID memberId = MEMBER_ID;
     UUID partnerId = OTHER_MEMBER_ID;
 
-    ChatRoom recentRoom = customChatRoom(1L, "최신 메시지", LocalDateTime.now(), true);
-    ChatRoom oldRoom = customChatRoom(2L, "오래된 메시지", LocalDateTime.now().minusHours(1), true);
+    ChatRoom recentRoom = customChatRoom(1L, "최신 메시지", now(), true);
+    ChatRoom oldRoom = customChatRoom(2L, "오래된 메시지", now().minusHours(1), true);
 
     given(chatRoomReader.readParticipatingChatRoomsByMemberId(memberId)).willReturn(List.of(oldRoom, recentRoom));
     given(chatRoomMemberReader.readPartnerIdByRequesterId(anyLong(), eq(memberId))).willReturn(partnerId);
@@ -407,8 +438,8 @@ class ChatRoomServiceTest {
   void 참여_중인_채팅방이_여러_개일_때_읽지_않은_메시지_수를_정상적으로_합산한다() {
     // given
     UUID memberId = MEMBER_ID;
-    ChatRoom room1 = customChatRoom(1L, "message", LocalDateTime.now(), true);
-    ChatRoom room2 = customChatRoom(2L, "message", LocalDateTime.now().minusMinutes(10), true);
+    ChatRoom room1 = customChatRoom(1L, "message", now(), true);
+    ChatRoom room2 = customChatRoom(2L, "message", now().minusMinutes(10), true);
 
     given(chatRoomReader.readParticipatingChatRoomsByMemberId(memberId))
         .willReturn(List.of(room1, room2));
@@ -433,7 +464,7 @@ class ChatRoomServiceTest {
     UUID memberId = MEMBER_ID;
     UUID partnerId = OTHER_MEMBER_ID;
 
-    ChatRoom chatRoom = customChatRoom(1L, "lastMessage", LocalDateTime.now(), true);
+    ChatRoom chatRoom = customChatRoom(1L, "lastMessage", now(), true);
     ChatPostResponse postResponse = ChatPostResponse.from(DEFAULT_POST_DETAIL_RESPONSE(chatRoom.getPostId()));
     ChatTradeResponse tradeResponse = ChatTradeResponse.from(DEFAULT_TRADE_DETAIL());
 
@@ -520,7 +551,7 @@ class ChatRoomServiceTest {
     UUID memberId = MEMBER_ID;
 
     ChatRoomMember exitedMember = CHAT_ROOM_MEMBER_1();
-    exitedMember.updateExitedAt(LocalDateTime.now());
+    exitedMember.updateExitedAt(now());
 
     given(chatRoomMemberReader.readChatRoomMember(chatRoomId, memberId)).willReturn(exitedMember);
 

--- a/src/test/unit/java/com/bob/support/fixture/domain/chat/ChatRoomFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/chat/ChatRoomFixture.java
@@ -7,6 +7,7 @@ public class ChatRoomFixture {
 
   public static ChatRoom DEFAULT_CHAT_ROOM_1() {
     return ChatRoom.builder()
+        .id(1L)
         .postId(1L)
         .tradeId(1L)
         .titleSuffix("제목")
@@ -30,6 +31,7 @@ public class ChatRoomFixture {
 
   public static ChatRoom DISABLE_CHAT_ROOM_1() {
     return ChatRoom.builder()
+        .id(1L)
         .postId(1L)
         .tradeId(3L)
         .titleSuffix("제목")

--- a/src/test/unit/java/com/bob/support/fixture/domain/chat/ChatRoomMemberFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/chat/ChatRoomMemberFixture.java
@@ -4,6 +4,7 @@ import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
 
 import com.bob.domain.chat.entity.ChatRoomMember;
+import java.time.LocalDateTime;
 
 public class ChatRoomMemberFixture {
 
@@ -20,6 +21,14 @@ public class ChatRoomMemberFixture {
         .chatRoomId(1L)
         .memberId(OTHER_MEMBER_ID)
         .exitedAt(null)
+        .build();
+  }
+
+  public static ChatRoomMember EXITED_CHAT_ROOM_MEMBER() {
+    return ChatRoomMember.builder()
+        .chatRoomId(1L)
+        .memberId(OTHER_MEMBER_ID)
+        .exitedAt(LocalDateTime.now().minusHours(1))
         .build();
   }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#76 

### 📜 작업 내용
- [x] 메시지 전송 시 채팅방을 나간 상대방인 경우 자동 재입장 처리 기능 구현
- [x] 단위, 통합 테스트 케이스 추가

### ⚠️ 종료할 이슈
this closes #76 
