### PR TITLE
feat#25: 미참조 파일 삭제 스케줄러 등록

### DIFF
--- a/src/main/java/com/bob/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/bob/domain/file/repository/FileRepository.java
@@ -10,5 +10,7 @@ public interface FileRepository extends CrudRepository<File, Long> {
 
   List<File> findByDomainAndReferenceId(FileDomain domain, String referenceId);
 
+  List<File> findByReferenceIdIsNull();
+
   Optional<File> findByFileName(String fileName);
 }

--- a/src/main/java/com/bob/domain/file/service/FileService.java
+++ b/src/main/java/com/bob/domain/file/service/FileService.java
@@ -16,7 +16,7 @@ import com.bob.domain.file.service.dto.query.ReadFilesWithDomainIdQuery;
 import com.bob.domain.file.service.dto.response.FileUploadUrlResponse;
 import com.bob.domain.file.service.dto.response.FilesResponse;
 import com.bob.domain.file.service.dto.response.internal.FileSummaryResponse;
-import com.bob.domain.file.service.port.FileImagePort;
+import com.bob.domain.file.service.port.FileS3Port;
 import com.bob.domain.file.service.reader.FileReader;
 import com.bob.domain.file.usecase.FileModifyUseCase;
 import com.bob.domain.file.usecase.FileReadUseCase;
@@ -36,7 +36,7 @@ public class FileService implements FileWriteUseCase, FileReadUseCase, FileModif
   private final FileRepository fileRepository;
   private final FileReader fileReader;
 
-  private final FileImagePort imagePort;
+  private final FileS3Port imagePort;
 
   @Transactional
   public void registerFileProcess(RegisterFileCommand command) {
@@ -69,6 +69,13 @@ public class FileService implements FileWriteUseCase, FileReadUseCase, FileModif
       fileReader.readFileByFileName(fileName)
           .ifPresent(file -> file.mappingDomainId(index, String.valueOf(command.domainId())));
     });
+  }
+
+  @Transactional
+  public void removeUnusedFilesProcess() {
+    List<File> files = fileReader.readUnusedFiles();
+    fileRepository.deleteAll(files);
+    imagePort.removeUnusedFilesProcess(files.stream().map(File::getFileName).toList());
   }
 
   public FileUploadUrlResponse generateFileUploadUrl(GenerateFileUploadUrlCommand command) {

--- a/src/main/java/com/bob/domain/file/service/port/FileS3Port.java
+++ b/src/main/java/com/bob/domain/file/service/port/FileS3Port.java
@@ -2,7 +2,9 @@ package com.bob.domain.file.service.port;
 
 import java.util.List;
 
-public interface FileImagePort {
+public interface FileS3Port {
 
   List<String> generateFileUploadUrlsProcess(List<String> fileNames, List<String> contentTypes);
+
+  void removeUnusedFilesProcess(List<String> fileNames);
 }

--- a/src/main/java/com/bob/domain/file/service/reader/FileReader.java
+++ b/src/main/java/com/bob/domain/file/service/reader/FileReader.java
@@ -20,6 +20,10 @@ public class FileReader {
     return fileRepository.findByDomainAndReferenceId(domain, refId);
   }
 
+  public List<File> readUnusedFiles() {
+    return fileRepository.findByReferenceIdIsNull();
+  }
+
   public Optional<File> readFileByFileName(String fileName) {
     return fileRepository.findByFileName(fileName);
   }

--- a/src/main/java/com/bob/domain/file/service/scheduler/FileCleanupScheduler.java
+++ b/src/main/java/com/bob/domain/file/service/scheduler/FileCleanupScheduler.java
@@ -1,0 +1,27 @@
+package com.bob.domain.file.service.scheduler;
+
+import com.bob.domain.file.service.FileService;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class FileCleanupScheduler {
+
+  private final FileService fileService;
+
+  @Scheduled(cron = "0 0 1 * * 1")
+  public void removeUnusedFiles() {
+    log.info("unused file remove scheduler started at {}", LocalDateTime.now());
+    try {
+      fileService.removeUnusedFilesProcess();
+      log.info("unused file removal completed successfully");
+    } catch (Exception e) {
+      log.error("unused file removal failed", e);
+    }
+  }
+}

--- a/src/main/java/com/bob/infra/aws/adapter/in/FileImageAdapter.java
+++ b/src/main/java/com/bob/infra/aws/adapter/in/FileImageAdapter.java
@@ -1,19 +1,26 @@
 package com.bob.infra.aws.adapter.in;
 
-import com.bob.domain.file.service.port.FileImagePort;
-import com.bob.infra.aws.service.usecase.ImageUrlReadUseCase;
+import com.bob.domain.file.service.port.FileS3Port;
+import com.bob.infra.aws.service.usecase.FileDeleteUseCase;
+import com.bob.infra.aws.service.usecase.FileReadUseCase;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class FileImageAdapter implements FileImagePort {
+public class FileImageAdapter implements FileS3Port {
 
-  private final ImageUrlReadUseCase readUseCase;
+  private final FileReadUseCase readUseCase;
+  private final FileDeleteUseCase deleteUseCase;
 
   @Override
   public List<String> generateFileUploadUrlsProcess(List<String> fileNames, List<String> contentTypes) {
-    return readUseCase.generateImageUploadUrlProcess(fileNames, contentTypes);
+    return readUseCase.generateFileUploadUrlProcess(fileNames, contentTypes);
+  }
+
+  @Override
+  public void removeUnusedFilesProcess(List<String> fileNames) {
+    deleteUseCase.removeFilesProcess(fileNames);
   }
 }

--- a/src/main/java/com/bob/infra/aws/service/S3ImageService.java
+++ b/src/main/java/com/bob/infra/aws/service/S3ImageService.java
@@ -1,21 +1,26 @@
 package com.bob.infra.aws.service;
 
-import com.bob.infra.aws.service.usecase.ImageUrlReadUseCase;
+import com.bob.infra.aws.service.usecase.FileDeleteUseCase;
+import com.bob.infra.aws.service.usecase.FileReadUseCase;
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
-public class S3ImageService implements ImageUrlReadUseCase {
+public class S3ImageService implements FileReadUseCase, FileDeleteUseCase {
 
+  private final S3Client client;
   private final S3Presigner signer;
 
   @Value("${spring.cloud.aws.s3.bucket}")
@@ -28,7 +33,7 @@ public class S3ImageService implements ImageUrlReadUseCase {
     return putRequest.url().toString();
   }
 
-  public List<String> generateImageUploadUrlProcess(List<String> fileNames, List<String> contentTypes) {
+  public List<String> generateFileUploadUrlProcess(List<String> fileNames, List<String> contentTypes) {
     return IntStream.range(0, fileNames.size())
         .mapToObj(idx -> issuePresignedImageUploadUrlProcess(fileNames.get(idx), contentTypes.get(idx)))
         .toList();
@@ -47,5 +52,19 @@ public class S3ImageService implements ImageUrlReadUseCase {
         .key(key)
         .contentType(contentType)
         .build();
+  }
+
+  @Override
+  public void removeFilesProcess(List<String> fileNames) {
+    fileNames.forEach(fileName -> {
+      try {
+        client.deleteObject(builder -> builder
+            .bucket(bucketName)
+            .key(fileName)
+        );
+      } catch (Exception e) {
+        log.warn("failed to delete file from S3: {}", fileName, e);
+      }
+    });
   }
 }

--- a/src/main/java/com/bob/infra/aws/service/usecase/FileDeleteUseCase.java
+++ b/src/main/java/com/bob/infra/aws/service/usecase/FileDeleteUseCase.java
@@ -1,0 +1,8 @@
+package com.bob.infra.aws.service.usecase;
+
+import java.util.List;
+
+public interface FileDeleteUseCase {
+
+  void removeFilesProcess(List<String> fileNames);
+}

--- a/src/main/java/com/bob/infra/aws/service/usecase/FileReadUseCase.java
+++ b/src/main/java/com/bob/infra/aws/service/usecase/FileReadUseCase.java
@@ -1,0 +1,8 @@
+package com.bob.infra.aws.service.usecase;
+
+import java.util.List;
+
+public interface FileReadUseCase {
+
+  List<String> generateFileUploadUrlProcess(List<String> fileNames, List<String> contentTypes);
+}

--- a/src/main/java/com/bob/infra/aws/service/usecase/ImageUrlReadUseCase.java
+++ b/src/main/java/com/bob/infra/aws/service/usecase/ImageUrlReadUseCase.java
@@ -1,8 +1,0 @@
-package com.bob.infra.aws.service.usecase;
-
-import java.util.List;
-
-public interface ImageUrlReadUseCase {
-
-  List<String> generateImageUploadUrlProcess(List<String> fileNames, List<String> contentTypes);
-}

--- a/src/test/intg/java/com/bob/domain/file/service/FileServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/file/service/FileServiceIntgTest.java
@@ -7,11 +7,13 @@ import static com.bob.support.fixture.command.ChangeFileCommandFixture.DEFAULT_C
 import static com.bob.support.fixture.command.CreatePostCommandFixture.FILE_NAMES;
 import static com.bob.support.fixture.command.RegisterFileCommandFixture.defaultRegisterFileCommand;
 import static com.bob.support.fixture.domain.FileFixture.customRefIdFiles;
+import static com.bob.support.fixture.domain.FileFixture.defaultFile;
 import static com.bob.support.fixture.domain.FileFixture.defaultFiles;
 import static com.bob.support.fixture.domain.FileFixture.otherFiles;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.bob.domain.file.entity.File;
 import com.bob.domain.file.repository.FileRepository;
@@ -21,7 +23,7 @@ import com.bob.domain.file.service.dto.command.GenerateFileUploadUrlCommand;
 import com.bob.domain.file.service.dto.query.ReadFilesWithDomainIdQuery;
 import com.bob.domain.file.service.dto.response.FileUploadUrlResponse;
 import com.bob.domain.file.service.dto.response.FilesResponse;
-import com.bob.domain.file.service.port.FileImagePort;
+import com.bob.domain.file.service.port.FileS3Port;
 import com.bob.domain.file.service.reader.FileReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.utils.image.ImageDirectory;
@@ -51,7 +53,7 @@ class FileServiceIntgTest extends TestContainerSupport {
   private FileReader fileReader;
 
   @MockitoBean
-  private FileImagePort imagePort;
+  private FileS3Port imagePort;
 
   @DisplayName("파일 등록 테스트")
   @Test
@@ -184,5 +186,24 @@ class FileServiceIntgTest extends TestContainerSupport {
           .extracting("fileUploadUrl")
           .containsExactlyElementsOf(urls);
     }
+  }
+
+  @DisplayName("미참조 파일 삭제 테스트")
+  @Test
+  void 참조되지_않은_파일들을_삭제할_수_있다() {
+    // given
+    fileRepository.saveAll(List.of(
+            defaultFile("unusedFile1.png", 0, null),
+            defaultFile("unusedFile2.png", 0, null)
+        )
+    );
+    assertThat(fileRepository.findByReferenceIdIsNull()).hasSize(2);
+
+    // when
+    fileService.removeUnusedFilesProcess();
+
+    // then
+    then(imagePort).should().removeUnusedFilesProcess(List.of("unusedFile1.png", "unusedFile2.png"));
+    assertThat(fileRepository.findByReferenceIdIsNull()).hasSize(0);
   }
 }

--- a/src/test/unit/java/com/bob/domain/file/service/FileServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/file/service/FileServiceTest.java
@@ -5,6 +5,7 @@ import static com.bob.global.exception.response.ApplicationError.FILE_UNAUTHORIZ
 import static com.bob.support.fixture.command.ChangeFileCommandFixture.DEFAULT_CHANGE_FILE_COMMAND_REF_ID_1;
 import static com.bob.support.fixture.command.CreatePostCommandFixture.FILE_NAMES;
 import static com.bob.support.fixture.command.RegisterFileCommandFixture.defaultRegisterFileCommand;
+import static com.bob.support.fixture.domain.FileFixture.defaultFile;
 import static com.bob.support.fixture.domain.FileFixture.defaultFiles;
 import static com.bob.support.fixture.domain.FileFixture.otherFiles;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,7 +19,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
 import com.bob.domain.file.entity.File;
-import com.bob.domain.file.entity.type.FileDomain;
 import com.bob.domain.file.repository.FileRepository;
 import com.bob.domain.file.service.dto.command.ModifyReferenceIdCommand;
 import com.bob.domain.file.service.dto.command.RegisterFileCommand;
@@ -26,7 +26,7 @@ import com.bob.domain.file.service.dto.command.GenerateFileUploadUrlCommand;
 import com.bob.domain.file.service.dto.query.ReadFilesWithDomainIdQuery;
 import com.bob.domain.file.service.dto.response.FileUploadUrlResponse;
 import com.bob.domain.file.service.dto.response.FilesResponse;
-import com.bob.domain.file.service.port.FileImagePort;
+import com.bob.domain.file.service.port.FileS3Port;
 import com.bob.domain.file.service.reader.FileReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.utils.image.ImageUtils;
@@ -54,7 +54,7 @@ class FileServiceTest {
   private FileReader fileReader;
 
   @Mock
-  private FileImagePort imagePort;
+  private FileS3Port imagePort;
 
   @DisplayName("파일 등록 - 성공 테스트")
   @Test
@@ -181,5 +181,24 @@ class FileServiceTest {
 
       then(imagePort).should().generateFileUploadUrlsProcess(fileNames, contentTypes);
     }
+  }
+
+  @DisplayName("참조되지 않는 파일 삭제 테스트")
+  @Test
+  void 사용되지_않은_파일들을_삭제할_수_있다() {
+    // given
+    List<File> unusedFiles = List.of(
+        defaultFile("unusedFile1.png", 0, null),
+        defaultFile("unusedFile2.png", 0, null)
+    );
+    given(fileReader.readUnusedFiles()).willReturn(unusedFiles);
+
+    // when
+    fileService.removeUnusedFilesProcess();
+
+    // then
+    then(fileReader).should().readUnusedFiles();
+    then(fileRepository).should().deleteAll(unusedFiles);
+    then(imagePort).should().removeUnusedFilesProcess(List.of("unusedFile1.png", "unusedFile2.png"));
   }
 }

--- a/src/test/unit/java/com/bob/domain/file/service/reader/FileReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/file/service/reader/FileReaderTest.java
@@ -45,6 +45,24 @@ class FileReaderTest {
   }
 
   @Test
+  @DisplayName("참조되지 않은 파일 목록 조회 테스트")
+  void 참조되지_않은_파일_목록을_조회한다() {
+    // given
+    List<File> unusedFiles = List.of(
+        defaultFile("file1.png", 0, null),
+        defaultFile("file2.png", 0, null)
+    );
+    given(fileRepository.findByReferenceIdIsNull()).willReturn(unusedFiles);
+
+    // when
+    List<File> result = fileReader.readUnusedFiles();
+
+    // then
+    assertThat(result).containsExactlyElementsOf(unusedFiles);
+    verify(fileRepository).findByReferenceIdIsNull();
+  }
+
+  @Test
   @DisplayName("파일 이름을 통한 파일 조회 테스트")
   void referenceId로_파일_목록을_조회한다() {
     // given

--- a/src/test/unit/java/com/bob/domain/file/service/scheduler/FileCleanupSchedulerTest.java
+++ b/src/test/unit/java/com/bob/domain/file/service/scheduler/FileCleanupSchedulerTest.java
@@ -1,0 +1,61 @@
+package com.bob.domain.file.service.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.bob.domain.file.service.FileService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+@DisplayName("파일 정리 스케줄러 테스트")
+@ExtendWith(MockitoExtension.class)
+class FileCleanupSchedulerTest {
+
+  @InjectMocks
+  private FileCleanupScheduler scheduler;
+
+  @Mock
+  private FileService fileService;
+
+  @Test
+  @DisplayName("미참조 파일 삭제 서비스 메서드 호출 테스트")
+  void 사용되지_않은_파일들을_성공적으로_삭제한다() {
+    // when
+    scheduler.removeUnusedFiles();
+
+    // then
+    verify(fileService, times(1)).removeUnusedFilesProcess();
+  }
+
+  @Test
+  @DisplayName("파일 정리 중 예외가 발생해도 로그만 찍고 종료된다")
+  void 파일_정리_중_예외가_발생해도_정상적으로_처리된다() {
+    // given
+    doThrow(new RuntimeException("S3 삭제 실패")).when(fileService).removeUnusedFilesProcess();
+    Logger logger = (Logger) LoggerFactory.getLogger(FileCleanupScheduler.class);
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+
+    // when
+    scheduler.removeUnusedFiles();
+
+    // then
+    verify(fileService).removeUnusedFilesProcess();
+    List<String> logs = listAppender.list.stream()
+        .map(ILoggingEvent::getFormattedMessage)
+        .toList();
+    assertThat(logs).anyMatch(msg -> msg.contains("unused file removal failed"));
+  }
+}

--- a/src/test/unit/java/com/bob/infra/aws/adapter/S3ImageServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/aws/adapter/S3ImageServiceTest.java
@@ -1,6 +1,7 @@
 package com.bob.infra.aws.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -10,14 +11,21 @@ import static org.mockito.Mockito.verify;
 import com.bob.infra.aws.service.S3ImageService;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -28,6 +36,9 @@ class S3ImageServiceTest {
 
   @InjectMocks
   private S3ImageService imageService;
+
+  @Mock
+  private S3Client client;
 
   @Mock
   private S3Presigner signer;
@@ -55,5 +66,63 @@ class S3ImageServiceTest {
     // then
     assertThat(result).isEqualTo(uri.toString());
     verify(signer, times(1)).presignPutObject(any(PutObjectPresignRequest.class));
+  }
+
+  @DisplayName("다중 Presigned PUT URL 생성 테스트")
+  @Test
+  void 다중_업로드_요청에_대한_URL들을_생성할_수_있다() throws MalformedURLException {
+    // given
+    List<String> fileNames = List.of("img1.jpg", "img2.jpg");
+    List<String> contentTypes = List.of("image/jpeg", "image/jpeg");
+    URI dummyUrl1 = URI.create("https://dummy-s3.com/" + fileNames.get(0));
+    URI dummyUrl2 = URI.create("https://dummy-s3.com/" + fileNames.get(1));
+    PresignedPutObjectRequest presigned1 = mock(PresignedPutObjectRequest.class);
+    PresignedPutObjectRequest presigned2 = mock(PresignedPutObjectRequest.class);
+    given(presigned1.url()).willReturn(dummyUrl1.toURL());
+    given(presigned2.url()).willReturn(dummyUrl2.toURL());
+    given(signer.presignPutObject(any(PutObjectPresignRequest.class))).willReturn(presigned1, presigned2);
+
+    // when
+    List<String> result = imageService.generateFileUploadUrlProcess(fileNames, contentTypes);
+
+    // then
+    assertThat(result).containsExactly(
+        dummyUrl1.toString(),
+        dummyUrl2.toString()
+    );
+    verify(signer, times(2)).presignPutObject(any(PutObjectPresignRequest.class));
+  }
+
+  @DisplayName("PutObjectRequest, PresignRequest 생성 로직 테스트")
+  @Test
+  void 파일저장_URL생성_요청과_파일저장_요청을_할_수_있다() {
+    // given
+    String key = "test.jpg";
+    String contentType = "image/jpeg";
+
+    // when
+    PutObjectRequest request = ReflectionTestUtils.invokeMethod(imageService, "createPutObjectRequest", key, contentType);
+    PutObjectPresignRequest presignRequest = ReflectionTestUtils.invokeMethod(imageService, "createPutObjectPresignRequest", request);
+
+    // then
+    assertThat(request.bucket()).isEqualTo("bucket");
+    assertThat(request.key()).isEqualTo("test.jpg");
+    assertThat(request.contentType()).isEqualTo("image/jpeg");
+
+    assertThat(presignRequest.putObjectRequest()).isEqualTo(request);
+    assertThat(presignRequest.signatureDuration()).isEqualTo(Duration.ofMinutes(1));
+  }
+
+  @DisplayName("S3 파일 삭제 테스트")
+  @Test
+  void 파일들을_S3에서_삭제할_수_있다() {
+    // given
+    List<String> fileNames = List.of("a.png", "b.jpg");
+
+    // when
+    imageService.removeFilesProcess(fileNames);
+
+    // then
+    verify(client, times(fileNames.size())).deleteObject(any(Consumer.class));
   }
 }

--- a/src/test/unit/java/com/bob/infra/aws/adapter/in/FileImageAdapterTest.java
+++ b/src/test/unit/java/com/bob/infra/aws/adapter/in/FileImageAdapterTest.java
@@ -2,8 +2,10 @@ package com.bob.infra.aws.adapter.in;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
-import com.bob.infra.aws.service.usecase.ImageUrlReadUseCase;
+import com.bob.infra.aws.service.usecase.FileDeleteUseCase;
+import com.bob.infra.aws.service.usecase.FileReadUseCase;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,11 +18,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class FileImageAdapterTest {
 
-  @Mock
-  private ImageUrlReadUseCase readUseCase;
-
   @InjectMocks
   private FileImageAdapter adapter;
+
+  @Mock
+  private FileReadUseCase readUseCase;
+
+  @Mock
+  private FileDeleteUseCase deleteUseCase;
 
   @Test
   @DisplayName("presigned URL 생성 테스트")
@@ -29,12 +34,25 @@ class FileImageAdapterTest {
     List<String> fileNames = List.of("profile/a.jpg", "profile/b.jpg");
     List<String> contentTypes = List.of("image/jpeg", "image/jpeg");
     List<String> expectedUrls = List.of("url1", "url2");
-    given(readUseCase.generateImageUploadUrlProcess(fileNames, contentTypes)).willReturn(expectedUrls);
+    given(readUseCase.generateFileUploadUrlProcess(fileNames, contentTypes)).willReturn(expectedUrls);
 
     // when
     List<String> result = adapter.generateFileUploadUrlsProcess(fileNames, contentTypes);
 
     // then
     assertThat(result).isEqualTo(expectedUrls);
+  }
+
+  @Test
+  @DisplayName("파일 삭제 테스트")
+  void 사용되지_않은_파일들을_삭제할_수_있다() {
+    // given
+    List<String> fileNames = List.of("file1.jpg", "file2.jpg");
+
+    // when
+    adapter.removeUnusedFilesProcess(fileNames);
+
+    // then
+    verify(deleteUseCase).removeFilesProcess(fileNames);
   }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
> #25 

### 📜 작업 내용
- [x] 파일 삭제 기능 구현
- [x] 게시글, 프로필, 채팅 등에서 사용되지 않는 미참조 파일 삭제 스케줄러 등록
  - file 테이블 데이터 삭제
  - s3 object 삭제

### ⚠️ 종료할 이슈
this closes #25 
