### PR TITLE
feat#78: 카테고리 기반 게시글 목록 조회 시 하위 카테고리 포함

### DIFF
--- a/src/main/java/com/bob/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/bob/domain/category/repository/CategoryRepository.java
@@ -1,8 +1,15 @@
 package com.bob.domain.category.repository;
 
 import com.bob.domain.category.entity.Category;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CategoryRepository extends CrudRepository<Category, Integer> {
 
+  @Query("""
+      SELECT c.id FROM Category c
+      WHERE c.parent.id = :parentId
+      """)
+  List<Integer> findChildCategoryIds(Integer parentId);
 }

--- a/src/main/java/com/bob/domain/category/service/reader/CategoryReader.java
+++ b/src/main/java/com/bob/domain/category/service/reader/CategoryReader.java
@@ -4,6 +4,7 @@ import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.repository.CategoryRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,5 +19,9 @@ public class CategoryReader {
   public Category readCategoryById(Integer categoryId) {
     return categoryRepository.findById(categoryId)
         .orElseThrow(() -> new ApplicationException(ApplicationError.UN_SUPPORTED_CATEGORY));
+  }
+
+  public List<Integer> readChildCategoryIds(Integer parentCategoryId) {
+    return categoryRepository.findChildCategoryIds(parentCategoryId);
   }
 }

--- a/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
@@ -33,7 +33,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
             keywordCondition(query.key(), query.keyword()),
             memberIdCondition(query.memberId()),
             emdCondition(query.emdId()),
-            categoryCondition(query.categoryId()),
+            categoryCondition(query.categoryIds()),
             priceCondition(query.price()),
             tradeStatusCondition(query.postStatus()),
             bookStatusCondition(query.bookStatus())
@@ -53,7 +53,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
             keywordCondition(query.key(), query.keyword()),
             memberIdCondition(query.memberId()),
             emdCondition(query.emdId()),
-            categoryCondition(query.categoryId()),
+            categoryCondition(query.categoryIds()),
             priceCondition(query.price()),
             tradeStatusCondition(query.postStatus()),
             bookStatusCondition(query.bookStatus())
@@ -81,8 +81,11 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     return emdId == null ? null : post.registrationAreaId.eq(emdId);
   }
 
-  private BooleanExpression categoryCondition(Integer category) {
-    return category == null ? null : post.category.id.eq(category);
+  private BooleanExpression categoryCondition(List<Integer> categoryIds) {
+    if (categoryIds == null || categoryIds.isEmpty()) {
+      return null;
+    }
+    return post.category.id.in(categoryIds);
   }
 
   private BooleanExpression priceCondition(SearchPrice price) {

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -1,6 +1,6 @@
 package com.bob.domain.post.service;
 
-import static com.bob.domain.post.entity.status.PostStatus.*;
+import static com.bob.domain.post.entity.status.PostStatus.valueOf;
 import static com.bob.domain.post.service.dto.response.PostFileSummaryResponse.from;
 
 import com.bob.domain.book.entity.Book;
@@ -8,7 +8,6 @@ import com.bob.domain.book.service.BookService;
 import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.service.reader.CategoryReader;
 import com.bob.domain.post.entity.Post;
-import com.bob.domain.post.entity.status.PostStatus;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
@@ -98,9 +97,16 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
 
   @Transactional(readOnly = true)
   public PostsResponse readFilteredPostsProcess(ReadFilteredPostsQuery query, Pageable pageable) {
+    addChildCategoryIds(query);
     List<Post> posts = postReader.readFilteredPosts(query, pageable);
     Long totalCount = postRepository.countFilteredPosts(query);
     return PostsResponse.of(totalCount, posts);
+  }
+
+  private void addChildCategoryIds(ReadFilteredPostsQuery query) {
+    if (query.categoryIds() == null || query.categoryIds().isEmpty()) return;
+    List<Integer> categoryIds = categoryReader.readChildCategoryIds(query.categoryIds().get(0));
+    query.updateCategoryIds(categoryIds);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bob/domain/post/service/dto/query/ReadFilteredPostsQuery.java
+++ b/src/main/java/com/bob/domain/post/service/dto/query/ReadFilteredPostsQuery.java
@@ -3,6 +3,7 @@ package com.bob.domain.post.service.dto.query;
 import com.bob.domain.post.service.dto.query.condition.SearchKey;
 import com.bob.domain.post.service.dto.query.condition.SearchPrice;
 import com.bob.domain.post.service.dto.query.condition.SortKey;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -12,11 +13,14 @@ public record ReadFilteredPostsQuery(
     String keyword,
     UUID memberId,
     Integer emdId,
-    Integer categoryId,
+    List<Integer> categoryIds,
     SearchPrice price,
     String postStatus,
     String bookStatus,
     SortKey sortKey
 ) {
 
+  public void updateCategoryIds(List<Integer> categoryIds) {
+    this.categoryIds.addAll(categoryIds);
+  }
 }

--- a/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
+++ b/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
@@ -4,6 +4,8 @@ import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.condition.SearchKey;
 import com.bob.domain.post.service.dto.query.condition.SearchPrice;
 import com.bob.domain.post.service.dto.query.condition.SortKey;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public record ReadFilteredPostsRequest(
@@ -24,7 +26,7 @@ public record ReadFilteredPostsRequest(
         .keyword(keyword)
         .memberId(memberId)
         .emdId(emdId)
-        .categoryId(categoryId)
+        .categoryIds(categoryId != null ? new ArrayList<>(List.of(categoryId)) : null)
         .price(SearchPrice.fromIndex(price).orElse(null))
         .postStatus(postStatus)
         .bookStatus(bookStatus)

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -313,9 +313,10 @@ class PostServiceIntgTest extends TestContainerSupport {
     ReadFilteredPostsQuery query = searchCategoryQuery();
     PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
 
+    assertThat(query.categoryIds()).contains(1, 12, 13, 14, 15, 16); // 1의 자식 카테고리는 12, 13, 14, 15, 16
     assertThat(result.posts())
         .extracting(PostSummary::categoryId)
-        .containsOnly(1);
+        .contains(1);
   }
 
   @Test

--- a/src/test/unit/java/com/bob/domain/category/service/reader/CategoryReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/category/service/reader/CategoryReaderTest.java
@@ -10,6 +10,7 @@ import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.repository.CategoryRepository;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,5 +57,35 @@ class CategoryReaderTest {
         .hasMessage(ApplicationError.UN_SUPPORTED_CATEGORY.getMessage());
 
     verify(categoryRepository).findById(categoryId);
+  }
+
+  @Test
+  @DisplayName("자식 카테고리 ID 조회 - 자식이 존재하는 경우")
+  void 부모_카테고리ID로_자식_카테고리ID_리스트를_조회할_수_있다() {
+    // given
+    Integer parentId = 1;
+    given(categoryRepository.findChildCategoryIds(parentId)).willReturn(List.of(12, 13, 14, 15, 16));
+
+    // when
+    List<Integer> result = categoryReader.readChildCategoryIds(parentId);
+
+    // then
+    assertThat(result).containsExactly(12, 13, 14, 15, 16);
+    verify(categoryRepository).findChildCategoryIds(parentId);
+  }
+
+  @Test
+  @DisplayName("자식 카테고리 ID 조회 - 자식이 없는 경우 빈 리스트 반환")
+  void 최하위_카테고리인_경우_빈_리스트를_반환한다() {
+    // given
+    Integer parentId = 60;
+    given(categoryRepository.findChildCategoryIds(parentId)).willReturn(List.of());
+
+    // when
+    List<Integer> result = categoryReader.readChildCategoryIds(parentId);
+
+    // then
+    assertThat(result).isEmpty();
+    verify(categoryRepository).findChildCategoryIds(parentId);
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -16,6 +16,7 @@ import static com.bob.support.fixture.domain.PostFixture.defaultIdPost;
 import static com.bob.support.fixture.domain.PostFixture.defaultPost;
 import static com.bob.support.fixture.query.PostQueryFixture.defaultReadFilteredPostsQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.defaultReadMemberFavoritePostsQuery;
+import static com.bob.support.fixture.query.PostQueryFixture.searchCategoryQuery;
 import static com.bob.support.fixture.response.PostAreaSummaryResponseFixture.DEFAULT_POST_AREA_SUMMARY;
 import static com.bob.support.fixture.response.PostAreaSummaryResponseFixture.NOT_VALID_POST_AREA_SUMMARY;
 import static com.bob.support.fixture.response.PostFileSummaryResponseFixture.DEFAULT_READ_FILES_RESPONSE;
@@ -268,6 +269,27 @@ class PostServiceTest {
     assertThat(response.totalCount()).isEqualTo(2L);
     then(postReader).should(times(1)).readFilteredPosts(query, pageable);
     then(postRepository).should(times(1)).countFilteredPosts(query);
+  }
+
+  @DisplayName("게시글 목록 조회 테스트 - 부모 카테고리 조회")
+  @Test
+  void 카테고리를_통한_게시글_목록_조회_시_자식_카테고리_게시글을_포함한다() {
+    // given
+    ReadFilteredPostsQuery query = searchCategoryQuery(); // categoryId = 1, 1의 자식 = 12, 13, 14, 15, 16
+    given(categoryReader.readChildCategoryIds(query.categoryIds().get(0))).willReturn(List.of(12, 13, 14, 15, 16));
+    given(postReader.readFilteredPosts(query, pageable)).willReturn(DEFAULT_MOCK_POSTS());
+    given(postRepository.countFilteredPosts(query)).willReturn(2L);
+
+    // when
+    PostsResponse response = postService.readFilteredPostsProcess(query, pageable);
+
+    // then
+    then(categoryReader).should(times(1)).readChildCategoryIds(query.categoryIds().get(0));
+    assertThat(query.categoryIds()).contains(12, 13, 14, 15, 16); // 서비스 단에서 게시글 목록 조회 전 자식 카테고리를 조회 후 카테고리 조건에 추가
+
+    then(postReader).should(times(1)).readFilteredPosts(query, pageable);
+    then(postRepository).should(times(1)).countFilteredPosts(query);
+    assertThat(response.totalCount()).isEqualTo(2L);
   }
 
   @Test

--- a/src/test/unit/java/com/bob/support/fixture/query/PostQueryFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/query/PostQueryFixture.java
@@ -5,6 +5,8 @@ import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
 import com.bob.domain.post.service.dto.query.condition.SearchKey;
 import com.bob.domain.post.service.dto.query.condition.SearchPrice;
 import com.bob.domain.post.service.dto.query.condition.SortKey;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 public class PostQueryFixture {
@@ -14,7 +16,7 @@ public class PostQueryFixture {
         .key(SearchKey.ALL)
         .keyword(null)
         .emdId(null)
-        .categoryId(null)
+        .categoryIds(new ArrayList<>())
         .price(null)
         .postStatus(null)
         .bookStatus(null)
@@ -58,7 +60,7 @@ public class PostQueryFixture {
 
   public static ReadFilteredPostsQuery searchCategoryQuery() {
     return ReadFilteredPostsQuery.builder()
-        .categoryId(1)
+        .categoryIds(new ArrayList<>(List.of(1)))
         .sortKey(SortKey.RECENT)
         .build();
   }


### PR DESCRIPTION
### #️⃣연관된 이슈
#78 

### 📜 작업 내용
- [x] 하위 카테고리 게시글 포함 로직 추가
- [x] 관련 테스트 코드 작성

### ⚠️ 종료할 이슈
this closes #78 
