### PR TITLE
fix#87: 비로그인 사용자의 알림 구독 예외 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ out/
 
 ### VS Code ###
 .vscode/
-
+/docker-compose.yml
 /src/main/resources/application-local.yml
 /src/main/resources/application-prod.yml
 /src/main/resources/application-secret.yml

--- a/src/main/java/com/bob/global/event/sse/manager/EmitterManager.java
+++ b/src/main/java/com/bob/global/event/sse/manager/EmitterManager.java
@@ -71,7 +71,7 @@ public class EmitterManager implements Runnable {
       try {
         emitter.send(SseEmitter.event().name(HEARTBEAT.name()).data("ping"));
       } catch (Exception e) {
-        log.debug("Heartbeat failed for key: {}, removing emitter", key);
+        log.debug("Failed to send heartbeat for key: {}, removing emitter", key);
         removeEmitter(emitter, key, repository);
       }
     });

--- a/src/main/java/com/bob/global/exception/response/AuthenticationError.java
+++ b/src/main/java/com/bob/global/exception/response/AuthenticationError.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum AuthenticationError {
   FAILED_AUTHENTICATION("E001", "인증에 실패하였습니다."),
-  IS_EXPIRED_TOKEN("E002", "만료된 토큰입니다."),
+  IS_EXPIRED_TOKEN("E002", "인증 정보가 만료되었습니다."),
   FAILED_GET_AUTHENTICATION_INFORMATION("E003", "인증 정보를 확인할 수 없습니다. 다시 로그인 해주세요.");
 
   private String code;

--- a/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -36,13 +36,18 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
   private final JwtProvider jwtProvider;
 
   @Override
+  protected boolean shouldNotFilterAsyncDispatch() {
+    return false;
+  }
+
+  @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
     if (registry.isWhiteList(request)) {
       filterChain.doFilter(request, response);
       return;
     }
 
-    String accessToken = getCookie(request, ACCESS_COOKIE_NAME);
+    final String accessToken = getCookie(request, ACCESS_COOKIE_NAME);
 
     if (optionalRegistry.isOptionalAuth(request)) {
       if (accessToken == null) {
@@ -61,8 +66,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       return;
     }
 
-    MemberDetails memberDetails = new MemberDetails(jwtProvider.getMemberId(accessToken));
-    Authentication authentication = new UsernamePasswordAuthenticationToken(
+    final MemberDetails memberDetails = new MemberDetails(jwtProvider.getMemberId(accessToken));
+    final Authentication authentication = new UsernamePasswordAuthenticationToken(
         memberDetails, null, memberDetails.getAuthorities()
     );
     SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/bob/infra/config/SecurityConfig.java
+++ b/src/main/java/com/bob/infra/config/SecurityConfig.java
@@ -40,7 +40,6 @@ public class SecurityConfig {
 
   private static final String[] AUTH_WHITELIST = {
       "/auth/**", "/ai/**", "/areas/**", "/members/temp/**",
-      "/chatrooms/*/subscribe", "/notifications/subscribe",
       "/h2-console/**",
       "/error/**",
   };

--- a/src/main/java/com/bob/infra/config/registry/PermitAllRegistry.java
+++ b/src/main/java/com/bob/infra/config/registry/PermitAllRegistry.java
@@ -22,9 +22,7 @@ public class PermitAllRegistry {
       new AntPathRequestMatcher("/members", POST.name()),
       new AntPathRequestMatcher("/members/temp/**", PATCH.name()),
       new AntPathRequestMatcher("/members/{memberId:\\d+}", GET.name()),
-      new AntPathRequestMatcher("/posts", GET.name()),
-      new AntPathRequestMatcher("/chatrooms/*/subscribe", GET.name()),
-      new AntPathRequestMatcher("/notifications/subscribe", GET.name())
+      new AntPathRequestMatcher("/posts", GET.name())
   );
 
   public boolean isWhiteList(HttpServletRequest request) {

--- a/src/main/java/com/bob/web/chat/controller/ChatStreamController.java
+++ b/src/main/java/com/bob/web/chat/controller/ChatStreamController.java
@@ -1,16 +1,11 @@
 package com.bob.web.chat.controller;
 
-import static com.bob.global.utils.web.CookieUtils.getCookie;
-
 import com.bob.domain.chat.service.dto.command.EnterChatRoomCommand;
 import com.bob.domain.chat.service.dto.query.ValidateParticipantQuery;
 import com.bob.domain.chat.usecase.ChatRoomModifyUseCase;
 import com.bob.domain.chat.usecase.ChatRoomReadUseCase;
 import com.bob.global.event.sse.manager.EmitterManager;
-import com.bob.global.exception.exceptions.ApplicationException;
-import com.bob.global.exception.response.ApplicationError;
-import com.bob.infra.auth.jwt.JwtProvider;
-import jakarta.servlet.http.HttpServletRequest;
+import com.bob.web.common.AuthenticationId;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,22 +23,11 @@ public class ChatStreamController {
   private final ChatRoomModifyUseCase modifyUseCase;
 
   private final EmitterManager emitterManager;
-  private final JwtProvider jwtProvider;
 
   @GetMapping("/{chatRoomId}/subscribe")
-  public SseEmitter handleSubscribeChat(@PathVariable Long chatRoomId, HttpServletRequest request) {
-    String token = getCookie(request, "AUTHORIZATION");
-    verifyAuthenticationRequest(token);
-
-    UUID memberId = jwtProvider.getMemberId(token);
+  public SseEmitter handleSubscribeChat(@PathVariable Long chatRoomId, @AuthenticationId UUID memberId) {
     readUseCase.validateParticipant(ValidateParticipantQuery.of(chatRoomId, memberId));
     modifyUseCase.enterChatRoomProcess(EnterChatRoomCommand.of(chatRoomId, memberId));
     return emitterManager.subscribeToChat(chatRoomId, memberId);
-  }
-
-  private void verifyAuthenticationRequest(String token) {
-    if (token == null || !jwtProvider.isVerified(token)) {
-      throw new ApplicationException(ApplicationError.AUTHENTICATION_FAILED);
-    }
   }
 }

--- a/src/main/java/com/bob/web/notification/controller/NotiStreamController.java
+++ b/src/main/java/com/bob/web/notification/controller/NotiStreamController.java
@@ -1,12 +1,8 @@
 package com.bob.web.notification.controller;
 
-import static com.bob.global.utils.web.CookieUtils.getCookie;
-
 import com.bob.global.event.sse.manager.EmitterManager;
-import com.bob.global.exception.exceptions.ApplicationException;
-import com.bob.global.exception.response.ApplicationError;
-import com.bob.infra.auth.jwt.JwtProvider;
-import jakarta.servlet.http.HttpServletRequest;
+import com.bob.web.common.AuthenticationId;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,18 +15,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotiStreamController {
 
   private final EmitterManager emitterManager;
-  private final JwtProvider jwtProvider;
 
   @GetMapping("/subscribe")
-  public SseEmitter handleSubscribeNotification(HttpServletRequest request) {
-    String token = getCookie(request, "AUTHORIZATION");
-    verifyAuthenticationRequest(token);
-    return emitterManager.subscribeToNoti(jwtProvider.getMemberId(token));
-  }
-
-  private void verifyAuthenticationRequest(String token) {
-    if (token == null || !jwtProvider.isVerified(token)) {
-      throw new ApplicationException(ApplicationError.AUTHENTICATION_FAILED);
-    }
+  public SseEmitter handleSubscribeNotification(@AuthenticationId UUID memberId) {
+    return emitterManager.subscribeToNoti(memberId);
   }
 }

--- a/src/test/unit/java/com/bob/web/chat/controller/ChatStreamControllerTest.java
+++ b/src/test/unit/java/com/bob/web/chat/controller/ChatStreamControllerTest.java
@@ -13,10 +13,6 @@ import com.bob.domain.chat.usecase.ChatRoomReadUseCase;
 import com.bob.global.event.sse.manager.EmitterManager;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
-import com.bob.infra.auth.jwt.JwtProvider;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,34 +37,16 @@ class ChatStreamControllerTest {
   @Mock
   private EmitterManager emitterManager;
 
-  @Mock
-  private JwtProvider jwtProvider;
-
-  @Mock
-  private HttpServletRequest request;
-
-  private final String token = "mock.auth.token";
-
-  @BeforeEach
-  void setup() {
-    Cookie cookie = new Cookie("AUTHORIZATION", token);
-    given(request.getCookies()).willReturn(new Cookie[]{cookie});
-  }
-
   @Test
   @DisplayName("SSE 구독 - 성공 테스트")
   void 채팅방_SSE_구독에_성공한다() {
     // given
-    given(jwtProvider.isVerified(token)).willReturn(true);
-    given(jwtProvider.getMemberId(token)).willReturn(MEMBER_ID);
     given(emitterManager.subscribeToChat(1L, MEMBER_ID)).willReturn(new SseEmitter());
 
     // when
-    SseEmitter emitter = controller.handleSubscribeChat(1L, request);
+    SseEmitter emitter = controller.handleSubscribeChat(1L, MEMBER_ID);
 
     // then
-    then(jwtProvider).should().isVerified(token);
-    then(jwtProvider).should().getMemberId(token);
     then(readUseCase).should().validateParticipant(ValidateParticipantQuery.of(1L, MEMBER_ID));
     then(modifyUseCase).should().enterChatRoomProcess(EnterChatRoomCommand.of(1L, MEMBER_ID));
     then(emitterManager).should().subscribeToChat(1L, MEMBER_ID);
@@ -76,55 +54,18 @@ class ChatStreamControllerTest {
   }
 
   @Test
-  @DisplayName("SSE 구독 - 실패 테스트(토큰 없음)")
-  void 토큰이_없으면_예외가_발생한다() {
-    // given
-    given(request.getCookies()).willReturn(null);
-
-    // when & then
-    assertThatThrownBy(() -> controller.handleSubscribeChat(1L, request))
-        .isInstanceOf(ApplicationException.class)
-        .hasMessage(ApplicationError.AUTHENTICATION_FAILED.getMessage());
-
-    then(jwtProvider).shouldHaveNoInteractions();
-    then(readUseCase).shouldHaveNoInteractions();
-    then(emitterManager).shouldHaveNoInteractions();
-  }
-
-  @Test
-  @DisplayName("SSE 구독 - 실패 테스트(토큰 검증 실패)")
-  void 인증되지_않은_토큰이면_예외가_발생한다() {
-    // given
-    given(jwtProvider.isVerified(token)).willReturn(false);
-
-    // when & then
-    assertThatThrownBy(() -> controller.handleSubscribeChat(1L, request))
-        .isInstanceOf(ApplicationException.class)
-        .hasMessage(ApplicationError.AUTHENTICATION_FAILED.getMessage());
-
-    then(jwtProvider).should().isVerified(token);
-    then(jwtProvider).shouldHaveNoMoreInteractions();
-    then(readUseCase).shouldHaveNoInteractions();
-    then(emitterManager).shouldHaveNoInteractions();
-  }
-
-  @Test
   @DisplayName("SSE 구독 - 실패 테스트(채팅방 참가자가 아님)")
   void 채팅방_참가자가_아니면_예외가_발생한다() {
     // given
-    given(jwtProvider.isVerified(token)).willReturn(true);
-    given(jwtProvider.getMemberId(token)).willReturn(MEMBER_ID);
     willThrow(new ApplicationException(ApplicationError.NOT_PARTICIPATED_CHAT_ROOM))
         .given(readUseCase)
         .validateParticipant(ValidateParticipantQuery.of(1L, MEMBER_ID));
 
     // when & then
-    assertThatThrownBy(() -> controller.handleSubscribeChat(1L, request))
+    assertThatThrownBy(() -> controller.handleSubscribeChat(1L, MEMBER_ID))
         .isInstanceOf(ApplicationException.class)
         .hasMessage(ApplicationError.NOT_PARTICIPATED_CHAT_ROOM.getMessage());
 
-    then(jwtProvider).should().isVerified(token);
-    then(jwtProvider).should().getMemberId(token);
     then(readUseCase).should().validateParticipant(ValidateParticipantQuery.of(1L, MEMBER_ID));
     then(emitterManager).shouldHaveNoInteractions();
   }

--- a/src/test/unit/java/com/bob/web/notification/controller/NotiStreamControllerTest.java
+++ b/src/test/unit/java/com/bob/web/notification/controller/NotiStreamControllerTest.java
@@ -8,10 +8,6 @@ import static org.mockito.BDDMockito.then;
 import com.bob.global.event.sse.manager.EmitterManager;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
-import com.bob.infra.auth.jwt.JwtProvider;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,66 +26,17 @@ class NotiStreamControllerTest {
   @Mock
   private EmitterManager emitterManager;
 
-  @Mock
-  private JwtProvider jwtProvider;
-
-  @Mock
-  private HttpServletRequest request;
-
-  private String token = "mock.auth.token";
-
-  @BeforeEach
-  void setup() {
-    Cookie cookie = new Cookie("AUTHORIZATION", token);
-    given(request.getCookies()).willReturn(new Cookie[]{cookie});
-  }
-
   @Test
   @DisplayName("SSE 구독 - 성공 테스트")
   void 채팅방_SSE_구독에_성공한다() {
     // given
-    given(jwtProvider.isVerified(token)).willReturn(true);
-    given(jwtProvider.getMemberId(token)).willReturn(MEMBER_ID);
     given(emitterManager.subscribeToNoti(MEMBER_ID)).willReturn(new SseEmitter());
 
     // when
-    SseEmitter emitter = controller.handleSubscribeNotification(request);
+    SseEmitter emitter = controller.handleSubscribeNotification(MEMBER_ID);
 
     // then
-    then(jwtProvider).should().isVerified(token);
-    then(jwtProvider).should().getMemberId(token);
     then(emitterManager).should().subscribeToNoti(MEMBER_ID);
     assert emitter != null;
-  }
-
-  @Test
-  @DisplayName("SSE 구독 - 실패 테스트(토큰 없음)")
-  void 토큰이_없으면_예외가_발생한다() {
-    // given
-    given(request.getCookies()).willReturn(null);
-
-    // when & then
-    assertThatThrownBy(() -> controller.handleSubscribeNotification(request))
-        .isInstanceOf(ApplicationException.class)
-        .hasMessage(ApplicationError.AUTHENTICATION_FAILED.getMessage());
-
-    then(jwtProvider).shouldHaveNoInteractions();
-    then(emitterManager).shouldHaveNoInteractions();
-  }
-
-  @Test
-  @DisplayName("SSE 구독 - 실패 테스트(토큰 검증 실패)")
-  void 인증되지_않은_토큰이면_예외가_발생한다() {
-    // given
-    given(jwtProvider.isVerified(token)).willReturn(false);
-
-    // when & then
-    assertThatThrownBy(() -> controller.handleSubscribeNotification(request))
-        .isInstanceOf(ApplicationException.class)
-        .hasMessage(ApplicationError.AUTHENTICATION_FAILED.getMessage());
-
-    then(jwtProvider).should().isVerified(token);
-    then(jwtProvider).shouldHaveNoMoreInteractions();
-    then(emitterManager).shouldHaveNoInteractions();
   }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#87 

### 📜 작업 내용
- [x] sse 구독 api의 인증 방식을 컨트롤러 검증 → JwtAuthorizationFilter 기반 인증으로 변경

### 📄 참고
이미 종료된 emitter를 통해 heartbeat 발송(health check) 시 SecurityContext 인증 객체가 사라져 서버 내부 오류(500) 발생
-> ASYNC dispatch 시 JWT 필터가 쿠키를 읽어 인증 객체 재구성

heartbeat 전송마다 첫 요청시의 쿠키를 읽고 인증이 이루어져 성능 부담 발생
-> 이슈 #88 처리 시, SSE 구독 시점에 인증 객체를 저장하고 재사용하는 방식으로 변경 예정

### ⚠️ 종료할 이슈
this closes #87 
