### PR TITLE
feat#80: 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/bob/global/exception/response/AuthenticationError.java
+++ b/src/main/java/com/bob/global/exception/response/AuthenticationError.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuthenticationError {
   FAILED_AUTHENTICATION("E001", "인증에 실패하였습니다."),
-  IS_EXPIRED_TOKEN("E002", "만료된 토큰입니다.");
+  IS_EXPIRED_TOKEN("E002", "만료된 토큰입니다."),
+  FAILED_GET_AUTHENTICATION_INFORMATION("E003", "인증 정보를 확인할 수 없습니다. 다시 로그인 해주세요.");
 
   private String code;
   private String message;

--- a/src/main/java/com/bob/global/exception/response/AuthenticationError.java
+++ b/src/main/java/com/bob/global/exception/response/AuthenticationError.java
@@ -7,9 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuthenticationError {
   FAILED_AUTHENTICATION("E001", "인증에 실패하였습니다."),
-  FAILED_VERIFY_TOKEN("E002", "검증할 수 없는 토큰입니다."),
-  IS_EXPIRED_TOKEN("E003", "만료된 토큰입니다."),
-  IS_NOT_EXIST_TOKEN("E004", "토큰이 존재하지 않습니다.");
+  IS_EXPIRED_TOKEN("E002", "만료된 토큰입니다.");
 
   private String code;
   private String message;

--- a/src/main/java/com/bob/global/utils/web/CookieUtils.java
+++ b/src/main/java/com/bob/global/utils/web/CookieUtils.java
@@ -33,5 +33,17 @@ public class CookieUtils {
 
     response.addHeader("Set-Cookie", cookie.toString());
   }
+
+  public static void removeCookie(HttpServletResponse response, String name) {
+    ResponseCookie cookie = ResponseCookie.from(name, "")
+        .path("/")
+        .sameSite(sameSite)
+        .httpOnly(true)
+        .secure(true)
+        .maxAge(0)
+        .build();
+
+    response.addHeader("Set-Cookie", cookie.toString());
+  }
 }
 

--- a/src/main/java/com/bob/infra/auth/adapter/TokenAuthAdapter.java
+++ b/src/main/java/com/bob/infra/auth/adapter/TokenAuthAdapter.java
@@ -1,0 +1,25 @@
+package com.bob.infra.auth.adapter;
+
+import com.bob.infra.auth.service.TokenService;
+import com.bob.web.common.CommonResponse;
+import com.bob.web.common.symbol.ResponseSymbol;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@RestController
+public class TokenAuthAdapter {
+
+  private final TokenService tokenService;
+
+  @PostMapping("/token/refresh")
+  public CommonResponse<ResponseSymbol> handleReIssueToken(HttpServletRequest request, HttpServletResponse response) {
+    tokenService.reIssueTokenProcess(request, response);
+    return new CommonResponse<>(true, ResponseSymbol.OK);
+  }
+}

--- a/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
+++ b/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
@@ -1,6 +1,14 @@
 package com.bob.infra.auth.filter;
 
+import static com.bob.global.utils.random.RandomUtils.generateCode;
+import static com.bob.global.utils.web.CookieUtils.addCookie;
+import static com.bob.global.utils.web.CookieUtils.getCookie;
+
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
+import com.bob.infra.auth.filter.port.AuthRedisPort;
 import com.bob.infra.auth.filter.request.LoginRequest;
+import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.response.MemberDetails;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -17,16 +25,18 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
-import com.bob.global.exception.response.AuthenticationError;
-import com.bob.infra.auth.jwt.JwtProvider;
-import com.bob.global.utils.web.CookieUtils;
 
 @RequiredArgsConstructor
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
+  private static final String ACCESS_COOKIE_NAME = "AUTHORIZATION";
+  private static final String REFRESH_COOKIE_NAME = "REFRESH_KEY";
+
   private final AuthenticationManager authenticationManager;
   private final AuthenticationEntryPoint authenticationEntryPoint;
+
+  private final AuthRedisPort redisPort;
+
   private final JwtProvider jwtProvider;
   private final ObjectMapper objectMapper;
 
@@ -42,9 +52,10 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     MemberDetails principal = (MemberDetails) authentication.getPrincipal();
     UUID memberId = principal.id();
     String accessToken = jwtProvider.generateAccessToken(memberId.toString());
-    String refreshToken = jwtProvider.generateRefreshToken(memberId.toString());
-    CookieUtils.addCookie(response, "AUTHORIZATION", accessToken, 216000);
-    CookieUtils.addCookie(response, "REFRESH", refreshToken, 216000);
+    String refreshKey = generateCode(32);
+    redisPort.updateRefreshKey(getCookie(request, REFRESH_COOKIE_NAME), refreshKey, memberId.toString(), 14);
+    addCookie(response, ACCESS_COOKIE_NAME, accessToken, 7200);
+    addCookie(response, REFRESH_COOKIE_NAME, refreshKey, 1209600);
     response.setStatus(HttpStatus.OK.value());
   }
 

--- a/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
+++ b/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
@@ -53,7 +53,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     UUID memberId = principal.id();
     String accessToken = jwtProvider.generateAccessToken(memberId.toString());
     String refreshKey = generateCode(32);
-    redisPort.updateRefreshKey(getCookie(request, REFRESH_COOKIE_NAME), refreshKey, memberId.toString(), 14);
+    redisPort.updateRefreshKey(getCookie(request, REFRESH_COOKIE_NAME), refreshKey, memberId.toString());
     addCookie(response, ACCESS_COOKIE_NAME, accessToken, 7200);
     addCookie(response, REFRESH_COOKIE_NAME, refreshKey, 1209600);
     response.setStatus(HttpStatus.OK.value());

--- a/src/main/java/com/bob/infra/auth/filter/port/AuthRedisPort.java
+++ b/src/main/java/com/bob/infra/auth/filter/port/AuthRedisPort.java
@@ -2,7 +2,7 @@ package com.bob.infra.auth.filter.port;
 
 public interface AuthRedisPort {
 
-  void updateRefreshKey(String oldKey, String newKey, String value, int expireDays);
+  String updateRefreshKey(String oldKey, String newKey, String value);
 
   void removeRefreshKey(String key);
 }

--- a/src/main/java/com/bob/infra/auth/filter/port/AuthRedisPort.java
+++ b/src/main/java/com/bob/infra/auth/filter/port/AuthRedisPort.java
@@ -1,0 +1,8 @@
+package com.bob.infra.auth.filter.port;
+
+public interface AuthRedisPort {
+
+  void updateRefreshKey(String oldKey, String newKey, String value, int expireDays);
+
+  void removeRefreshKey(String key);
+}

--- a/src/main/java/com/bob/infra/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/bob/infra/auth/jwt/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.bob.infra.auth.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.util.Date;
@@ -44,10 +46,13 @@ public class JwtProvider {
   public boolean isVerified(String token) {
     try {
       Jwts.parserBuilder()
+          .setSigningKey(getSecretKey(key))
           .build()
-          .isSigned(token);
+          .parseClaimsJws(token);
       return true;
-    } catch (Exception e) {
+    } catch (ExpiredJwtException e) {
+      return true;
+    } catch (JwtException e) {
       return false;
     }
   }

--- a/src/main/java/com/bob/infra/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/bob/infra/auth/jwt/JwtProvider.java
@@ -21,9 +21,6 @@ public class JwtProvider {
   @Value("${jwt.access-token-expire-time}")
   private Long accessExpireTime;
 
-  @Value("${jwt.refresh-token-expire-time}")
-  private Long refreshExpireTime;
-
   public String generateAccessToken(String memberId) {
     return Jwts.builder()
         .setIssuer(ISSUER)
@@ -31,17 +28,6 @@ public class JwtProvider {
         .claim("memberId", memberId)
         .setIssuedAt(new Date(System.currentTimeMillis()))
         .setExpiration(new Date(System.currentTimeMillis() + accessExpireTime * 1000))
-        .signWith(getSecretKey(key))
-        .compact();
-  }
-
-  public String generateRefreshToken(String memberId) {
-    return Jwts.builder()
-        .setIssuer(ISSUER)
-        .setSubject("refresh-token")
-        .claim("memberId", memberId)
-        .setIssuedAt(new Date(System.currentTimeMillis()))
-        .setExpiration(new Date(System.currentTimeMillis() + refreshExpireTime * 1000))
         .signWith(getSecretKey(key))
         .compact();
   }

--- a/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -3,6 +3,7 @@ package com.bob.infra.auth.jwt.filter;
 import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
 import static com.bob.global.exception.response.AuthenticationError.IS_EXPIRED_TOKEN;
 import static com.bob.global.utils.web.CookieUtils.getCookie;
+import static com.bob.global.utils.web.CookieUtils.removeCookie;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
 import com.bob.infra.auth.jwt.JwtProvider;
@@ -27,6 +28,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
   private static final String ACCESS_COOKIE_NAME = "AUTHORIZATION";
+  private static final String REFRESH_COOKIE_NAME = "REFRESH_KEY";
 
   private final JwtAuthenticationEntryPoint jwtAuthEntryPoint;
   private final PermitAllRegistry registry;
@@ -42,8 +44,14 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     String accessToken = getCookie(request, ACCESS_COOKIE_NAME);
 
-    if (optionalRegistry.isOptionalAuth(request) && accessToken == null) {
-      filterChain.doFilter(request, response);
+    if (optionalRegistry.isOptionalAuth(request)) {
+      if (accessToken == null) {
+        filterChain.doFilter(request, response);
+      } else if (!isAuthentication(accessToken)) {
+        removeCookie(response, ACCESS_COOKIE_NAME);
+        removeCookie(response, REFRESH_COOKIE_NAME);
+        filterChain.doFilter(request, response);
+      }
       return;
     }
 
@@ -62,11 +70,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
   private boolean isAuthentication(String accessToken) {
     return accessToken != null
-           && jwtProvider.isVerified(accessToken)
-           && !jwtProvider.isExpired(accessToken);
+        && jwtProvider.isVerified(accessToken)
+        && !jwtProvider.isExpired(accessToken);
   }
 
-  private void setErroneousAuthenticationExceptionBody(HttpServletRequest request, HttpServletResponse response, String accessToken) throws IOException {
+  private void setErroneousAuthenticationExceptionBody(HttpServletRequest request, HttpServletResponse response,
+      String accessToken) throws IOException {
     // 토큰이 존재하지 않거나 유효하지 않은 토큰
     if (accessToken == null || !jwtProvider.isVerified(accessToken)) {
       jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(FAILED_AUTHENTICATION));

--- a/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package com.bob.infra.auth.jwt.filter;
 
 import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
+import static com.bob.global.exception.response.AuthenticationError.IS_EXPIRED_TOKEN;
 import static com.bob.global.utils.web.CookieUtils.getCookie;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
@@ -47,7 +48,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     }
 
     if (!isAuthentication(accessToken)) {
-      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(FAILED_AUTHENTICATION));
+      setErroneousAuthenticationExceptionBody(request, response, accessToken);
       return;
     }
 
@@ -63,5 +64,18 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     return accessToken != null
            && jwtProvider.isVerified(accessToken)
            && !jwtProvider.isExpired(accessToken);
+  }
+
+  private void setErroneousAuthenticationExceptionBody(HttpServletRequest request, HttpServletResponse response, String accessToken) throws IOException {
+    // 토큰이 존재하지 않거나 유효하지 않은 토큰
+    if (accessToken == null || !jwtProvider.isVerified(accessToken)) {
+      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(FAILED_AUTHENTICATION));
+      return;
+    }
+
+    // 유효한 토큰이 존재하지만 만료된 토큰
+    if (jwtProvider.isExpired(accessToken)) {
+      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(IS_EXPIRED_TOKEN));
+    }
   }
 }

--- a/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -1,9 +1,11 @@
 package com.bob.infra.auth.jwt.filter;
 
-import static com.bob.global.exception.response.AuthenticationError.FAILED_VERIFY_TOKEN;
-import static com.bob.global.exception.response.AuthenticationError.IS_EXPIRED_TOKEN;
-import static com.bob.global.exception.response.AuthenticationError.IS_NOT_EXIST_TOKEN;
+import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
+import static com.bob.global.utils.web.CookieUtils.getCookie;
 
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.infra.auth.jwt.JwtProvider;
+import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import com.bob.infra.auth.response.MemberDetails;
 import com.bob.infra.config.registry.OptionalRegistry;
 import com.bob.infra.config.registry.PermitAllRegistry;
@@ -13,23 +15,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
-import com.bob.infra.auth.jwt.JwtProvider;
-import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
-import com.bob.global.utils.web.CookieUtils;
 
 @RequiredArgsConstructor
 @Component
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
-  @Value("${jwt.cookie-name}")
-  private String COOKIE_NAME;
+  private static final String ACCESS_COOKIE_NAME = "AUTHORIZATION";
 
   private final JwtAuthenticationEntryPoint jwtAuthEntryPoint;
   private final PermitAllRegistry registry;
@@ -43,24 +39,15 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       return;
     }
 
-    if (optionalRegistry.isOptionalAuth(request) && CookieUtils.getCookie(request, COOKIE_NAME) == null) {
+    String accessToken = getCookie(request, ACCESS_COOKIE_NAME);
+
+    if (optionalRegistry.isOptionalAuth(request) && accessToken == null) {
       filterChain.doFilter(request, response);
       return;
     }
 
-    String accessToken = CookieUtils.getCookie(request, COOKIE_NAME);
-    if (accessToken == null) {
-      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(IS_NOT_EXIST_TOKEN));
-      return;
-    }
-
-    if (!jwtProvider.isVerified(accessToken)) {
-      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(FAILED_VERIFY_TOKEN));
-      return;
-    }
-
-    if (jwtProvider.isExpired(accessToken)) {
-      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(IS_EXPIRED_TOKEN));
+    if (!isAuthentication(accessToken)) {
+      jwtAuthEntryPoint.commence(request, response, new ApplicationAuthenticationException(FAILED_AUTHENTICATION));
       return;
     }
 
@@ -70,5 +57,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     );
     SecurityContextHolder.getContext().setAuthentication(authentication);
     filterChain.doFilter(request, response);
+  }
+
+  private boolean isAuthentication(String accessToken) {
+    return accessToken != null
+           && jwtProvider.isVerified(accessToken)
+           && !jwtProvider.isExpired(accessToken);
   }
 }

--- a/src/main/java/com/bob/infra/auth/service/TokenService.java
+++ b/src/main/java/com/bob/infra/auth/service/TokenService.java
@@ -1,0 +1,42 @@
+package com.bob.infra.auth.service;
+
+import static com.bob.global.utils.random.RandomUtils.generateCode;
+import static com.bob.global.utils.web.CookieUtils.addCookie;
+import static com.bob.global.utils.web.CookieUtils.getCookie;
+
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
+import com.bob.infra.auth.filter.port.AuthRedisPort;
+import com.bob.infra.auth.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+
+  private final JwtProvider jwtProvider;
+
+  private final AuthRedisPort redisPort;
+
+  private static final String ACCESS_COOKIE_NAME = "AUTHORIZATION";
+  private static final String REFRESH_COOKIE_NAME = "REFRESH_KEY";
+
+  public void reIssueTokenProcess(HttpServletRequest request, HttpServletResponse response) {
+    String oldKey = getCookie(request, REFRESH_COOKIE_NAME);
+    verifyKey(oldKey);
+    String newRefreshKey = generateCode(32);
+    String id = redisPort.updateRefreshKey(oldKey, newRefreshKey, null);
+    String newAccessToken = jwtProvider.generateAccessToken(id);
+    addCookie(response, ACCESS_COOKIE_NAME, newAccessToken, 7200);
+    addCookie(response, REFRESH_COOKIE_NAME, newRefreshKey, 1209600);
+  }
+
+  private void verifyKey(String key) {
+    if (key == null) {
+      throw new ApplicationAuthenticationException(AuthenticationError.FAILED_GET_AUTHENTICATION_INFORMATION);
+    }
+  }
+}

--- a/src/main/java/com/bob/infra/config/SecurityConfig.java
+++ b/src/main/java/com/bob/infra/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.bob.infra.config;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 import com.bob.infra.auth.filter.LoginFilter;
+import com.bob.infra.auth.filter.port.AuthRedisPort;
 import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.jwt.filter.JwtAuthorizationFilter;
 import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
@@ -40,9 +41,11 @@ public class SecurityConfig {
       "/h2-console/**",
       "/error/**",
   };
+
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final JwtAuthorizationFilter jwtAuthorizationFilter;
   private final MemberDetailsService memberDetailsService;
+  private final AuthRedisPort redisPort;
   private final JwtProvider jwtProvider;
   private final ObjectMapper objectMapper;
 
@@ -58,7 +61,7 @@ public class SecurityConfig {
             .logoutUrl("/auth/logout")
             .logoutSuccessHandler((req, res, auth) -> res.setStatus(SC_OK))
             .addLogoutHandler((req, res, auth) -> req.getSession().invalidate())
-            .deleteCookies("JSESSIONID", "AUTHORIZATION", "REFRESH")
+            .deleteCookies("JSESSIONID", "AUTHORIZATION", "REFRESH_KEY")
         )
         .sessionManagement(m -> m.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
@@ -110,6 +113,7 @@ public class SecurityConfig {
     LoginFilter loginFilter = new LoginFilter(
         authenticationManager,
         jwtAuthenticationEntryPoint,
+        redisPort,
         jwtProvider,
         objectMapper
     );

--- a/src/main/java/com/bob/infra/redis/adapter/in/AuthRedisAdapter.java
+++ b/src/main/java/com/bob/infra/redis/adapter/in/AuthRedisAdapter.java
@@ -1,5 +1,8 @@
 package com.bob.infra.redis.adapter.in;
 
+import static com.bob.global.exception.response.AuthenticationError.FAILED_GET_AUTHENTICATION_INFORMATION;
+
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
 import com.bob.infra.auth.filter.port.AuthRedisPort;
 import com.bob.infra.redis.repository.RedisRepository;
 import java.time.Duration;
@@ -10,16 +13,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthRedisAdapter implements AuthRedisPort {
 
-  private static final String KEY_PREFIX = "refresh:";
-
   private final RedisRepository redisRepository;
 
+  private static final String KEY_PREFIX = "refresh:";
+
   @Override
-  public void updateRefreshKey(String oldKey, String newKey, String value, int expireDays) {
+  public String updateRefreshKey(String oldKey, String newKey, String value) {
     if (oldKey != null && isExistKey(oldKey)) {
+      value = getValue(oldKey);
       removeKey(oldKey);
     }
-    redisRepository.setValue(KEY_PREFIX + newKey, value, Duration.ofDays(expireDays));
+    checkValue(value);
+    redisRepository.setValue(KEY_PREFIX + newKey, value, Duration.ofDays(14));
+    return value;
   }
 
   @Override
@@ -35,5 +41,16 @@ public class AuthRedisAdapter implements AuthRedisPort {
 
   private void removeKey(String key) {
     redisRepository.delete(KEY_PREFIX + key);
+  }
+
+  private String getValue(String key) {
+    return redisRepository.getValue(KEY_PREFIX + key)
+        .orElseThrow(() -> new ApplicationAuthenticationException(FAILED_GET_AUTHENTICATION_INFORMATION));
+  }
+
+  private static void checkValue(String value) {
+    if (value == null) {
+      throw new ApplicationAuthenticationException(FAILED_GET_AUTHENTICATION_INFORMATION);
+    }
   }
 }

--- a/src/main/java/com/bob/infra/redis/adapter/in/AuthRedisAdapter.java
+++ b/src/main/java/com/bob/infra/redis/adapter/in/AuthRedisAdapter.java
@@ -1,0 +1,39 @@
+package com.bob.infra.redis.adapter.in;
+
+import com.bob.infra.auth.filter.port.AuthRedisPort;
+import com.bob.infra.redis.repository.RedisRepository;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AuthRedisAdapter implements AuthRedisPort {
+
+  private static final String KEY_PREFIX = "refresh:";
+
+  private final RedisRepository redisRepository;
+
+  @Override
+  public void updateRefreshKey(String oldKey, String newKey, String value, int expireDays) {
+    if (oldKey != null && isExistKey(oldKey)) {
+      removeKey(oldKey);
+    }
+    redisRepository.setValue(KEY_PREFIX + newKey, value, Duration.ofDays(expireDays));
+  }
+
+  @Override
+  public void removeRefreshKey(String key) {
+    if (isExistKey(key)) {
+      removeKey(key);
+    }
+  }
+
+  private boolean isExistKey(String key) {
+    return redisRepository.isExist(KEY_PREFIX + key);
+  }
+
+  private void removeKey(String key) {
+    redisRepository.delete(KEY_PREFIX + key);
+  }
+}

--- a/src/main/java/com/bob/infra/redis/repository/RedisRepository.java
+++ b/src/main/java/com/bob/infra/redis/repository/RedisRepository.java
@@ -23,4 +23,8 @@ public class RedisRepository {
   public void delete(String key) {
     redisTemplate.delete(key);
   }
+
+  public boolean isExist(String key) {
+    return redisTemplate.hasKey(key);
+  }
 }

--- a/src/main/java/com/bob/infra/redis/repository/RedisRepository.java
+++ b/src/main/java/com/bob/infra/redis/repository/RedisRepository.java
@@ -17,7 +17,9 @@ public class RedisRepository {
   }
 
   public Optional<String> getValue(String key) {
-    return Optional.of(redisTemplate.opsForValue().get(key));
+    return isExist(key)
+        ? Optional.ofNullable(redisTemplate.opsForValue().get(key))
+        : Optional.empty();
   }
 
   public void delete(String key) {
@@ -25,6 +27,6 @@ public class RedisRepository {
   }
 
   public boolean isExist(String key) {
-    return redisTemplate.hasKey(key);
+    return Boolean.TRUE.equals(redisTemplate.hasKey(key));
   }
 }

--- a/src/test/intg/java/com/bob/infra/config/LogoutIntgTest.java
+++ b/src/test/intg/java/com/bob/infra/config/LogoutIntgTest.java
@@ -35,6 +35,6 @@ class LogoutIntgTest extends TestContainerSupport {
         .andExpect(status().isOk())
         .andExpect(cookie().maxAge("JSESSIONID", 0))
         .andExpect(cookie().maxAge("AUTHORIZATION", 0))
-        .andExpect(cookie().maxAge("REFRESH", 0));
+        .andExpect(cookie().maxAge("REFRESH_KEY", 0));
   }
 }

--- a/src/test/unit/java/com/bob/global/utils/CookieUtilsTest.java
+++ b/src/test/unit/java/com/bob/global/utils/CookieUtilsTest.java
@@ -77,4 +77,18 @@ class CookieUtilsTest {
     // then
     then(response).should().addHeader(eq(SET_COOKIE_HEADER), contains(AUTH_COOKIE));
   }
+
+  @Test
+  @DisplayName("Cookie 제거 - 성공 테스트")
+  void 쿠키를_응답에서_제거할_수_있다() {
+    // given
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    // when
+    CookieUtils.removeCookie(response, AUTH_COOKIE_NAME);
+
+    // then
+    then(response).should().addHeader(eq(SET_COOKIE_HEADER), contains(AUTH_COOKIE_NAME + "="));
+    then(response).should().addHeader(eq(SET_COOKIE_HEADER), contains("Max-Age=0"));
+  }
 }

--- a/src/test/unit/java/com/bob/infra/auth/adapter/TokenAuthAdapterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/adapter/TokenAuthAdapterTest.java
@@ -1,0 +1,50 @@
+package com.bob.infra.auth.adapter;
+
+import static com.bob.web.common.symbol.ResponseSymbol.OK;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bob.infra.auth.service.TokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@DisplayName("토큰 재발급 API 테스트")
+@ExtendWith(MockitoExtension.class)
+class TokenAuthAdapterTest {
+
+  @InjectMocks
+  private TokenAuthAdapter tokenAuthAdapter;
+
+  @Mock
+  private TokenService tokenService;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    mvc = MockMvcBuilders.standaloneSetup(tokenAuthAdapter).build();
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 API 호출 테스트")
+  void 토큰_재발급을_요청할_수_있다() throws Exception {
+    // when & then
+    mvc.perform(post("/auth/token/refresh"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value(OK.name()));
+
+    verify(tokenService, times(1)).reIssueTokenProcess(any(), any());
+  }
+}

--- a/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
@@ -116,7 +116,7 @@ class LoginFilterTest {
     verify(response, times(1)).addHeader(eq(SET_COOKIE_HEADER), contains(AUTH_COOKIE));
     verify(response).setStatus(HttpStatus.OK.value());
     assertThat(authentication.getPrincipal()).isInstanceOf(MemberDetails.class);
-    then(redisPort).should(times(1)).updateRefreshKey(any(), any(), any(), eq(14));
+    then(redisPort).should(times(1)).updateRefreshKey(any(), any(), any());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
@@ -3,7 +3,6 @@ package com.bob.infra.auth.filter;
 import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
 import static com.bob.support.fixture.auth.CookieFixture.ACCESS_VALUE;
 import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE;
-import static com.bob.support.fixture.auth.CookieFixture.REFRESH_VALUE;
 import static com.bob.support.fixture.auth.CookieFixture.SET_COOKIE_HEADER;
 import static com.bob.support.fixture.request.LoginRequestFixture.defaultLoginRequest;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.infra.auth.filter.port.AuthRedisPort;
 import com.bob.infra.auth.filter.request.LoginRequest;
 import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.response.MemberDetails;
@@ -47,23 +47,31 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class LoginFilterTest {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-  @Mock
-  HttpServletResponse response;
-
-  @Mock
-  Authentication authentication;
-
-  @Mock
-  HttpServletRequest request;
   @InjectMocks
   private LoginFilter loginFilter;
+
   @Mock
   private AuthenticationManager authManager;
+
   @Mock
   private AuthenticationEntryPoint authenticationEntryPoint;
+
   @Mock
   private JwtProvider jwtProvider;
+
+  @Mock
+  private AuthRedisPort redisPort;
+
+  @Mock
+  private Authentication authentication;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private HttpServletRequest request;
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeEach
   void setUp() {
@@ -100,7 +108,6 @@ class LoginFilterTest {
         memberDetails, null, memberDetails.getAuthorities()
     );
     given(jwtProvider.generateAccessToken(any(String.class))).willReturn(ACCESS_VALUE);
-    given(jwtProvider.generateRefreshToken(any(String.class))).willReturn(REFRESH_VALUE);
 
     // when
     loginFilter.successfulAuthentication(request, response, filterChain, authentication);
@@ -109,6 +116,7 @@ class LoginFilterTest {
     verify(response, times(1)).addHeader(eq(SET_COOKIE_HEADER), contains(AUTH_COOKIE));
     verify(response).setStatus(HttpStatus.OK.value());
     assertThat(authentication.getPrincipal()).isInstanceOf(MemberDetails.class);
+    then(redisPort).should(times(1)).updateRefreshKey(any(), any(), any(), eq(14));
   }
 
   @Test
@@ -121,11 +129,9 @@ class LoginFilterTest {
     loginFilter.unsuccessfulAuthentication(request, response, failed);
 
     // then
-    then(authenticationEntryPoint).should()
-        .commence(eq(request), eq(response),
-            argThat(e ->
-                ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION
-            )
-        );
+    then(authenticationEntryPoint).should().commence(eq(request), eq(response),
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION)
+    );
+    then(redisPort).shouldHaveNoInteractions();
   }
 }

--- a/src/test/unit/java/com/bob/infra/auth/jwt/JwtProviderTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/JwtProviderTest.java
@@ -85,4 +85,30 @@ class JwtProviderTest {
     // then
     assertThat(isExpired).isTrue();
   }
+
+  @Test
+  @DisplayName("Token 서명 검증 - 실패 테스트(서명 불일치)")
+  void 서명이_조작된_토큰이면_false를_반환한다() {
+    // given
+    String tamperedToken = validToken(MEMBER_ID.toString()) + "tampered";
+
+    // when
+    boolean isVerified = jwtProvider.isVerified(tamperedToken);
+
+    // then
+    assertThat(isVerified).isFalse();
+  }
+
+  @Test
+  @DisplayName("Token 만료 여부 확인 - 실패 테스트(서명 불일치)")
+  void 서명이_조작된_토큰이면_true를_반환한다() {
+    // given
+    String tamperedToken = validToken(MEMBER_ID.toString()) + "tampered";
+
+    // when
+    boolean isExpired = jwtProvider.isExpired(tamperedToken);
+
+    // then
+    assertThat(isExpired).isTrue();
+  }
 }

--- a/src/test/unit/java/com/bob/infra/auth/jwt/JwtProviderTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/JwtProviderTest.java
@@ -22,7 +22,6 @@ class JwtProviderTest {
     jwtProvider = new JwtProvider();
     ReflectionTestUtils.setField(jwtProvider, "key", SECRET_KEY);
     ReflectionTestUtils.setField(jwtProvider, "accessExpireTime", 60L);
-    ReflectionTestUtils.setField(jwtProvider, "refreshExpireTime", 120L);
   }
 
   @Test
@@ -30,16 +29,6 @@ class JwtProviderTest {
   void AccessToken을_생성할_수_있다() {
     // when
     String token = jwtProvider.generateAccessToken(MEMBER_ID.toString());
-
-    // then
-    assertThat(token).isNotBlank();
-  }
-
-  @Test
-  @DisplayName("Refresh Token 생성 - 성공 테스트")
-  void RefreshToken을_생성할_수_있다() {
-    // when
-    String token = jwtProvider.generateRefreshToken(MEMBER_ID.toString());
 
     // then
     assertThat(token).isNotBlank();

--- a/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
@@ -77,7 +77,7 @@ class JwtAuthorizationFilterTest {
     given(request.getCookies()).willReturn(new Cookie[]{defaultAuthCookie()});
     given(jwtProvider.isVerified(ACCESS_VALUE)).willReturn(true);
     given(jwtProvider.isExpired(ACCESS_VALUE)).willReturn(false);
-    given(jwtProvider.getMemberId(ACCESS_VALUE)).willReturn(any(UUID.class));
+    given(jwtProvider.getMemberId(ACCESS_VALUE)).willReturn(UUID.randomUUID());
 
     // when
     jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
@@ -153,7 +153,7 @@ class JwtAuthorizationFilterTest {
   }
 
   @Test
-  @DisplayName("선택적 인증 요청 테스트")
+  @DisplayName("선택적 인증 요청 테스트 - 쿠키 없음")
   void 선택적_인증이고_쿠키가_없으면_필터를_우회한다() throws Exception {
     // given
     given(optionalRegistry.isOptionalAuth(request)).willReturn(true);
@@ -163,6 +163,28 @@ class JwtAuthorizationFilterTest {
     jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
 
     // then
+    then(filterChain).should().doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("선택적 인증 요청 테스트 - 유효하지 않은 토큰이면 쿠키를 제거하고 필터를 우회한다")
+  void 선택적_인증이고_토큰이_유효하지_않으면_쿠키를_제거하고_필터를_우회한다() throws Exception {
+    // given
+    Cookie cookie = defaultAuthCookie();
+    given(request.getCookies()).willReturn(new Cookie[]{cookie});
+    given(optionalRegistry.isOptionalAuth(request)).willReturn(true);
+    given(jwtProvider.isVerified(ACCESS_VALUE)).willReturn(false);
+
+    // when
+    jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
+
+    // then
+    then(response).should().addHeader(eq("Set-Cookie"), argThat(value ->
+        value.contains("AUTHORIZATION=") && value.contains("Max-Age=0")
+    ));
+    then(response).should().addHeader(eq("Set-Cookie"), argThat(value ->
+        value.contains("REFRESH_KEY=") && value.contains("Max-Age=0")
+    ));
     then(filterChain).should().doFilter(request, response);
   }
 }

--- a/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
@@ -1,6 +1,7 @@
 package com.bob.infra.auth.jwt.filter;
 
 import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
+import static com.bob.global.exception.response.AuthenticationError.IS_EXPIRED_TOKEN;
 import static com.bob.support.fixture.auth.CookieFixture.ACCESS_VALUE;
 import static com.bob.support.fixture.auth.CookieFixture.defaultAuthCookie;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,7 +12,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
-import com.bob.global.utils.web.CookieUtils;
 import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import com.bob.infra.auth.response.MemberDetails;
@@ -53,9 +53,6 @@ class JwtAuthorizationFilterTest {
 
   @Mock
   private FilterChain filterChain;
-
-  @Mock
-  private CookieUtils cookieUtils;
 
   @Mock
   private PermitAllRegistry permitAllRegistry;
@@ -138,7 +135,7 @@ class JwtAuthorizationFilterTest {
 
     // then
     then(jwtAuthenticationEntryPoint).should().commence(eq(request), eq(response),
-        argThat(e -> ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION)
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == IS_EXPIRED_TOKEN)
     );
   }
 

--- a/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilterTest.java
@@ -1,10 +1,7 @@
 package com.bob.infra.auth.jwt.filter;
 
-import static com.bob.global.exception.response.AuthenticationError.FAILED_VERIFY_TOKEN;
-import static com.bob.global.exception.response.AuthenticationError.IS_EXPIRED_TOKEN;
-import static com.bob.global.exception.response.AuthenticationError.IS_NOT_EXIST_TOKEN;
+import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
 import static com.bob.support.fixture.auth.CookieFixture.ACCESS_VALUE;
-import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE_NAME;
 import static com.bob.support.fixture.auth.CookieFixture.defaultAuthCookie;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,7 +31,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("JWT 토큰 인증 필터 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -69,7 +65,6 @@ class JwtAuthorizationFilterTest {
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(jwtAuthorizationFilter, "COOKIE_NAME", AUTH_COOKIE_NAME);
     given(permitAllRegistry.isWhiteList(any(HttpServletRequest.class))).willReturn(false);
   }
 
@@ -93,8 +88,7 @@ class JwtAuthorizationFilterTest {
     // then
     assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
     assertThat(SecurityContextHolder.getContext().getAuthentication().isAuthenticated()).isTrue();
-    assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal())
-        .isInstanceOf(MemberDetails.class);
+    assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isInstanceOf(MemberDetails.class);
     then(filterChain).should().doFilter(request, response);
   }
 
@@ -108,12 +102,9 @@ class JwtAuthorizationFilterTest {
     jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
 
     // then
-    then(jwtAuthenticationEntryPoint).should()
-        .commence(eq(request), eq(response),
-            argThat(
-                e -> ((ApplicationAuthenticationException) e).getError() == IS_NOT_EXIST_TOKEN
-            )
-        );
+    then(jwtAuthenticationEntryPoint).should().commence(eq(request), eq(response),
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION)
+    );
   }
 
   @Test
@@ -128,12 +119,9 @@ class JwtAuthorizationFilterTest {
     jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
 
     // then
-    then(jwtAuthenticationEntryPoint).should()
-        .commence(eq(request), eq(response),
-            argThat(e ->
-                ((ApplicationAuthenticationException) e).getError() == FAILED_VERIFY_TOKEN
-            )
-        );
+    then(jwtAuthenticationEntryPoint).should().commence(eq(request), eq(response),
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION)
+    );
   }
 
   @Test
@@ -149,12 +137,9 @@ class JwtAuthorizationFilterTest {
     jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
 
     // then
-    then(jwtAuthenticationEntryPoint).should()
-        .commence(eq(request), eq(response),
-            argThat(
-                e -> ((ApplicationAuthenticationException) e).getError() == IS_EXPIRED_TOKEN
-            )
-        );
+    then(jwtAuthenticationEntryPoint).should().commence(eq(request), eq(response),
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION)
+    );
   }
 
   @Test

--- a/src/test/unit/java/com/bob/infra/auth/jwt/handler/JwtAuthenticationEntryPointTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/jwt/handler/JwtAuthenticationEntryPointTest.java
@@ -2,6 +2,8 @@ package com.bob.infra.auth.jwt.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -14,8 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.test.util.ReflectionTestUtils;
-import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
-import com.bob.global.exception.response.AuthenticationError;
 
 @DisplayName("JWT 예외 핸들러 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -24,9 +24,9 @@ class JwtAuthenticationEntryPointTest {
   @InjectMocks
   private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-  private final String CONTENT_TYPE = "application/json; charset=UTF-8";
-  private final ObjectMapper objectMapper = new ObjectMapper();
   private MockHttpServletResponse response;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeEach
   void setUp() {
@@ -38,7 +38,7 @@ class JwtAuthenticationEntryPointTest {
   @DisplayName("예외 반환 테스트 - 인증 실패 전역 예외")
   void AuthenticationException_발생시_기본_예외를_반환한다() throws IOException {
     // given
-    AuthenticationException exception = new AuthenticationException("인증 실패") {};
+    AuthenticationException exception = new AuthenticationException("") {};
 
     // when
     jwtAuthenticationEntryPoint.commence(null, response, exception);
@@ -46,13 +46,12 @@ class JwtAuthenticationEntryPointTest {
     // then
     String content = response.getContentAsString();
     assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-    assertThat(response.getContentType()).isEqualTo(CONTENT_TYPE);
     assertThat(content).contains(AuthenticationError.FAILED_AUTHENTICATION.getCode());
     assertThat(content).contains(AuthenticationError.FAILED_AUTHENTICATION.getMessage());
   }
 
   @Test
-  @DisplayName("예외 반환 테스트 - 특정 예외")
+  @DisplayName("예외 반환 테스트 - 커스텀 예외")
   void ApplicationAuthenticationException_발생_시_커스텀_예외를_반환한다() throws IOException {
     // given
     AuthenticationException exception = new ApplicationAuthenticationException(AuthenticationError.IS_EXPIRED_TOKEN) {};
@@ -63,7 +62,6 @@ class JwtAuthenticationEntryPointTest {
     // then
     String content = response.getContentAsString();
     assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-    assertThat(response.getContentType()).isEqualTo(CONTENT_TYPE);
     assertThat(content).contains(AuthenticationError.IS_EXPIRED_TOKEN.getCode());
     assertThat(content).contains(AuthenticationError.IS_EXPIRED_TOKEN.getMessage());
   }

--- a/src/test/unit/java/com/bob/infra/auth/service/TokenServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/TokenServiceTest.java
@@ -1,0 +1,87 @@
+package com.bob.infra.auth.service;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
+import com.bob.infra.auth.filter.port.AuthRedisPort;
+import com.bob.infra.auth.jwt.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("토큰 재발급 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+  @InjectMocks
+  private TokenService tokenService;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private AuthRedisPort redisPort;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  private static final String REFRESH_COOKIE_NAME = "REFRESH_KEY";
+  private static final String NEW_ACCESS_TOKEN = "new-access-token";
+  private static final String OLD_REFRESH_KEY = "old-refresh-key";
+
+  @BeforeEach
+  void setupRequestCookie() {
+    Cookie[] cookies = new Cookie[]{
+        new Cookie(REFRESH_COOKIE_NAME, OLD_REFRESH_KEY)
+    };
+    given(request.getCookies()).willReturn(cookies);
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 성공 테스트")
+  void 쿠키가_존재하면_토큰을_재발급하고_SetCookie헤더를_추가한다() {
+    // given
+    given(request.getCookies()).willReturn(new Cookie[]{new Cookie("REFRESH_KEY", OLD_REFRESH_KEY)});
+    given(redisPort.updateRefreshKey(eq(OLD_REFRESH_KEY), anyString(), eq(null))).willReturn(MEMBER_ID.toString());
+    given(jwtProvider.generateAccessToken(MEMBER_ID.toString())).willReturn(NEW_ACCESS_TOKEN);
+
+    // when
+    tokenService.reIssueTokenProcess(request, response);
+
+    // then
+    verify(redisPort).updateRefreshKey(eq(OLD_REFRESH_KEY), anyString(), eq(null));
+    verify(jwtProvider).generateAccessToken(MEMBER_ID.toString());
+    verify(response, times(2)).addHeader(eq("Set-Cookie"), anyString());
+  }
+
+
+
+  @Test
+  @DisplayName("토큰 재발급 실패 테스트 - 쿠키 없음")
+  void 쿠키가_없으면_예외가_발생한다() {
+    // given
+    given(request.getCookies()).willReturn(null);
+
+    // when & then
+    assertThatThrownBy(() -> tokenService.reIssueTokenProcess(request, response))
+        .isInstanceOf(ApplicationAuthenticationException.class)
+        .hasMessage(AuthenticationError.FAILED_GET_AUTHENTICATION_INFORMATION.getMessage());
+  }
+}

--- a/src/test/unit/java/com/bob/infra/redis/adapter/in/AuthRedisAdapterTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/adapter/in/AuthRedisAdapterTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.verify;
 
 import com.bob.infra.redis.repository.RedisRepository;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,9 +36,10 @@ class AuthRedisAdapterTest {
   void 기존_key가_존재하면_삭제하고_새로운_key를_저장한다() {
     // given
     given(redisRepository.isExist("refresh:" + OLD_KEY)).willReturn(true);
+    given(redisRepository.getValue("refresh:" + OLD_KEY)).willReturn(Optional.of(VALUE));
 
     // when
-    authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, VALUE, EXPIRE_DAYS);
+    authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, VALUE);
 
     // then
     verify(redisRepository).delete("refresh:" + OLD_KEY);
@@ -48,7 +50,7 @@ class AuthRedisAdapterTest {
   @DisplayName("refresh key 업데이트 테스트 - 기존 key가 null이면 새로운 key만 저장")
   void 기존_key가_null이면_새로운_key만_저장한다() {
     // when
-    authRedisAdapter.updateRefreshKey(null, NEW_KEY, VALUE, EXPIRE_DAYS);
+    authRedisAdapter.updateRefreshKey(null, NEW_KEY, VALUE);
 
     // then
     verify(redisRepository, never()).delete(any());
@@ -62,7 +64,7 @@ class AuthRedisAdapterTest {
     given(redisRepository.isExist("refresh:" + OLD_KEY)).willReturn(false);
 
     // when
-    authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, VALUE, EXPIRE_DAYS);
+    authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, VALUE);
 
     // then
     verify(redisRepository, never()).delete("refresh:" + OLD_KEY);

--- a/src/test/unit/java/com/bob/infra/redis/adapter/in/AuthRedisAdapterTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/adapter/in/AuthRedisAdapterTest.java
@@ -1,0 +1,97 @@
+package com.bob.infra.redis.adapter.in;
+
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+
+import com.bob.infra.redis.repository.RedisRepository;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("인증 관련 redis adapter 테스트")
+@ExtendWith(MockitoExtension.class)
+class AuthRedisAdapterTest {
+
+  @InjectMocks
+  private AuthRedisAdapter authRedisAdapter;
+
+  @Mock
+  private RedisRepository redisRepository;
+
+  private static final String OLD_KEY = "oldKey";
+  private static final String NEW_KEY = "newKey";
+  private static final String VALUE = "refresh-token-value";
+  private static final int EXPIRE_DAYS = 14;
+
+  @Test
+  @DisplayName("refresh key 업데이트 테스트 - key 존재 시 삭제 후 새로운 key 저장")
+  void 기존_key가_존재하면_삭제하고_새로운_key를_저장한다() {
+    // given
+    given(redisRepository.isExist("refresh:" + OLD_KEY)).willReturn(true);
+
+    // when
+    authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, VALUE, EXPIRE_DAYS);
+
+    // then
+    verify(redisRepository).delete("refresh:" + OLD_KEY);
+    verify(redisRepository).setValue(eq("refresh:" + NEW_KEY), eq(VALUE), eq(Duration.ofDays(EXPIRE_DAYS)));
+  }
+
+  @Test
+  @DisplayName("refresh key 업데이트 테스트 - 기존 key가 null이면 새로운 key만 저장")
+  void 기존_key가_null이면_새로운_key만_저장한다() {
+    // when
+    authRedisAdapter.updateRefreshKey(null, NEW_KEY, VALUE, EXPIRE_DAYS);
+
+    // then
+    verify(redisRepository, never()).delete(any());
+    verify(redisRepository).setValue(eq("refresh:" + NEW_KEY), eq(VALUE), eq(Duration.ofDays(EXPIRE_DAYS)));
+  }
+
+  @Test
+  @DisplayName("refresh key 업데이트 테스트 - 기존 key가 존재하지 않으면 새로운 key만 저장")
+  void 기존_key가_존재하지_않으면_새로운_key만_저장한다() {
+    // given
+    given(redisRepository.isExist("refresh:" + OLD_KEY)).willReturn(false);
+
+    // when
+    authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, VALUE, EXPIRE_DAYS);
+
+    // then
+    verify(redisRepository, never()).delete("refresh:" + OLD_KEY);
+    verify(redisRepository).setValue(eq("refresh:" + NEW_KEY), eq(VALUE), eq(Duration.ofDays(EXPIRE_DAYS)));
+  }
+
+  @Test
+  @DisplayName("refresh key 삭제 테스트 - key가 존재하면 삭제")
+  void key가_존재하면_삭제한다() {
+    // given
+    given(redisRepository.isExist("refresh:" + NEW_KEY)).willReturn(true);
+
+    // when
+    authRedisAdapter.removeRefreshKey(NEW_KEY);
+
+    // then
+    verify(redisRepository).delete("refresh:" + NEW_KEY);
+  }
+
+  @Test
+  @DisplayName("refresh key 삭제 테스트 - key가 존재하지 않으면 아무 동작 없음")
+  void key가_존재하지_않으면_아무_동작도_하지_않는다() {
+    // given
+    given(redisRepository.isExist("refresh:" + NEW_KEY)).willReturn(false);
+
+    // when
+    authRedisAdapter.removeRefreshKey(NEW_KEY);
+
+    // then
+    verify(redisRepository, never()).delete(any());
+  }
+}

--- a/src/test/unit/java/com/bob/infra/redis/adapter/in/AuthRedisAdapterTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/adapter/in/AuthRedisAdapterTest.java
@@ -1,11 +1,17 @@
 package com.bob.infra.redis.adapter.in;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.verify;
 
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
+import com.bob.global.exception.response.AuthenticationError;
 import com.bob.infra.redis.repository.RedisRepository;
 import java.time.Duration;
 import java.util.Optional;
@@ -69,6 +75,27 @@ class AuthRedisAdapterTest {
     // then
     verify(redisRepository, never()).delete("refresh:" + OLD_KEY);
     verify(redisRepository).setValue(eq("refresh:" + NEW_KEY), eq(VALUE), eq(Duration.ofDays(EXPIRE_DAYS)));
+  }
+
+  @Test
+  @DisplayName("refresh key 업데이트 테스트 - key가 존재하지만 조작된 경우 예외 발생")
+  void key가_존재하지만_조작된_경우_예외가_발생한다() {
+    // given
+    given(redisRepository.isExist("refresh:" + OLD_KEY)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> authRedisAdapter.updateRefreshKey(OLD_KEY, NEW_KEY, null))
+        .isInstanceOf(ApplicationAuthenticationException.class)
+        .hasMessage(AuthenticationError.FAILED_GET_AUTHENTICATION_INFORMATION.getMessage());
+  }
+
+  @Test
+  @DisplayName("refresh key 업데이트 테스트 - 새로운 key의 value가 null이면 예외 발생")
+  void 새로운_key의_value가_null이면_예외가_발생한다() {
+    // when & then
+    assertThatThrownBy(() -> authRedisAdapter.updateRefreshKey(null, NEW_KEY, null))
+        .isInstanceOf(ApplicationAuthenticationException.class)
+        .hasMessage(AuthenticationError.FAILED_GET_AUTHENTICATION_INFORMATION.getMessage());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/infra/redis/repository/RedisRepositoryTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/repository/RedisRepositoryTest.java
@@ -62,6 +62,21 @@ class RedisRepositoryTest {
   }
 
   @Test
+  @DisplayName("Redis 값 조회 - 존재하지 않는 key면 빈 Optional을 반환한다")
+  void redis에_key가_없으면_optional_empty를_반환한다() {
+    // given
+    String key = "missing-key";
+    given(redisTemplate.hasKey(key)).willReturn(false);
+
+    // when
+    Optional<String> result = redisRepository.getValue(key);
+
+    // then
+    assertThat(result).isEmpty();
+    then(redisTemplate).should().hasKey(key);
+  }
+
+  @Test
   @DisplayName("Redis 값 삭제 - 성공 테스트")
   void redis에서_값을_삭제할_수_있다() {
     // given

--- a/src/test/unit/java/com/bob/infra/redis/repository/RedisRepositoryTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/repository/RedisRepositoryTest.java
@@ -51,6 +51,7 @@ class RedisRepositoryTest {
     String key = "test-key";
     String value = "test-value";
     given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    given(redisTemplate.hasKey(key)).willReturn(true);
     given(valueOperations.get(key)).willReturn(value);
 
     // when

--- a/src/test/unit/java/com/bob/infra/redis/repository/RedisRepositoryTest.java
+++ b/src/test/unit/java/com/bob/infra/redis/repository/RedisRepositoryTest.java
@@ -72,4 +72,34 @@ class RedisRepositoryTest {
     // then
     then(redisTemplate).should().delete(key);
   }
+
+  @Test
+  @DisplayName("key 존재 여부 반환 테스트")
+  void redis에_key가_존재하는지_확인할_수_있다() {
+    // given
+    String key = "exist-key";
+    given(redisTemplate.hasKey(key)).willReturn(true);
+
+    // when
+    boolean result = redisRepository.isExist(key);
+
+    // then
+    assertThat(result).isTrue();
+    then(redisTemplate).should().hasKey(key);
+  }
+
+  @Test
+  @DisplayName("key 존재 여부 반환 테스트 - 존재하지 않는 경우")
+  void redis에_key가_없으면_false를_반환한다() {
+    // given
+    String key = "missing-key";
+    given(redisTemplate.hasKey(key)).willReturn(false);
+
+    // when
+    boolean result = redisRepository.isExist(key);
+
+    // then
+    assertThat(result).isFalse();
+    then(redisTemplate).should().hasKey(key);
+  }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #80 

### 📜 작업 내용
- [x] refresh token 검증 및 access token 발급
- [x] 인증 실패 응답 메시지 통일 ("인증에 실패하였습니다.")
- [x] 선택적 인증 요청 토큰이 만료된 경우 서버 자체 로그아웃

### ⚠️ 종료할 이슈
this closes #80 
