### PR TITLE
feat#83: 소셜 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,16 @@ repositories {
 dependencies {
     // WEB
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // PERSIST
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.mysql:mysql-connector-j'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
@@ -193,6 +195,7 @@ jacocoTestCoverageVerification {
                     'com.bob.**.response.**',
                     'com.bob.**.dto.**',
                     'com.bob.**.symbol.**',
+                    'com.bob.**.provider.**',
                     'com.bob.**.dsl.**', // QueryDSL Impl 제외, 도메인 통합 테스트에서 검증
                     'com.bob.**.Q*', // QueryDSL Q 클래스 제외
                     'com.bob.**.dummy.**', // TODO: 개발 완료 시 삭제

--- a/src/main/java/com/bob/BookBridgeApplication.java
+++ b/src/main/java/com/bob/BookBridgeApplication.java
@@ -2,8 +2,11 @@ package com.bob;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @EnableAsync
 @EnableJpaAuditing
@@ -12,5 +15,10 @@ public class BookBridgeApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(BookBridgeApplication.class, args);
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 }

--- a/src/main/java/com/bob/domain/area/service/AreaService.java
+++ b/src/main/java/com/bob/domain/area/service/AreaService.java
@@ -36,8 +36,12 @@ public class AreaService implements AreaWriteUseCase, AreaReadUseCase, AreaModif
 
   @Transactional
   public void createActivityAreaProcess(CreateAreaCommand command) {
-    ActivityArea activityArea = command.toActivityArea();
-    activityAreaRepository.save(activityArea);
+    activityAreaRepository.save(command.toActivityArea());
+  }
+
+  @Transactional
+  public void createNonAuthenticatedActivityAreaProcess(CreateAreaCommand command) {
+    activityAreaRepository.save(command.toNonAuthenticatedActivityArea());
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/area/service/dto/command/CreateAreaCommand.java
+++ b/src/main/java/com/bob/domain/area/service/dto/command/CreateAreaCommand.java
@@ -20,4 +20,11 @@ public record CreateAreaCommand(
         .authenticationAt(LocalDate.now())
         .build();
   }
+
+  public ActivityArea toNonAuthenticatedActivityArea() {
+    return ActivityArea.builder()
+        .id(new ActivityAreaId(memberId, emdId))
+        .authenticationAt(LocalDate.EPOCH)
+        .build();
+  }
 }

--- a/src/main/java/com/bob/domain/area/usecase/AreaWriteUseCase.java
+++ b/src/main/java/com/bob/domain/area/usecase/AreaWriteUseCase.java
@@ -5,4 +5,6 @@ import com.bob.domain.area.service.dto.command.CreateAreaCommand;
 public interface AreaWriteUseCase {
 
   void createActivityAreaProcess(CreateAreaCommand command);
+
+  void createNonAuthenticatedActivityAreaProcess(CreateAreaCommand command);
 }

--- a/src/main/java/com/bob/domain/member/entity/Member.java
+++ b/src/main/java/com/bob/domain/member/entity/Member.java
@@ -4,6 +4,8 @@ import com.bob.global.audit.BaseTime;
 import com.bob.global.utils.uuid.GeneratedUuidV7;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.Objects;
@@ -25,6 +27,10 @@ public class Member extends BaseTime {
   @Id
   @GeneratedUuidV7
   private UUID id;
+
+  @Enumerated(EnumType.STRING)
+  @Column
+  private SocialProvider provider;
 
   @Column(unique = true, length = 50, nullable = false)
   private String email;

--- a/src/main/java/com/bob/domain/member/entity/SocialProvider.java
+++ b/src/main/java/com/bob/domain/member/entity/SocialProvider.java
@@ -1,0 +1,5 @@
+package com.bob.domain.member.entity;
+
+public enum SocialProvider {
+  GOOGLE, NAVER
+}

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileImageCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberAreaSummaryResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
@@ -24,6 +25,7 @@ import com.bob.domain.member.usecase.MemberModifyUseCase;
 import com.bob.domain.member.usecase.MemberReadUseCase;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
 import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -45,8 +47,7 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
   @Transactional
   public void signupProcess(CreateMemberCommand command) {
     verifyEmail(command.email());
-    String encodedPassword = encoder.encode(command.password());
-    Member member = command.toMember(encodedPassword);
+    Member member = command.toMember(encoder.encode(command.password()));
     memberRepository.save(member);
     areaPort.createMemberActivityArea(member.getId(), command.emdId());
   }
@@ -67,6 +68,17 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
     if (!redisPort.isVerified(email)) {
       throw new ApplicationException(UNVERIFIED_EMAIL);
     }
+  }
+
+  @Transactional
+  public UUID socialLoginProcess(SocialLoginCommand command) {
+    return memberRepository.findByEmail(command.email())
+        .map(Member::getId)
+        .orElseGet(() -> {
+          Member member = memberRepository.save(command.toMember(encoder.encode(generateCode(12))));
+          areaPort.createNonAuthenticatedActivityArea(member.getId(), command.emdId());
+          return member.getId();
+        });
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/bob/domain/member/service/dto/command/SocialLoginCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/SocialLoginCommand.java
@@ -1,0 +1,32 @@
+package com.bob.domain.member.service.dto.command;
+
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.entity.SocialProvider;
+import lombok.Builder;
+
+@Builder
+public record SocialLoginCommand(
+    String provider,
+    String email,
+    String nickname,
+    Integer emdId
+) {
+
+  public static SocialLoginCommand of(String provider, String email, String nickname) {
+    return SocialLoginCommand.builder()
+        .provider(provider)
+        .email(email)
+        .nickname(nickname)
+        .emdId(213)
+        .build();
+  }
+
+  public Member toMember(String encodedPassword) {
+    return Member.builder()
+        .provider(SocialProvider.valueOf(provider))
+        .email(email)
+        .password(encodedPassword)
+        .nickname(nickname)
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/member/service/port/out/MemberAreaPort.java
+++ b/src/main/java/com/bob/domain/member/service/port/out/MemberAreaPort.java
@@ -7,5 +7,7 @@ public interface MemberAreaPort {
 
   void createMemberActivityArea(UUID memberId, Integer emdId);
 
+  void createNonAuthenticatedActivityArea(UUID memberId, Integer emdId);
+
   MemberAreaSummaryResponse readMemberAreaSummary(UUID memberId);
 }

--- a/src/main/java/com/bob/domain/member/usecase/MemberWriteUseCase.java
+++ b/src/main/java/com/bob/domain/member/usecase/MemberWriteUseCase.java
@@ -1,8 +1,12 @@
 package com.bob.domain.member.usecase;
 
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
+import com.bob.domain.member.service.dto.command.SocialLoginCommand;
+import java.util.UUID;
 
 public interface MemberWriteUseCase {
 
   void signupProcess(CreateMemberCommand command);
+
+  UUID socialLoginProcess(SocialLoginCommand command);
 }

--- a/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandler.java
+++ b/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandler.java
@@ -1,0 +1,32 @@
+package com.bob.infra.auth.oauth.handler;
+
+import static com.bob.global.utils.web.CookieUtils.removeCookie;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SocialAuthFailureHandler implements AuthenticationFailureHandler {
+
+  private static final String ACCESS_COOKIE_NAME = "AUTHORIZATION";
+  private static final String REFRESH_COOKIE_NAME = "REFRESH_KEY";
+
+  @Value("${app.base-url}")
+  private String baseUrl;
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+    exception.printStackTrace();
+    removeCookie(response, ACCESS_COOKIE_NAME);
+    removeCookie(response, REFRESH_COOKIE_NAME);
+    response.sendRedirect(baseUrl + "/error");
+  }
+}

--- a/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthSuccessHandler.java
+++ b/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthSuccessHandler.java
@@ -1,0 +1,40 @@
+package com.bob.infra.auth.oauth.handler;
+
+import static com.bob.global.utils.random.RandomUtils.*;
+import static com.bob.global.utils.web.CookieUtils.addCookie;
+
+import com.bob.infra.auth.filter.port.AuthRedisPort;
+import com.bob.infra.auth.jwt.JwtProvider;
+import com.bob.infra.config.props.JwtProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SocialAuthSuccessHandler implements AuthenticationSuccessHandler {
+
+  @Value("${app.base-url}")
+  private String baseUrl;
+
+  private final AuthRedisPort redisPort;
+
+  private final JwtProvider jwtProvider;
+  private final JwtProperties jwtProps;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+    String memberId = authentication.getName();
+    String accessToken = jwtProvider.generateAccessToken(memberId);
+    String refreshKey = generateCode(32);
+    redisPort.updateRefreshKey(null, refreshKey, memberId);
+    addCookie(response, jwtProps.accessName(), accessToken, jwtProps.refreshTokenExpireTime());
+    addCookie(response, jwtProps.refreshName(), refreshKey, jwtProps.refreshTokenExpireTime());
+    response.sendRedirect(baseUrl);
+  }
+}

--- a/src/main/java/com/bob/infra/auth/oauth/provider/GoogleProfile.java
+++ b/src/main/java/com/bob/infra/auth/oauth/provider/GoogleProfile.java
@@ -1,0 +1,15 @@
+package com.bob.infra.auth.oauth.provider;
+
+import java.util.Map;
+
+public class GoogleProfile {
+
+  public static SocialProvider from(Map<String, Object> attrs) {
+    return new SocialProvider(
+        SocialProvider.Provider.GOOGLE,
+        (String) attrs.get("sub"),
+        (String) attrs.get("email"),
+        (String) attrs.getOrDefault("name", ((String) attrs.get("email")).split("@")[0])
+    );
+  }
+}

--- a/src/main/java/com/bob/infra/auth/oauth/provider/NaverProfile.java
+++ b/src/main/java/com/bob/infra/auth/oauth/provider/NaverProfile.java
@@ -1,0 +1,17 @@
+package com.bob.infra.auth.oauth.provider;
+
+import java.util.Map;
+
+public class NaverProfile {
+
+  @SuppressWarnings("unchecked")
+  public static SocialProvider from(Map<String, Object> attrs) {
+    Map<String, Object> response = (Map<String, Object>) attrs.get("response");
+    return new SocialProvider(
+        SocialProvider.Provider.NAVER,
+        (String) response.get("id"),
+        (String) response.get("email"),
+        (String) response.getOrDefault("nickname", ((String) response.get("email")).split("@")[0])
+    );
+  }
+}

--- a/src/main/java/com/bob/infra/auth/oauth/provider/SocialProvider.java
+++ b/src/main/java/com/bob/infra/auth/oauth/provider/SocialProvider.java
@@ -1,0 +1,10 @@
+package com.bob.infra.auth.oauth.provider;
+
+public record SocialProvider(
+    Provider provider,
+    String providerId,
+    String email,
+    String nickname
+) {
+  public enum Provider { GOOGLE, NAVER }
+}

--- a/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
+++ b/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
@@ -7,6 +7,7 @@ import com.bob.infra.auth.service.port.AuthMemberPort;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -19,7 +20,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SocialAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-  private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2userService;
+  private final DefaultOAuth2UserService oAuth2UserService = new DefaultOAuth2UserService();
   private final AuthMemberPort memberPort;
 
   @Override
@@ -27,7 +28,7 @@ public class SocialAuthService implements OAuth2UserService<OAuth2UserRequest, O
     final String provider = userRequest.getClientRegistration().getRegistrationId();
     verifyProvider(provider);
 
-    final OAuth2User oAuth2User = oAuth2userService.loadUser(userRequest);
+    final OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
     final Map<String, Object> attrs = oAuth2User.getAttributes();
     final SocialProvider profile = switch (provider) {
       case "google" -> GoogleProfile.from(attrs);

--- a/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
+++ b/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
@@ -1,0 +1,48 @@
+package com.bob.infra.auth.service;
+
+import com.bob.infra.auth.oauth.provider.GoogleProfile;
+import com.bob.infra.auth.oauth.provider.NaverProfile;
+import com.bob.infra.auth.oauth.provider.SocialProvider;
+import com.bob.infra.auth.service.port.AuthMemberPort;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SocialAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  private final OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2userService;
+  private final AuthMemberPort memberPort;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    final String provider = userRequest.getClientRegistration().getRegistrationId();
+    verifyProvider(provider);
+
+    final OAuth2User oAuth2User = oAuth2userService.loadUser(userRequest);
+    final Map<String, Object> attrs = oAuth2User.getAttributes();
+    final SocialProvider profile = switch (provider) {
+      case "google" -> GoogleProfile.from(attrs);
+      case "naver" -> NaverProfile.from(attrs);
+      default -> throw new OAuth2AuthenticationException(new OAuth2Error("000"), "해당 로그인 방법은 지원하지 않습니다.");
+    };
+
+    final UUID memberId = memberPort.socialLoginProcess(provider.toUpperCase(), profile.email(), profile.nickname());
+    final Map<String, Object> principalAttrs = Map.of("memberId", memberId.toString());
+    return new DefaultOAuth2User(null, principalAttrs, "memberId");
+  }
+
+  private static void verifyProvider(String provider) {
+    if (!"google".equalsIgnoreCase(provider) && !"naver".equalsIgnoreCase(provider)) {
+      throw new OAuth2AuthenticationException(new OAuth2Error("001"), "해당 로그인 방법은 지원하지 않습니다.");
+    }
+  }
+}

--- a/src/main/java/com/bob/infra/auth/service/port/AuthMemberPort.java
+++ b/src/main/java/com/bob/infra/auth/service/port/AuthMemberPort.java
@@ -1,0 +1,8 @@
+package com.bob.infra.auth.service.port;
+
+import java.util.UUID;
+
+public interface AuthMemberPort {
+
+  UUID socialLoginProcess(String provider, String email, String nickname);
+}

--- a/src/main/java/com/bob/infra/config/SecurityConfig.java
+++ b/src/main/java/com/bob/infra/config/SecurityConfig.java
@@ -7,7 +7,10 @@ import com.bob.infra.auth.filter.port.AuthRedisPort;
 import com.bob.infra.auth.jwt.JwtProvider;
 import com.bob.infra.auth.jwt.filter.JwtAuthorizationFilter;
 import com.bob.infra.auth.jwt.handler.JwtAuthenticationEntryPoint;
+import com.bob.infra.auth.oauth.handler.SocialAuthFailureHandler;
+import com.bob.infra.auth.oauth.handler.SocialAuthSuccessHandler;
 import com.bob.infra.auth.service.MemberDetailsService;
+import com.bob.infra.auth.service.SocialAuthService;
 import com.bob.infra.config.props.JwtProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -24,7 +27,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -39,19 +41,25 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private static final String[] AUTH_WHITELIST = {
-      "/auth/**", "/ai/**", "/areas/**", "/members/temp/**",
-      "/h2-console/**",
-      "/error/**",
+      "/auth/**", "/oauth2/**", "/login/oauth2/**",
+      "/ai/**", "/areas/**", "/members/temp/**",
+      "/h2-console/**", "/error/**",
   };
+
+  private final MemberDetailsService memberDetailsService;
+  private final SocialAuthService socialAuthService;
+  private final SocialAuthSuccessHandler socialAuthSuccessHandler;
+  private final SocialAuthFailureHandler socialAuthFailureHandler;
 
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final JwtAuthorizationFilter jwtAuthorizationFilter;
-  private final MemberDetailsService memberDetailsService;
-  private final AuthRedisPort redisPort;
-  private final JwtProvider jwtProvider;
-  private final ObjectMapper objectMapper;
-
   private final JwtProperties jwtProperties;
+  private final JwtProvider jwtProvider;
+
+  private final AuthRedisPort redisPort;
+
+  private final PasswordEncoder passwordEncoder;
+  private final ObjectMapper objectMapper;
 
   @Bean
   public SecurityFilterChain configure(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
@@ -61,6 +69,13 @@ public class SecurityConfig {
         .anonymous(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
+        .oauth2Login(oauth -> oauth
+            .authorizationEndpoint(p -> p.baseUri("/oauth2/authorization"))
+            .redirectionEndpoint(p -> p.baseUri("/login/oauth2/code/*"))
+            .userInfoEndpoint(p -> p.userService(socialAuthService))
+            .successHandler(socialAuthSuccessHandler)
+            .failureHandler(socialAuthFailureHandler)
+        )
         .logout(filter -> filter
             .logoutUrl("/auth/logout")
             .logoutSuccessHandler((req, res, auth) -> res.setStatus(SC_OK))
@@ -87,14 +102,8 @@ public class SecurityConfig {
   @Bean
   public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
     AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
-    builder.userDetailsService(memberDetailsService)
-        .passwordEncoder(passwordEncoder());
+    builder.userDetailsService(memberDetailsService).passwordEncoder(passwordEncoder);
     return builder.build();
-  }
-
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
   @Bean

--- a/src/main/java/com/bob/web/area/adapter/in/MemberAreaAdapter.java
+++ b/src/main/java/com/bob/web/area/adapter/in/MemberAreaAdapter.java
@@ -24,6 +24,11 @@ public class MemberAreaAdapter implements MemberAreaPort {
   }
 
   @Override
+  public void createNonAuthenticatedActivityArea(UUID memberId, Integer emdId) {
+    writeUseCase.createNonAuthenticatedActivityAreaProcess(CreateAreaCommand.of(memberId, emdId));
+  }
+
+  @Override
   public MemberAreaSummaryResponse readMemberAreaSummary(UUID memberId) {
     AreaSummaryResponse response = readUseCase.readAreaSummaryProcess(ReadAreaQuery.of(memberId));
     return MemberAreaSummaryResponse.of(response.emdId(), response.validity(), response.authenticatedAt());

--- a/src/main/java/com/bob/web/member/adapter/in/AuthMemberAdapter.java
+++ b/src/main/java/com/bob/web/member/adapter/in/AuthMemberAdapter.java
@@ -1,0 +1,20 @@
+package com.bob.web.member.adapter.in;
+
+import com.bob.domain.member.service.dto.command.SocialLoginCommand;
+import com.bob.domain.member.usecase.MemberWriteUseCase;
+import com.bob.infra.auth.service.port.AuthMemberPort;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AuthMemberAdapter implements AuthMemberPort {
+
+  private final MemberWriteUseCase writeUseCase;
+
+  @Override
+  public UUID socialLoginProcess(String provider, String email, String nickname) {
+    return writeUseCase.socialLoginProcess(SocialLoginCommand.of(provider, email, nickname));
+  }
+}

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -12,7 +12,11 @@ import static com.bob.support.fixture.domain.MemberFixture.encryptPasswordMember
 import static com.bob.support.fixture.response.MemberAreaSummaryResponseFixture.DEFAULT_AREA_SUMMARY_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.repository.MemberRepository;
@@ -21,6 +25,7 @@ import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileImageCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
@@ -29,6 +34,7 @@ import com.bob.domain.member.service.port.out.MemberRedisPort;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +54,9 @@ class MemberServiceIntgTest extends TestContainerSupport {
   @Autowired
   private MemberRepository memberRepository;
 
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+
   @MockitoBean
   private MemberAreaPort areaPort;
 
@@ -56,9 +65,6 @@ class MemberServiceIntgTest extends TestContainerSupport {
 
   @MockitoBean
   private MemberMailPort mailPort;
-
-  @Autowired
-  private PasswordEncoder passwordEncoder;
 
   @Test
   @DisplayName("회원가입 - 성공 테스트")
@@ -105,6 +111,41 @@ class MemberServiceIntgTest extends TestContainerSupport {
     assertThatThrownBy(() -> memberService.signupProcess(command))
         .isInstanceOf(ApplicationException.class)
         .hasMessage(ApplicationError.ALREADY_EXISTS_EMAIL.getMessage());
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 존재하지 않는 회원의 회원가입 테스트")
+  void 동일한_이메일을_가진_회원이_존재하지_않는_경우_회원가입을_진행하고_미인증_활동지역을_생성한다() {
+    // given
+    String email = "test@naver.com";
+    String nickname = "foo";
+    SocialLoginCommand command = SocialLoginCommand.of("NAVER", email, nickname);
+
+    // when
+    UUID result = memberService.socialLoginProcess(command);
+
+    // then
+    Member saved = memberRepository.findByEmail(email).orElseThrow();
+    assertThat(saved.getEmail()).isEqualTo(email);
+    assertThat(saved.getNickname()).isEqualTo(nickname);
+    assertThat(result).isEqualTo(saved.getId());
+    then(areaPort).should(times(1)).createNonAuthenticatedActivityArea(saved.getId(), command.emdId());
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 존재하는 회원의 로그인 테스트")
+  void 동일한_이메일을_가진_회원이_존재하는_경우_회원_ID를_반환한다() {
+    // given
+    String email = "test@google.com";
+    Member existing = memberRepository.save(customEmailMember(email));
+    SocialLoginCommand command = SocialLoginCommand.of("GOOGLE", email, "foo");
+
+    // when
+    UUID result = memberService.socialLoginProcess(command);
+
+    // then
+    assertThat(result).isEqualTo(existing.getId());
+    then(areaPort).should(never()).createNonAuthenticatedActivityArea(any(), any());
   }
 
   @Test

--- a/src/test/intg/resources/application-intg.yml
+++ b/src/test/intg/resources/application-intg.yml
@@ -1,4 +1,15 @@
 spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: id
+            client-secret: secret
+            scope: profile
+            redirect-uri: redirect
+            client-authentication-method: method
+            authorization-grant-type: grant
   main:
     allow-bean-definition-overriding: true
 
@@ -37,3 +48,6 @@ jwt:
 sse:
   heartbeat-interval: 10
   default-timeout: 60000
+
+app:
+  base-url: "https://base"

--- a/src/test/unit/java/com/bob/domain/area/service/AreaServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/area/service/AreaServiceTest.java
@@ -63,6 +63,8 @@ class AreaServiceTest {
   @Mock
   private Geometry geometry;
 
+  // TODO: 테스트 커버리지 미충족 시 인증, 미인증 상태의 활동 지역 생성 테스트 작성 필요
+
   @Test
   @DisplayName("회원가입 시 행정구역 안에 있는 경우 - 성공 테스트")
   void 요청한_위치에_사용자의_위치가_포함되는_경우_좌표_인증에_성공한다() {

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -18,9 +18,11 @@ import static com.bob.support.fixture.query.MemberQueryFixture.defaultReadProfil
 import static com.bob.support.fixture.response.MemberAreaSummaryResponseFixture.DEFAULT_AREA_SUMMARY_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import com.bob.domain.member.entity.Member;
@@ -29,6 +31,7 @@ import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
@@ -36,6 +39,8 @@ import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
 import com.bob.domain.member.service.reader.MemberReader;
 import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -118,6 +123,48 @@ class MemberServiceTest {
     assertThatThrownBy(() -> memberService.signupProcess(command))
         .isInstanceOf(RuntimeException.class)
         .hasMessage(ALREADY_EXISTS_EMAIL.getMessage());
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 존재하지 않는 회원의 회원가입 테스트")
+  void 동일한_이메일을_가진_회원이_존재하지_않는_경우_회원가입을_진행한다() {
+    // given
+    SocialLoginCommand command = SocialLoginCommand.of("NAVER", "test@naver.com", "foo");
+    given(memberRepository.findByEmail("test@naver.com")).willReturn(Optional.empty());
+    given(encoder.encode(anyString())).willReturn("$2a$encodedDummy");
+
+    Member saved = defaultIdMember();
+    given(memberRepository.save(any(Member.class))).willReturn(saved);
+
+    // when
+    UUID result = memberService.socialLoginProcess(command);
+
+    // then
+    ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+    then(memberRepository).should(times(1)).save(captor.capture());
+
+    Member toSave = captor.getValue();
+    assertThat(toSave.getEmail()).isEqualTo("test@naver.com");
+    assertThat(toSave.getNickname()).isEqualTo("foo");
+    assertThat(toSave.getPassword()).isEqualTo("$2a$encodedDummy");
+    then(areaPort).should(times(1)).createNonAuthenticatedActivityArea(saved.getId(), command.emdId());
+    assertThat(result).isEqualTo(saved.getId());
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 존재하는 회원의 로그인 테스트")
+  void 동일한_이메일을_가진_회원이_존재하는_경우_회원_ID를_반환한다() {
+    // given
+    SocialLoginCommand command = SocialLoginCommand.of("GOOGLE", "test@google.com", "foo");
+    given(memberRepository.findByEmail("test@google.com")).willReturn(Optional.of(defaultIdMember()));
+
+    // when
+    UUID result = memberService.socialLoginProcess(command);
+
+    // then
+    assertThat(result).isEqualTo(defaultIdMember().getId());
+    then(memberRepository).should(never()).save(any(Member.class));
+    then(areaPort).should(never()).createNonAuthenticatedActivityArea(any(), any());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandlerTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandlerTest.java
@@ -1,0 +1,71 @@
+package com.bob.infra.auth.oauth.handler;
+
+import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE_NAME;
+import static com.bob.support.fixture.auth.CookieFixture.REFRESH_COOKIE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.Cookie;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("소셜 로그인 실패 핸들러 테스트")
+@ExtendWith(MockitoExtension.class)
+class SocialAuthFailureHandlerTest {
+
+  @InjectMocks
+  private SocialAuthFailureHandler handler;
+
+  private MockHttpServletRequest request;
+
+  private MockHttpServletResponse response;
+
+  private String baseUrl = "https://base";
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(handler, "baseUrl", baseUrl);
+
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 실패 - 에러 페이지 리다이렉트")
+  void 소셜로그인_실패시_에러페이지로_리다이렉트한다() throws Exception {
+    // given
+    AuthenticationException ex = new AuthenticationException("oauth failed") {};
+
+    // when
+    handler.onAuthenticationFailure(request, response, ex);
+
+    // then
+    assertThat(response.getRedirectedUrl()).isEqualTo(baseUrl + "/error");
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 실패 - 쿠키 삭제")
+  void 소셜로그인_실패시_쿠키를_삭제한다() throws Exception {
+    // when
+    handler.onAuthenticationFailure(request, response, new AuthenticationException("any") {});
+
+    // then
+    Cookie[] cookies = response.getCookies();
+    assertThat(cookies).isNotNull();
+
+    Cookie accessCookie = Arrays.stream(cookies).filter(c -> AUTH_COOKIE_NAME.equals(c.getName())).findFirst().orElse(null);
+    Cookie refreshCookie = Arrays.stream(cookies).filter(c -> REFRESH_COOKIE_NAME.equals(c.getName())).findFirst().orElse(null);
+    assertThat(accessCookie).isNotNull();
+    assertThat(refreshCookie).isNotNull();
+    assertThat(accessCookie.getMaxAge()).isZero();
+    assertThat(refreshCookie.getMaxAge()).isZero();
+  }
+}

--- a/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthSuccessHandlerTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthSuccessHandlerTest.java
@@ -1,0 +1,108 @@
+package com.bob.infra.auth.oauth.handler;
+
+import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE_ACCESS_VALUE;
+import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE_NAME;
+import static com.bob.support.fixture.auth.CookieFixture.REFRESH_COOKIE_NAME;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bob.infra.auth.filter.port.AuthRedisPort;
+import com.bob.infra.auth.jwt.JwtProvider;
+import com.bob.infra.config.props.JwtProperties;
+import jakarta.servlet.http.Cookie;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("소셜 로그인 성공 핸들러 테스트")
+@ExtendWith(MockitoExtension.class)
+class SocialAuthSuccessHandlerTest {
+
+  @InjectMocks
+  private SocialAuthSuccessHandler handler;
+
+  @Mock
+  private AuthRedisPort redisPort;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private JwtProperties jwtProps;
+
+  private MockHttpServletRequest request;
+
+  private MockHttpServletResponse response;
+
+  private String baseUrl = "https://base";
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(handler, "baseUrl", baseUrl);
+    given(jwtProps.accessName()).willReturn(AUTH_COOKIE_NAME);
+    given(jwtProps.refreshName()).willReturn(REFRESH_COOKIE_NAME);
+    given(jwtProps.refreshTokenExpireTime()).willReturn(1);
+    given(jwtProvider.generateAccessToken(MEMBER_ID.toString())).willReturn(AUTH_COOKIE_ACCESS_VALUE);
+
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 성공 - JWT 쿠키 발급, Redis 저장, 리다이렉트")
+  void 소셜로그인_성공시_token을_발급하고_홈페이지로_리다이렉트된다() throws Exception {
+    // given
+    String memberId = MEMBER_ID.toString();
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(MEMBER_ID.toString(), null);
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    then(redisPort).should(times(1)).updateRefreshKey(isNull(), captor.capture(), eq(memberId));
+
+    String issuedRefreshKey = captor.getValue();
+    assertThat(issuedRefreshKey).isNotBlank();
+    assertThat(issuedRefreshKey.length()).isEqualTo(32);
+
+    Cookie[] cookies = response.getCookies();
+    assertThat(cookies).isNotNull();
+    assertThat(Arrays.stream(cookies).map(Cookie::getName)).containsExactlyInAnyOrder(AUTH_COOKIE_NAME, REFRESH_COOKIE_NAME);
+
+    Cookie accessCookie = Arrays.stream(cookies).filter(c -> AUTH_COOKIE_NAME.equals(c.getName())).findFirst().orElseThrow();
+    Cookie refreshCookie = Arrays.stream(cookies).filter(c -> REFRESH_COOKIE_NAME.equals(c.getName())).findFirst().orElseThrow();
+    assertThat(accessCookie.getValue()).isEqualTo(AUTH_COOKIE_ACCESS_VALUE);
+    assertThat(refreshCookie.getValue()).isEqualTo(issuedRefreshKey);
+    assertThat(response.getRedirectedUrl()).isEqualTo(baseUrl);
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 성공 - 토큰 생성")
+  void 소셜로그인_성공시_access_token을_생성한다() throws IOException {
+    // given
+    UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(MEMBER_ID.toString(), null);
+
+    // when
+    handler.onAuthenticationSuccess(request, response, auth);
+
+    // then
+    then(jwtProvider).should(times(1)).generateAccessToken(MEMBER_ID.toString());
+  }
+}

--- a/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
@@ -1,0 +1,154 @@
+package com.bob.infra.auth.service;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
+
+import com.bob.infra.auth.service.port.AuthMemberPort;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@DisplayName("소셜 로그인 인증 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class SocialAuthServiceTest {
+
+  @InjectMocks
+  SocialAuthService socialAuthService;
+
+  @Mock
+  OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate;
+
+  @Mock
+  AuthMemberPort memberPort;
+
+  @Test
+  @DisplayName("구글 로그인 테스트")
+  void 구글_소셜_로그인() {
+    // given
+    ClientRegistration registration = googleRegistration();
+    OAuth2UserRequest request = requestOf(registration);
+    Map<String, Object> attrs = Map.of("sub", "1", "email", "test@google.com", "name", "foo");
+    OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "sub");
+    given(delegate.loadUser(request)).willReturn(loadedUser);
+    given(memberPort.socialLoginProcess(eq("GOOGLE"), eq("test@google.com"), eq("foo"))).willReturn(MEMBER_ID);
+
+    // when
+    OAuth2User principal = socialAuthService.loadUser(request);
+
+    // then
+    then(memberPort).should(times(1)).socialLoginProcess("GOOGLE", "test@google.com", "foo");
+    assertThat(principal.getName()).isEqualTo(MEMBER_ID.toString());
+    assertThat(principal.getAttributes()).containsEntry("memberId", MEMBER_ID.toString());
+  }
+
+  @Test
+  @DisplayName("네이버 로그인 테스트")
+  void 네이버_소셜_로그인() {
+    // given
+    ClientRegistration registration = naverRegistration();
+    OAuth2UserRequest request = requestOf(registration);
+    Map<String, Object> response = Map.of("id", "1", "email", "test@naver.com", "nickname", "foo");
+    Map<String, Object> attrs = Map.of("response", response);
+    OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "response");
+    given(delegate.loadUser(request)).willReturn(loadedUser);
+    given(memberPort.socialLoginProcess(eq("NAVER"), eq("test@naver.com"), eq("foo"))).willReturn(MEMBER_ID);
+
+    // when
+    OAuth2User principal = socialAuthService.loadUser(request);
+
+    // then
+    then(memberPort).should(times(1)).socialLoginProcess("NAVER", "test@naver.com", "foo");
+    assertThat(principal.getName()).isEqualTo(MEMBER_ID.toString());
+    assertThat(principal.getAttributes()).containsEntry("memberId", MEMBER_ID.toString());
+  }
+
+  @Test
+  @DisplayName("지원하지 않는 소셜 서비스 로그인 테스트")
+  void 지원하지_않는_provider는_예외를_발생시킨다() {
+    // given
+    ClientRegistration registration = kakaoRegistration();
+    OAuth2UserRequest request = requestOf(registration);
+
+    // when & then
+    assertThatThrownBy(() -> socialAuthService.loadUser(request))
+        .isInstanceOf(OAuth2AuthenticationException.class)
+        .hasMessage("해당 로그인 방법은 지원하지 않습니다.");
+  }
+
+  private static OAuth2UserRequest requestOf(ClientRegistration registration) {
+    final OAuth2AccessToken token = new OAuth2AccessToken(
+        BEARER,
+        "access-token",
+        Instant.now().minusSeconds(10),
+        Instant.now().plusSeconds(3600)
+    );
+    return new OAuth2UserRequest(registration, token);
+  }
+
+  private static ClientRegistration googleRegistration() {
+    return ClientRegistration
+        .withRegistrationId("google")
+        .clientId("id")
+        .clientSecret("secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/login/oauth2/code/google")
+        .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+        .tokenUri("https://oauth2.googleapis.com/token")
+        .userInfoUri("https://openidconnect.googleapis.com/v1/userinfo")
+        .userNameAttributeName("sub")
+        .scope("openid", "email", "profile")
+        .build();
+  }
+
+  private static ClientRegistration naverRegistration() {
+    return ClientRegistration
+        .withRegistrationId("naver")
+        .clientId("id")
+        .clientSecret("secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/login/oauth2/code/naver")
+        .authorizationUri("https://nid.naver.com/oauth2.0/authorize")
+        .tokenUri("https://nid.naver.com/oauth2.0/token")
+        .userInfoUri("https://openapi.naver.com/v1/nid/me")
+        .userNameAttributeName("response")
+        .scope("name", "email", "nickname")
+        .build();
+  }
+
+  /**
+   * 지원하지 않는 provider (kakao)
+   */
+  private static ClientRegistration kakaoRegistration() {
+    return ClientRegistration
+        .withRegistrationId("kakao")
+        .clientId("id")
+        .clientSecret("secret")
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/login/oauth2/code/kakao")
+        .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+        .tokenUri("https://kauth.kakao.com/oauth/token")
+        .userInfoUri("https://kapi.kakao.com/v2/user/me")
+        .userNameAttributeName("id")
+        .scope("profile", "account_email")
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
@@ -12,6 +12,7 @@ import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenTy
 import com.bob.infra.auth.service.port.AuthMemberPort;
 import java.time.Instant;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,13 +20,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("소셜 로그인 인증 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -35,10 +37,15 @@ class SocialAuthServiceTest {
   SocialAuthService socialAuthService;
 
   @Mock
-  OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate;
+  DefaultOAuth2UserService oAuth2UserService;
 
   @Mock
   AuthMemberPort memberPort;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(socialAuthService, "oAuth2UserService", oAuth2UserService);
+  }
 
   @Test
   @DisplayName("구글 로그인 테스트")
@@ -48,7 +55,7 @@ class SocialAuthServiceTest {
     OAuth2UserRequest request = requestOf(registration);
     Map<String, Object> attrs = Map.of("sub", "1", "email", "test@google.com", "name", "foo");
     OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "sub");
-    given(delegate.loadUser(request)).willReturn(loadedUser);
+    given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
     given(memberPort.socialLoginProcess(eq("GOOGLE"), eq("test@google.com"), eq("foo"))).willReturn(MEMBER_ID);
 
     // when
@@ -69,7 +76,7 @@ class SocialAuthServiceTest {
     Map<String, Object> response = Map.of("id", "1", "email", "test@naver.com", "nickname", "foo");
     Map<String, Object> attrs = Map.of("response", response);
     OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "response");
-    given(delegate.loadUser(request)).willReturn(loadedUser);
+    given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
     given(memberPort.socialLoginProcess(eq("NAVER"), eq("test@naver.com"), eq("foo"))).willReturn(MEMBER_ID);
 
     // when
@@ -130,7 +137,7 @@ class SocialAuthServiceTest {
         .tokenUri("https://nid.naver.com/oauth2.0/token")
         .userInfoUri("https://openapi.naver.com/v1/nid/me")
         .userNameAttributeName("response")
-        .scope("name", "email", "nickname")
+        .scope("email", "nickname")
         .build();
   }
 

--- a/src/test/unit/java/com/bob/web/area/adapter/in/MemberAreaAdapterTest.java
+++ b/src/test/unit/java/com/bob/web/area/adapter/in/MemberAreaAdapterTest.java
@@ -35,8 +35,8 @@ class MemberAreaAdapterTest {
   private AreaReadUseCase readUseCase;
 
   @Test
-  @DisplayName("회원 활동 지역 생성 기능 호출 테스트")
-  void 회원_활동_지역을_생성한다() {
+  @DisplayName("인증 활동 지역 생성 기능 호출 테스트")
+  void 인증_상태의_활동_지역을_생성한다() {
     // given
     UUID memberId = MEMBER_ID;
     Integer emdId = EMD_AREA_ID;
@@ -47,6 +47,21 @@ class MemberAreaAdapterTest {
 
     // then
     then(writeUseCase).should().createActivityAreaProcess(command);
+  }
+
+  @Test
+  @DisplayName("미인증 활동 지역 생성 기능 호출 테스트")
+  void 미인증_상태의_활동_지역을_생성한다() {
+    // given
+    UUID memberId = MEMBER_ID;
+    Integer emdId = EMD_AREA_ID;
+    CreateAreaCommand command = CreateAreaCommand.of(memberId, emdId);
+
+    // when
+    memberAreaAdapter.createNonAuthenticatedActivityArea(memberId, emdId);
+
+    // then
+    then(writeUseCase).should().createNonAuthenticatedActivityAreaProcess(command);
   }
 
   @Test

--- a/src/test/unit/java/com/bob/web/member/adapter/in/AuthMemberAdapterTest.java
+++ b/src/test/unit/java/com/bob/web/member/adapter/in/AuthMemberAdapterTest.java
@@ -1,0 +1,42 @@
+package com.bob.web.member.adapter.in;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.bob.domain.member.service.dto.command.SocialLoginCommand;
+import com.bob.domain.member.usecase.MemberWriteUseCase;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("AuthMemberAdapter 테스트")
+@ExtendWith(MockitoExtension.class)
+class AuthMemberAdapterTest {
+
+  @InjectMocks
+  private AuthMemberAdapter authMemberAdapter;
+
+  @Mock
+  private MemberWriteUseCase writeUseCase;
+
+  @Test
+  @DisplayName("소셜 로그인 기능 호출 테스트")
+  void 소셜_로그인_메서드_호출() {
+    // given
+    SocialLoginCommand command = SocialLoginCommand.of("GOOGLE", "test@google.com", "foo");
+    given(writeUseCase.socialLoginProcess(command)).willReturn(MEMBER_ID);
+
+    // when
+    UUID result = authMemberAdapter.socialLoginProcess("GOOGLE", "test@google.com", "foo");
+
+    // then
+    then(writeUseCase).should().socialLoginProcess(command);
+    assertThat(result).isEqualTo(MEMBER_ID);
+  }
+}


### PR DESCRIPTION
### #️⃣연관된 이슈
#83 

### 📜 작업 내용
- [x] 구글 로그인
- [x] 네이버 로그인

### 📄 참고
- 동일 이메일로 일반 회원가입을 진행한 경우 기존 회원 정보 반환
- 소셜 로그인을 통한 회원가입 진행 시 활동지역 미인증 상태로 계정 생성

### ⚠️ 종료할 이슈
this closes #83 
