### PR TITLE
feat#92: 거래 취소 시 알림 및 시스템 메시지에 취소 사유 포함

### DIFF
--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -4,9 +4,14 @@ import static com.bob.domain.trade.entity.status.TradeStatus.CANCELED;
 import static com.bob.domain.trade.entity.status.TradeStatus.REQUESTED;
 import static com.bob.domain.trade.entity.status.TradeStatus.valueOf;
 import static com.bob.domain.trade.service.dto.response.internal.TradeMemberSummary.from;
+import static com.bob.domain.trade.service.util.TradeMessageTemplate.CHAT_CANCELED_WITH_REASON;
+import static com.bob.domain.trade.service.util.TradeMessageTemplate.CHAT_DEFAULT;
+import static com.bob.domain.trade.service.util.TradeMessageTemplate.NOTI_CANCELED_WITH_REASON;
+import static com.bob.domain.trade.service.util.TradeMessageTemplate.NOTI_DEFAULT;
 import static com.bob.global.event.application.dto.type.NotiEventType.TRADE;
 import static com.bob.global.exception.response.ApplicationError.TRADE_ACCESS_DENIED;
 import static com.bob.global.exception.response.ApplicationError.TRADE_ALREADY_PROCESSED;
+import static com.bob.global.exception.response.ApplicationError.TRADE_STATUS_UNCHANGED;
 import static java.time.LocalDateTime.now;
 
 import com.bob.domain.trade.entity.Trade;
@@ -84,23 +89,34 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeM
     TradePostSummary post = TradePostSummary.from(postPort.readTradePostSummary(trade.getPostId()));
     verifyTradeOwner(post.sellerId(), command.memberId());
     verifyRequestedOnly(trade.getId(), trade.getPostId(), command.status());
-    TradeStatus status = valueOf(command.status());
+
+    final TradeStatus status = valueOf(command.status());
+    verifyIsSameRequest(trade.getTradeStatus(), status);
     trade.updateTradeStatus(status, now());
     postPort.changePostStatus(trade.getPostId(), status.toPostStatusValue());
-    sendTradeNotification(post, trade.getSellerId(), trade.getBuyerId(), status.value());
-    publishSystemMessageEvent(post, command.memberId(), trade.getBuyerId(), status.value());
+
+    final String notificationBody = buildNotificationBody(post.title(), status, command.reason());
+    final String chatMessageBody = buildChatMessageBody(status, command.reason());
+    sendTradeNotification(post, trade.getSellerId(), trade.getBuyerId(), notificationBody);
+    publishSystemMessageEvent(post, command.memberId(), trade.getBuyerId(), chatMessageBody);
   }
 
-  private void sendTradeNotification(TradePostSummary post, UUID memberId, UUID buyerId, String status) {
-    String body = String.format("[%s]의 거래 상태가 '%s'(으)로 변경되었습니다.", post.title(), status);
+  private void sendTradeNotification(TradePostSummary post, UUID memberId, UUID buyerId, String body) {
     NotiEvent event = NotiEvent.toSystemNotiEvent(TRADE, String.valueOf(post.postId()), "SYSTEM", memberId, buyerId, body);
     eventPublisher.publishEvent(event);
+    System.out.println("good1");
   }
 
-  private void publishSystemMessageEvent(TradePostSummary post, UUID memberId, UUID buyerId, String status) {
-    String body = String.format("거래 상태가 '%s'(으)로 변경되었습니다.", status);
+  private void publishSystemMessageEvent(TradePostSummary post, UUID memberId, UUID buyerId, String body) {
     SystemChatMessageEvent event = SystemChatMessageEvent.of("TRADE", post.postId().toString(), memberId, buyerId, body);
     eventPublisher.publishEvent(event);
+    System.out.println("good2");
+  }
+
+  private static void verifyTradeOwner(UUID ownerId, UUID memberId) {
+    if (!ownerId.equals(memberId)) {
+      throw new ApplicationException(TRADE_ACCESS_DENIED);
+    }
   }
 
   private void verifyRequestedOnly(Long requestId, Long postId, String status) {
@@ -116,9 +132,34 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeM
         });
   }
 
-  private void verifyTradeOwner(UUID ownerId, UUID memberId) {
-    if (!ownerId.equals(memberId)) {
-      throw new ApplicationException(TRADE_ACCESS_DENIED);
+  private static void verifyIsSameRequest(TradeStatus s1, TradeStatus s2) {
+    if (s1 == s2) {
+      throw new ApplicationException(TRADE_STATUS_UNCHANGED);
     }
+  }
+
+  private static String buildNotificationBody(String title, TradeStatus status, String reason) {
+    if (status == CANCELED) {
+      return normalizeReason(reason) != null
+          ? NOTI_CANCELED_WITH_REASON.format(title, CANCELED.value(), normalizeReason(reason))
+          : NOTI_DEFAULT.format(title, CANCELED);
+    }
+    return NOTI_DEFAULT.format(title, status);
+  }
+
+  private static String buildChatMessageBody(TradeStatus status, String reason) {
+    if (status == CANCELED) {
+      return normalizeReason(reason) != null
+          ? CHAT_CANCELED_WITH_REASON.format(normalizeReason(reason))
+          : CHAT_DEFAULT.format();
+    }
+    return CHAT_DEFAULT.format(status);
+  }
+
+  private static String normalizeReason(String reason) {
+    if (reason == null || reason.trim().isEmpty()) {
+      return null;
+    }
+    return reason.trim();
   }
 }

--- a/src/main/java/com/bob/domain/trade/service/dto/command/ChangeTradeStatusCommand.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/command/ChangeTradeStatusCommand.java
@@ -7,7 +7,8 @@ import lombok.Builder;
 public record ChangeTradeStatusCommand(
     UUID memberId,
     Long tradeId,
-    String status
+    String status,
+    String reason
 ) {
 
 }

--- a/src/main/java/com/bob/domain/trade/service/util/TradeMessageTemplate.java
+++ b/src/main/java/com/bob/domain/trade/service/util/TradeMessageTemplate.java
@@ -1,0 +1,20 @@
+package com.bob.domain.trade.service.util;
+
+public enum TradeMessageTemplate {
+
+  NOTI_DEFAULT("[%s]의 거래 상태가 '%s'(으)로 변경되었습니다."),
+  NOTI_CANCELED_WITH_REASON("[%s]의 거래 상태가 '%s'(으)로 변경되었습니다.\n사유: %s"),
+
+  CHAT_DEFAULT("거래 상태가 '%s'(으)로 변경되었습니다."),
+  CHAT_CANCELED_WITH_REASON("거래가 취소되었습니다.\n사유: %s");
+
+  private final String template;
+
+  TradeMessageTemplate(String template) {
+    this.template = template;
+  }
+
+  public String format(Object... args) {
+    return String.format(template, args);
+  }
+}

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -53,6 +53,7 @@ public enum ApplicationError {
   NOT_EXISTS_TRADE("E601", "거래를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
   TRADE_ACCESS_DENIED("E602", "거래에 접근할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
   TRADE_ALREADY_PROCESSED("E603", "다른 회원과 거래가 진행중이거나 완료된 상태입니다.", HttpStatus.CONFLICT),
+  TRADE_STATUS_UNCHANGED("E604", "변경하려는 거래 상태와 현재 상태가 동일합니다.", HttpStatus.CONFLICT),
 
   // 알림 예외
   NOT_EXISTS_NOTIFICATION("E701", "알림을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/bob/web/trade/request/ChangeTradeStatusRequest.java
+++ b/src/main/java/com/bob/web/trade/request/ChangeTradeStatusRequest.java
@@ -1,12 +1,18 @@
 package com.bob.web.trade.request;
 
 import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 
 public record ChangeTradeStatusRequest(
     @NotBlank(message = "거래 상태는 필수입니다.")
-    String status
+    String status,
+
+    @Nullable
+    @Size(max = 200, message = "취소 사유는 200자 이하로 입력해주세요.")
+    String reason
 ) {
 
   public ChangeTradeStatusCommand toCommand(UUID memberId, Long tradeId) {
@@ -14,6 +20,7 @@ public record ChangeTradeStatusRequest(
         .memberId(memberId)
         .tradeId(tradeId)
         .status(status)
+        .reason(reason)
         .build();
   }
 }

--- a/src/test/intg/java/com/bob/domain/trade/service/TradeServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/trade/service/TradeServiceIntgTest.java
@@ -169,7 +169,7 @@ class TradeServiceIntgTest extends TestContainerSupport {
     Trade trade = testTrade;
     given(postPort.readTradePostSummary(trade.getPostId())).willReturn(mockPostResponse());
     given(chatRoomReader.readExistingChatRoom(postId, sellerId, buyerId1)).willReturn(Optional.of(chatRoom.getId()));
-    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(sellerId, trade.getId(), "RESERVED");
+    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(sellerId, trade.getId(), "RESERVED", null);
 
     // when
     tradeService.changeTradeStatusProcess(command);
@@ -185,7 +185,7 @@ class TradeServiceIntgTest extends TestContainerSupport {
     // given
     Trade trade = testTrade;
     given(postPort.readTradePostSummary(trade.getPostId())).willReturn(mockPostResponse());
-    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(sellerId, trade.getId(), "RESERVED");
+    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(sellerId, trade.getId(), "RESERVED", null);
 
     // when & then
     assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
@@ -201,7 +201,7 @@ class TradeServiceIntgTest extends TestContainerSupport {
     Trade trade = testTrade;
     UUID otherUserId = UUID.fromString("0197365f-8074-7d24-a332-999999999999");
     given(postPort.readTradePostSummary(trade.getPostId())).willReturn(mockPostResponse());
-    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(otherUserId, trade.getId(), "RESERVED");
+    ChangeTradeStatusCommand command = new ChangeTradeStatusCommand(otherUserId, trade.getId(), "RESERVED", null);
 
     // when & then
     assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))

--- a/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
@@ -1,11 +1,15 @@
 package com.bob.domain.trade.service;
 
+import static com.bob.global.exception.response.ApplicationError.TRADE_ACCESS_DENIED;
+import static com.bob.global.exception.response.ApplicationError.TRADE_ALREADY_PROCESSED;
 import static com.bob.support.fixture.command.ChangeTradeStatusCommandFixture.DEFAULT_CHANGE_STATUS_COMMAND;
+import static com.bob.support.fixture.command.ChangeTradeStatusCommandFixture.DEFAULT_CHANGE_STATUS_COMMAND_WITH_REASON;
 import static com.bob.support.fixture.command.CreateTradeCommandFixture.DEFAULT_CREATE_TRADE_COMMAND;
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_ID_TRADE;
 import static com.bob.support.fixture.domain.TradeFixture.DEFAULT_TRADES;
 import static com.bob.support.fixture.domain.TradeFixture.REQUESTED_TRADE;
+import static com.bob.support.fixture.domain.TradeFixture.RESERVED_TRADE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.CUSTOM_MEMBER_PROFILE_RESPONSE;
 import static com.bob.support.fixture.response.PostResponseFixture.CUSTOM_POST_DETAIL_RESPONSE;
 import static com.bob.support.fixture.response.PostResponseFixture.DEFAULT_POST_DETAIL_RESPONSE;
@@ -29,11 +33,13 @@ import com.bob.domain.trade.service.port.out.TradePostPort;
 import com.bob.domain.trade.service.reader.TradeReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -114,7 +120,7 @@ class TradeServiceTest {
     // when & then
     assertThatThrownBy(() -> tradeService.readTradesProcess(query))
         .isInstanceOf(ApplicationException.class)
-        .hasMessage(ApplicationError.TRADE_ACCESS_DENIED.getMessage());
+        .hasMessage(TRADE_ACCESS_DENIED.getMessage());
 
     then(postPort).should(times(1)).readTradePostSummary(postId);
     then(tradeReader).shouldHaveNoInteractions();
@@ -175,7 +181,7 @@ class TradeServiceTest {
     // when & then
     assertThatThrownBy(() -> tradeService.readTradeDetailProcess(query))
         .isInstanceOf(ApplicationException.class)
-        .hasMessageContaining("거래에 접근할 권한이 없습니다");
+        .hasMessageContaining(TRADE_ACCESS_DENIED.getMessage());
 
     then(tradeReader).should(times(1)).readTradeById(tradeId);
   }
@@ -200,6 +206,33 @@ class TradeServiceTest {
     then(postPort).should().changePostStatus(requestTrade.getPostId(), "IN_PROGRESS");
   }
 
+  @Test
+  @DisplayName("거래 상태 변경 - 성공 테스트 (취소 사유 입력)")
+  void 거래_상태를_취소로_변경_시_사유가_본문에_포함된다() {
+    // given
+    String reason = "cancel reason";
+    ChangeTradeStatusCommand command = DEFAULT_CHANGE_STATUS_COMMAND_WITH_REASON("CANCELED", reason);
+
+    Trade requestTrade = RESERVED_TRADE(1L, 1L);
+    given(tradeReader.readTradeById(command.tradeId())).willReturn(requestTrade);
+    given(postPort.readTradePostSummary(requestTrade.getPostId())).willReturn(DEFAULT_POST_DETAIL_RESPONSE(1L));
+
+    final ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+
+    // when
+    tradeService.changeTradeStatusProcess(command);
+
+    // then
+    then(postPort).should().changePostStatus(requestTrade.getPostId(), "READY");
+    then(eventPublisher).should(times(2)).publishEvent(eventCaptor.capture());
+
+    // 채팅, 알림 이벤트 발행 시 body의 거래 취소 사유 포함 여부 검증
+    final List<Object> events = eventCaptor.getAllValues();
+    assertThat(events).hasSize(2);
+    assertThat(events).allMatch(e -> extractEventBody(e).contains(reason));
+    then(eventPublisher).shouldHaveNoMoreInteractions();
+  }
+
   @DisplayName("거래 상태 변경 - 실패 테스트 (이미 처리된 거래 존재)")
   @Test
   void 거래_상태_변경시_이미_처리된_거래가_있으면_예외가_발생한다() {
@@ -214,7 +247,7 @@ class TradeServiceTest {
     // when & then
     assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
         .isInstanceOf(ApplicationException.class)
-        .hasMessageContaining("다른 회원과 거래가 진행중이거나 완료된 상태입니다.");
+        .hasMessageContaining(TRADE_ALREADY_PROCESSED.getMessage());
 
     then(tradeReader).should().readTradeById(command.tradeId());
     then(tradeReader).should().readTradesByPostId(requestTrade.getPostId());
@@ -233,9 +266,46 @@ class TradeServiceTest {
     // when & then
     assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
         .isInstanceOf(ApplicationException.class)
-        .hasMessageContaining("거래에 접근할 권한이 없습니다");
+        .hasMessageContaining(TRADE_ACCESS_DENIED.getMessage());
 
     then(tradeReader).should().readTradeById(command.tradeId());
     then(postPort).should().readTradePostSummary(requestTrade.getPostId());
+  }
+
+  @DisplayName("거래 상태 변경 - 실패 테스트 (동일한 상태 변경 요청)")
+  @Test
+  void 거래_상태_변경시_현재_상태와_요청_상태가_동일하면_예외가_발생한다() {
+    // given
+    ChangeTradeStatusCommand command = DEFAULT_CHANGE_STATUS_COMMAND("RESERVED");
+    Trade requestTrade = RESERVED_TRADE(1L, 1L);
+
+    given(tradeReader.readTradeById(command.tradeId())).willReturn(requestTrade);
+    given(postPort.readTradePostSummary(requestTrade.getPostId())).willReturn(DEFAULT_POST_DETAIL_RESPONSE(1L));
+
+    // when & then
+    assertThatThrownBy(() -> tradeService.changeTradeStatusProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessageContaining(ApplicationError.TRADE_STATUS_UNCHANGED.getMessage());
+
+    then(tradeReader).should().readTradeById(command.tradeId());
+    then(postPort).should().readTradePostSummary(requestTrade.getPostId());
+  }
+
+  private static String extractEventBody(Object event) {
+    try {
+      Method m1 = event.getClass().getMethod("getBody");
+      Object o1 = m1.invoke(event);
+      return String.valueOf(o1);
+    } catch (NoSuchMethodException e1) {
+      try {
+        Method m2 = event.getClass().getMethod("body");
+        Object o2 = m2.invoke(event);
+        return String.valueOf(o2);
+      } catch (Exception e2) {
+        return String.valueOf(event);
+      }
+    } catch (Exception e) {
+      return String.valueOf(event);
+    }
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeTradeStatusCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeTradeStatusCommandFixture.java
@@ -7,6 +7,10 @@ import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
 public class ChangeTradeStatusCommandFixture {
 
   public static ChangeTradeStatusCommand DEFAULT_CHANGE_STATUS_COMMAND(String status) {
-    return new ChangeTradeStatusCommand(MEMBER_ID, 1L, status);
+    return new ChangeTradeStatusCommand(MEMBER_ID, 1L, status, null);
+  }
+
+  public static ChangeTradeStatusCommand DEFAULT_CHANGE_STATUS_COMMAND_WITH_REASON(String status, String reason) {
+    return new ChangeTradeStatusCommand(MEMBER_ID, 1L, status, reason);
   }
 }


### PR DESCRIPTION
### 📜 작업 내용
- [x] 거래 취소 시 메시지, 알림 본문에 사유 포함
- [x] 테스트케이스 추가

### ⚠️ 종료할 이슈
this closes #92
