### PR TITLE
feat#90: 회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/bob/domain/member/entity/Member.java
+++ b/src/main/java/com/bob/domain/member/entity/Member.java
@@ -44,6 +44,9 @@ public class Member extends BaseTime {
   @Column
   private String profileImageUrl;
 
+  @Column
+  private boolean isRemove;
+
   public void updatePassword(String newPassword) {
     password = newPassword;
   }
@@ -54,6 +57,10 @@ public class Member extends BaseTime {
 
   public void updateProfileImageUrl(String newProfileImageUrl) {
     profileImageUrl = newProfileImageUrl;
+  }
+
+  public void updateRemoveStatus(boolean isRemove) {
+    this.isRemove = isRemove;
   }
 
   public boolean isEqualsNickname(String oldNickname) {

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PAS
 import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
 import static com.bob.global.exception.response.ApplicationError.UNVERIFIED_EMAIL;
 import static com.bob.global.utils.random.RandomUtils.generateCode;
+import static com.bob.global.utils.web.CookieUtils.removeCookie;
 
 import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.repository.MemberRepository;
@@ -13,6 +14,7 @@ import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileImageCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberAreaSummaryResponse;
@@ -24,9 +26,12 @@ import com.bob.domain.member.service.reader.MemberReader;
 import com.bob.domain.member.usecase.MemberModifyUseCase;
 import com.bob.domain.member.usecase.MemberReadUseCase;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
+import com.bob.global.event.application.dto.RemoveMemberEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +48,8 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
   private final MemberRedisPort redisPort;
 
   private final PasswordEncoder encoder;
+
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public void signupProcess(CreateMemberCommand command) {
@@ -126,5 +133,14 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
   public void changeMemberProfileImageProcess(ChangeProfileImageCommand command) {
     Member member = memberReader.readMemberById(command.memberId());
     member.updateProfileImageUrl(command.fileName());
+  }
+
+  @Transactional
+  public void softRemoveMemberProcess(RemoveMemberCommand command, HttpServletResponse response) {
+    Member member = memberReader.readMemberById(command.memberId());
+    member.updateRemoveStatus(true);
+    eventPublisher.publishEvent(RemoveMemberEvent.of(member.getId()));
+    removeCookie(response, "AUTHORIZATION");
+    removeCookie(response, "REFRESH_KEY");
   }
 }

--- a/src/main/java/com/bob/domain/member/service/dto/command/RemoveMemberCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/RemoveMemberCommand.java
@@ -1,0 +1,9 @@
+package com.bob.domain.member.service.dto.command;
+
+import java.util.UUID;
+
+public record RemoveMemberCommand(
+    UUID memberId
+) {
+
+}

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
@@ -14,10 +14,14 @@ public record MemberProfileResponse(
 ) {
 
   public static MemberProfileResponse from(Member member, MemberAreaSummaryResponse areaSummary) {
+    final boolean removed = Boolean.TRUE.equals(member.isRemove());
+    final String nickname = removed ? "(알 수 없음)" : member.getNickname();
+    final String profileImageUrl = removed ? null : member.getProfileImageUrl();
+
     return MemberProfileResponse.builder()
         .memberId(member.getId())
-        .nickname(member.getNickname())
-        .profileImageUrl(member.getProfileImageUrl())
+        .nickname(nickname)
+        .profileImageUrl(profileImageUrl)
         .area(Area.of(areaSummary.emdId(), areaSummary.validity(), areaSummary.authenticatedAt()))
         .build();
   }

--- a/src/main/java/com/bob/domain/member/usecase/MemberModifyUseCase.java
+++ b/src/main/java/com/bob/domain/member/usecase/MemberModifyUseCase.java
@@ -4,6 +4,8 @@ import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileImageCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface MemberModifyUseCase {
 
@@ -14,4 +16,6 @@ public interface MemberModifyUseCase {
   void issueTempPasswordProcess(IssuePasswordCommand command);
 
   void changeMemberProfileImageProcess(ChangeProfileImageCommand command);
+
+  void softRemoveMemberProcess(RemoveMemberCommand command, HttpServletResponse response);
 }

--- a/src/main/java/com/bob/domain/post/entity/Post.java
+++ b/src/main/java/com/bob/domain/post/entity/Post.java
@@ -75,6 +75,9 @@ public class Post extends BaseTime {
   @Builder.Default
   private Integer scrapCount = 0;
 
+  @Column
+  private boolean isWithhold;
+
   public void updateOptionalFields(Integer sellPrice, String bookStatus, String description) {
     Optional.ofNullable(sellPrice).ifPresent(s -> this.sellPrice = s);
     Optional.ofNullable(bookStatus).ifPresent(b -> this.bookStatus = BookStatus.from(b));
@@ -83,5 +86,9 @@ public class Post extends BaseTime {
 
   public void updatePostStatus(PostStatus status) {
     this.postStatus = status;
+  }
+
+  public void updateIsWithhold(boolean isWithhold) {
+    this.isWithhold = isWithhold;
   }
 }

--- a/src/main/java/com/bob/domain/post/entity/status/PostStatus.java
+++ b/src/main/java/com/bob/domain/post/entity/status/PostStatus.java
@@ -1,5 +1,5 @@
 package com.bob.domain.post.entity.status;
 
 public enum PostStatus {
-  READY, IN_PROGRESS, COMPLETED;
+  READY, IN_PROGRESS, COMPLETED, REMOVED
 }

--- a/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
@@ -30,6 +30,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     return queryFactory
         .selectFrom(post)
         .where(
+            notRemoved(),
             keywordCondition(query.key(), query.keyword()),
             memberIdCondition(query.memberId()),
             emdCondition(query.emdId()),
@@ -50,6 +51,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         .select(post.count())
         .from(post)
         .where(
+            notRemoved(),
             keywordCondition(query.key(), query.keyword()),
             memberIdCondition(query.memberId()),
             emdCondition(query.emdId()),
@@ -59,6 +61,10 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
             bookStatusCondition(query.bookStatus())
         )
         .fetchOne();
+  }
+
+  private BooleanExpression notRemoved() {
+    return post.postStatus.ne(PostStatus.REMOVED);
   }
 
   private BooleanExpression keywordCondition(SearchKey key, String keyword) {

--- a/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/bob/domain/post/repository/dsl/CustomPostRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     return queryFactory
         .selectFrom(post)
         .where(
-            notRemoved(),
+            visibleCondition(),
             keywordCondition(query.key(), query.keyword()),
             memberIdCondition(query.memberId()),
             emdCondition(query.emdId()),
@@ -51,7 +51,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         .select(post.count())
         .from(post)
         .where(
-            notRemoved(),
+            visibleCondition(),
             keywordCondition(query.key(), query.keyword()),
             memberIdCondition(query.memberId()),
             emdCondition(query.emdId()),
@@ -63,8 +63,8 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         .fetchOne();
   }
 
-  private BooleanExpression notRemoved() {
-    return post.postStatus.ne(PostStatus.REMOVED);
+  private BooleanExpression visibleCondition() {
+    return post.postStatus.ne(PostStatus.REMOVED).and(post.isWithhold.isFalse());
   }
 
   private BooleanExpression keywordCondition(SearchKey key, String keyword) {

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -21,6 +21,7 @@ import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.command.RemovePostCommand;
+import com.bob.domain.post.service.dto.command.WithholdPostStatusCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
@@ -40,6 +41,7 @@ import com.bob.domain.post.usecase.PostModifyUseCase;
 import com.bob.domain.post.usecase.PostReadUseCase;
 import com.bob.domain.post.usecase.PostWriteUseCase;
 import com.bob.global.exception.exceptions.ApplicationException;
+import com.bob.global.exception.response.ApplicationError;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -125,15 +127,22 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
 
   @Transactional
   public PostDetailResponse readPostDetailProcess(ReadPostDetailQuery query) {
-    if (query.shouldIncreaseViewCount()) {
+    if (query.isClient()) {
       postRepository.increaseViewCount(query.postId());
     }
     Post post = postReader.readPostById(query.postId());
+    verifyAccessiblePost(post, query.isClient());
     PostMemberSummaryResponse memberSummary = memberPort.readPostMemberSummary(post.getSellerId());
     PostFileSummaryResponse fileSummary = from(filePort.readPostFileSummaries(post.getId()));
     boolean isOwner = query.memberId() != null && post.getSellerId().equals(query.memberId());
     boolean isFavorite = postFavoriteService.isFavorite(query.memberId(), post.getId());
     return PostDetailResponse.from(post, memberSummary, fileSummary, isFavorite, isOwner);
+  }
+
+  private static void verifyAccessiblePost(Post post, boolean isClient) {
+    if (isClient && (post.getPostStatus() == REMOVED || post.isWithhold())) {
+      throw new ApplicationException(ApplicationError.NOT_ACCESSIBLE_POST);
+    }
   }
 
   @Transactional
@@ -171,5 +180,14 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
     if (status == IN_PROGRESS) {
       throw new ApplicationException(UNREMOVABLE_POST_STATE);
     }
+  }
+
+  @Transactional
+  public void withholdPostProcess(WithholdPostStatusCommand command) {
+    postReader.readPostsByMember(command.memberId())
+        .forEach(p -> {
+          p.updateIsWithhold(true);
+          postFavoriteService.removePostFavoriteProcess(p.getId());
+        });
   }
 }

--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -1,13 +1,20 @@
 package com.bob.domain.post.service;
 
+import static com.bob.domain.post.entity.status.PostStatus.IN_PROGRESS;
+import static com.bob.domain.post.entity.status.PostStatus.REMOVED;
 import static com.bob.domain.post.entity.status.PostStatus.valueOf;
 import static com.bob.domain.post.service.dto.response.PostFileSummaryResponse.from;
+import static com.bob.global.exception.response.ApplicationError.ALREADY_REMOVED_POST_STATE;
+import static com.bob.global.exception.response.ApplicationError.NOT_POST_OWNER;
+import static com.bob.global.exception.response.ApplicationError.NOT_VERIFIED_MEMBER;
+import static com.bob.global.exception.response.ApplicationError.UNREMOVABLE_POST_STATE;
 
 import com.bob.domain.book.entity.Book;
 import com.bob.domain.book.service.BookService;
 import com.bob.domain.category.entity.Category;
 import com.bob.domain.category.service.reader.CategoryReader;
 import com.bob.domain.post.entity.Post;
+import com.bob.domain.post.entity.status.PostStatus;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
@@ -33,7 +40,6 @@ import com.bob.domain.post.usecase.PostModifyUseCase;
 import com.bob.domain.post.usecase.PostReadUseCase;
 import com.bob.domain.post.usecase.PostWriteUseCase;
 import com.bob.global.exception.exceptions.ApplicationException;
-import com.bob.global.exception.response.ApplicationError;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -71,12 +77,12 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
 
   private void verifyAreaAuthentication(boolean validity) {
     if (!validity) {
-      throw new ApplicationException(ApplicationError.NOT_VERIFIED_MEMBER);
+      throw new ApplicationException(NOT_VERIFIED_MEMBER);
     }
   }
 
   private void imageMapping(List<String> fileNames, Long postId) {
-    if(fileNames == null || fileNames.isEmpty()) {
+    if (fileNames == null || fileNames.isEmpty()) {
       return;
     }
     filePort.modifyReferenceId(fileNames, String.valueOf(postId));
@@ -104,7 +110,9 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
   }
 
   private void addChildCategoryIds(ReadFilteredPostsQuery query) {
-    if (query.categoryIds() == null || query.categoryIds().isEmpty()) return;
+    if (query.categoryIds() == null || query.categoryIds().isEmpty()) {
+      return;
+    }
     List<Integer> categoryIds = categoryReader.readChildCategoryIds(query.categoryIds().get(0));
     query.updateCategoryIds(categoryIds);
   }
@@ -117,7 +125,9 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
 
   @Transactional
   public PostDetailResponse readPostDetailProcess(ReadPostDetailQuery query) {
-    if(query.shouldIncreaseViewCount()) postRepository.increaseViewCount(query.postId());
+    if (query.shouldIncreaseViewCount()) {
+      postRepository.increaseViewCount(query.postId());
+    }
     Post post = postReader.readPostById(query.postId());
     PostMemberSummaryResponse memberSummary = memberPort.readPostMemberSummary(post.getSellerId());
     PostFileSummaryResponse fileSummary = from(filePort.readPostFileSummaries(post.getId()));
@@ -143,13 +153,23 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
   public void removePostProcess(RemovePostCommand command) {
     Post post = postReader.readPostById(command.postId());
     verifyPostOwner(command.memberId(), post.getSellerId());
+    verifyRemovable(post.getPostStatus());
     postFavoriteService.removePostFavoriteProcess(post.getId());
-    postRepository.deleteById(post.getId());
+    post.updatePostStatus(REMOVED);
   }
 
-  private void verifyPostOwner(UUID requestMemberId, UUID postMemberId) {
+  private static void verifyPostOwner(UUID requestMemberId, UUID postMemberId) {
     if (!Objects.equals(requestMemberId, postMemberId)) {
-      throw new ApplicationException(ApplicationError.NOT_POST_OWNER);
+      throw new ApplicationException(NOT_POST_OWNER);
+    }
+  }
+
+  private static void verifyRemovable(PostStatus status) {
+    if (status == REMOVED) {
+      throw new ApplicationException(ALREADY_REMOVED_POST_STATE);
+    }
+    if (status == IN_PROGRESS) {
+      throw new ApplicationException(UNREMOVABLE_POST_STATE);
     }
   }
 }

--- a/src/main/java/com/bob/domain/post/service/dto/command/WithholdPostStatusCommand.java
+++ b/src/main/java/com/bob/domain/post/service/dto/command/WithholdPostStatusCommand.java
@@ -1,0 +1,9 @@
+package com.bob.domain.post.service.dto.command;
+
+import java.util.UUID;
+
+public record WithholdPostStatusCommand(
+    UUID memberId
+) {
+
+}

--- a/src/main/java/com/bob/domain/post/service/dto/query/ReadPostDetailQuery.java
+++ b/src/main/java/com/bob/domain/post/service/dto/query/ReadPostDetailQuery.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 public record ReadPostDetailQuery(
     UUID memberId,
     Long postId,
-    boolean shouldIncreaseViewCount
+    boolean isClient
 ) {
 
   public static ReadPostDetailQuery of(UUID memberId, Long postId, boolean flag) {

--- a/src/main/java/com/bob/domain/post/service/event/PostEventHandler.java
+++ b/src/main/java/com/bob/domain/post/service/event/PostEventHandler.java
@@ -1,0 +1,21 @@
+package com.bob.domain.post.service.event;
+
+import com.bob.domain.post.service.PostService;
+import com.bob.domain.post.service.dto.command.WithholdPostStatusCommand;
+import com.bob.global.event.application.dto.RemoveMemberEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PostEventHandler {
+
+  private final PostService postService;
+
+  @EventListener
+  public void handleMemberRemoveEvent(RemoveMemberEvent event) {
+    WithholdPostStatusCommand command = new WithholdPostStatusCommand(event.memberId());
+    postService.withholdPostProcess(command);
+  }
+}

--- a/src/main/java/com/bob/domain/post/service/reader/PostReader.java
+++ b/src/main/java/com/bob/domain/post/service/reader/PostReader.java
@@ -6,6 +6,7 @@ import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,10 @@ public class PostReader {
 
   public List<Post> readFilteredPosts(ReadFilteredPostsQuery query, Pageable pageable) {
     return postRepository.findFilteredPosts(query, pageable);
+  }
+
+  public List<Post> readPostsByMember(UUID memberId) {
+    return postRepository.findAllBySellerId(memberId);
   }
 
   public Post readPostById(Long postId) {

--- a/src/main/java/com/bob/global/event/application/dto/RemoveMemberEvent.java
+++ b/src/main/java/com/bob/global/event/application/dto/RemoveMemberEvent.java
@@ -1,0 +1,12 @@
+package com.bob.global.event.application.dto;
+
+import java.util.UUID;
+
+public record RemoveMemberEvent(
+    UUID memberId
+) {
+
+  public static RemoveMemberEvent of(UUID memberId) {
+    return new RemoveMemberEvent(memberId);
+  }
+}

--- a/src/main/java/com/bob/global/exception/exceptions/ApplicationAuthenticationException.java
+++ b/src/main/java/com/bob/global/exception/exceptions/ApplicationAuthenticationException.java
@@ -1,8 +1,8 @@
 package com.bob.global.exception.exceptions;
 
+import com.bob.global.exception.response.AuthenticationError;
 import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
-import com.bob.global.exception.response.AuthenticationError;
 
 @Getter
 public class ApplicationAuthenticationException extends AuthenticationException {

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -39,6 +39,8 @@ public enum ApplicationError {
   NOT_POST_OWNER("E303", "게시글 작성자가 아닙니다.", HttpStatus.FORBIDDEN),
   ALREADY_POST_FAVORITE("E304", "이미 좋아요한 게시글입니다.", HttpStatus.BAD_REQUEST),
   INVALID_POST_FAVORITE("E305", "좋아요 하지 않은 게시글입니다.", HttpStatus.BAD_REQUEST),
+  ALREADY_REMOVED_POST_STATE("E306", "이미 삭제 된 게시글입니다.", HttpStatus.BAD_REQUEST),
+  UNREMOVABLE_POST_STATE("E307", "거래 예약 상태의 게시글을 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
 
   // 채팅 예외
   IS_SAME_CHAT_MEMBER("E401", "자신과의 채팅은 불가능합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/bob/global/exception/response/ApplicationError.java
+++ b/src/main/java/com/bob/global/exception/response/ApplicationError.java
@@ -41,6 +41,7 @@ public enum ApplicationError {
   INVALID_POST_FAVORITE("E305", "좋아요 하지 않은 게시글입니다.", HttpStatus.BAD_REQUEST),
   ALREADY_REMOVED_POST_STATE("E306", "이미 삭제 된 게시글입니다.", HttpStatus.BAD_REQUEST),
   UNREMOVABLE_POST_STATE("E307", "거래 예약 상태의 게시글을 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
+  NOT_ACCESSIBLE_POST("E308", "삭제되었거나 보류 중인 게시글은 조회할 수 없습니다.", HttpStatus.NOT_FOUND),
 
   // 채팅 예외
   IS_SAME_CHAT_MEMBER("E401", "자신과의 채팅은 불가능합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/bob/global/exception/response/AuthenticationError.java
+++ b/src/main/java/com/bob/global/exception/response/AuthenticationError.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum AuthenticationError {
   FAILED_AUTHENTICATION("E001", "인증에 실패하였습니다."),
   IS_EXPIRED_TOKEN("E002", "인증 정보가 만료되었습니다."),
-  FAILED_GET_AUTHENTICATION_INFORMATION("E003", "인증 정보를 확인할 수 없습니다. 다시 로그인 해주세요.");
+  FAILED_GET_AUTHENTICATION_INFORMATION("E003", "인증 정보를 확인할 수 없습니다. 다시 로그인 해주세요."),
+  IS_REMOVED_MEMBER("E004", "탈퇴한 계정입니다.");
 
   private String code;
   private String message;

--- a/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
+++ b/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -58,11 +59,15 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
   @Override
   protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
-    authenticationEntryPoint.commence(
-        request,
-        response,
-        new ApplicationAuthenticationException(AuthenticationError.FAILED_AUTHENTICATION) {}
-    );
+    AuthenticationError error = setAuthenticationError(failed);
+    authenticationEntryPoint.commence(request, response, new ApplicationAuthenticationException(error) {});
+  }
+
+  private static AuthenticationError setAuthenticationError(AuthenticationException ex) {
+    if (ex instanceof DisabledException) {
+      return AuthenticationError.IS_REMOVED_MEMBER;
+    }
+    return AuthenticationError.FAILED_AUTHENTICATION;
   }
 
   private LoginRequest readLoginData(HttpServletRequest request) {

--- a/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/bob/infra/auth/jwt/filter/JwtAuthorizationFilter.java
@@ -66,7 +66,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       return;
     }
 
-    final MemberDetails memberDetails = new MemberDetails(jwtProvider.getMemberId(accessToken));
+    final MemberDetails memberDetails = new MemberDetails(jwtProvider.getMemberId(accessToken), true);
     final Authentication authentication = new UsernamePasswordAuthenticationToken(
         memberDetails, null, memberDetails.getAuthorities()
     );

--- a/src/main/java/com/bob/infra/auth/response/MemberDetails.java
+++ b/src/main/java/com/bob/infra/auth/response/MemberDetails.java
@@ -9,11 +9,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 public record MemberDetails(
     UUID id,
     String email,
-    String password
+    String password,
+    boolean enabled
 ) implements UserDetails {
 
-  public MemberDetails(UUID id) {
-    this(id, null, null);
+  public MemberDetails(UUID id, boolean enabled) {
+    this(id, null, null, enabled);
   }
 
   @Override
@@ -29,6 +30,11 @@ public record MemberDetails(
   @Override
   public String getUsername() {
     return email;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
   }
 }
 

--- a/src/main/java/com/bob/infra/auth/service/MemberDetailsService.java
+++ b/src/main/java/com/bob/infra/auth/service/MemberDetailsService.java
@@ -20,6 +20,6 @@ public class MemberDetailsService implements UserDetailsService {
     Member member = memberRepository.findByEmail(username)
         .orElseThrow(() -> new UsernameNotFoundException(username));
 
-    return new MemberDetails(member.getId(), member.getEmail(), member.getPassword());
+    return new MemberDetails(member.getId(), member.getEmail(), member.getPassword(), !member.isRemove());
   }
 }

--- a/src/main/java/com/bob/web/member/controller/MemberController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.bob.web.member.controller;
 
 import static com.bob.web.common.symbol.ResponseSymbol.CREATED;
+import static com.bob.web.common.symbol.ResponseSymbol.DELETED;
 import static com.bob.web.common.symbol.ResponseSymbol.SENT;
 import static com.bob.web.common.symbol.ResponseSymbol.UPDATED;
 import static com.bob.web.member.request.ReadProfileRequest.toQuery;
 
+import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.usecase.MemberModifyUseCase;
 import com.bob.domain.member.usecase.MemberReadUseCase;
@@ -17,11 +19,13 @@ import com.bob.web.member.request.ChangeProfileRequest;
 import com.bob.web.member.request.IssuePasswordRequest;
 import com.bob.web.member.request.ChangeMemberProfileImageRequest;
 import com.bob.web.member.request.SignupRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -88,5 +92,15 @@ public class MemberController {
   ) {
     modifyUseCase.changeMemberProfileImageProcess(request.toCommand(memberId));
     return new CommonResponse<>(true, UPDATED);
+  }
+
+  @DeleteMapping("/me")
+  public CommonResponse<ResponseSymbol> handleRemoveMember(
+      HttpServletResponse response,
+      @AuthenticationId UUID memberId
+  ) {
+    RemoveMemberCommand command = new RemoveMemberCommand(memberId);
+    modifyUseCase.softRemoveMemberProcess(command, response);
+    return new CommonResponse<>(true, DELETED);
   }
 }

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -32,26 +32,20 @@ import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
-import com.bob.global.event.application.dto.RemoveMemberEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
-import com.bob.support.redis.RedisContainerConfig;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
-@Import(RedisContainerConfig.class)
 @DisplayName("사용자 서비스 통합 테스트")
 @Transactional
 @SpringBootTest

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -25,24 +25,33 @@ import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileImageCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
+import com.bob.global.event.application.dto.RemoveMemberEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
+import com.bob.support.redis.RedisContainerConfig;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
+@Import(RedisContainerConfig.class)
 @DisplayName("사용자 서비스 통합 테스트")
 @Transactional
 @SpringBootTest
@@ -274,5 +283,28 @@ class MemberServiceIntgTest extends TestContainerSupport {
 
     // then
     assertThat(member.getProfileImageUrl()).isEqualTo(command.fileName());
+  }
+
+  @Test
+  @DisplayName("회원 삭제 - 성공 테스트(소프트 삭제 + 이벤트 발행 + 쿠키 제거)")
+  void 회원을_삭제상태로_변경하고_이벤트를_발행하며_쿠키를_제거한다() {
+    // given
+    Member member = defaultMember();
+    memberRepository.save(member);
+
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    RemoveMemberCommand command = new RemoveMemberCommand(member.getId());
+
+    // when
+    memberService.softRemoveMemberProcess(command, response);
+
+    // then
+    Member after = memberRepository.findById(member.getId()).orElseThrow();
+    assertThat(after.isRemove()).isTrue();
+    List<String> setCookies = response.getHeaders("Set-Cookie");
+    assertThat(setCookies).anySatisfy(h ->
+        assertThat(h).contains("AUTHORIZATION=").contains("Max-Age=0"));
+    assertThat(setCookies).anySatisfy(h ->
+        assertThat(h).contains("REFRESH_KEY=").contains("Max-Age=0"));
   }
 }

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -8,6 +8,7 @@ import static com.bob.support.fixture.command.ChangePostCommandFixture.DEFAULT_C
 import static com.bob.support.fixture.command.CreatePostCommandFixture.FILE_NAMES;
 import static com.bob.support.fixture.command.CreatePostCommandFixture.defaultCreatePostCommand;
 import static com.bob.support.fixture.domain.CategoryFixture.defaultCategory;
+import static com.bob.support.fixture.query.PostQueryFixture.defaultReadFilteredPostsQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchAuthorQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchBetween_5000_10000_PriceQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchBookStatusQuery;
@@ -51,6 +52,7 @@ import com.bob.domain.post.service.port.out.PostAreaPort;
 import com.bob.domain.post.service.port.out.PostFilePort;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.support.TestContainerSupport;
+import com.bob.support.redis.RedisContainerConfig;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.time.LocalDateTime;
@@ -62,10 +64,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
+@Import(RedisContainerConfig.class)
 @DisplayName("게시글 서비스 통합 테스트")
 @Transactional
 @SpringBootTest
@@ -88,6 +93,9 @@ class PostServiceIntgTest extends TestContainerSupport {
 
   @Autowired
   private BookRepository bookRepository;
+
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
 
   @MockitoBean
   private PostAreaPort areaPort;
@@ -331,6 +339,31 @@ class PostServiceIntgTest extends TestContainerSupport {
   }
 
   @Test
+  void 삭제_된_게시글은_조회_목록에서_제외된다() {
+    long allPostsCount = postRepository.count();
+    long removedPostsCount = jdbcTemplate.queryForObject(
+        """
+          SELECT COUNT(*) 
+          FROM posts
+          WHERE post_status = 'REMOVED'
+        """, Long.class
+    );
+    System.out.println("모든 게시글: " + allPostsCount);
+    System.out.println("삭제 게시글: " + removedPostsCount);
+
+    ReadFilteredPostsQuery query = defaultReadFilteredPostsQuery(); // 기본 게시글 조회 쿼리 (app 기본)
+    pageable = PageRequest.of(0, Integer.MAX_VALUE); // 모든 게시글 개수 조회를 위한 page limit 수정
+    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+
+    assertThat(result.posts())
+        .extracting(PostSummary::postStatus)
+        .doesNotContain("REMOVED");
+
+    assertThat(removedPostsCount).isNotZero();
+    assertThat(result.posts()).hasSize((int) (allPostsCount - removedPostsCount));
+  }
+
+  @Test
   @DisplayName("책 상태 필터 - 최상")
   void 책상태로_게시글을_조회할_수_있다() {
     ReadFilteredPostsQuery query = searchBookStatusQuery();
@@ -479,7 +512,7 @@ class PostServiceIntgTest extends TestContainerSupport {
 
 
   @Test
-  @DisplayName("게시글 삭제 - 작성자 본인이 삭제하면 게시글과 좋아요가 모두 삭제된다")
+  @DisplayName("게시글 삭제 - 작성자 본인이 삭제하면 게시글은 삭제 상태가 되고 좋아요는 모두 삭제된다")
   void 작성자_본인이_게시글을_삭제하면_게시글과_좋아요가_모두_삭제된다() {
     // given
     UUID writerId = UUID.fromString("0197365f-8074-7d24-a332-0c5f1dbe9c59");
@@ -499,7 +532,7 @@ class PostServiceIntgTest extends TestContainerSupport {
     Optional<PostFavorite> writerFavorite = postFavoriteRepository.findByMemberIdAndPostId(writerId, post.getId());
     Optional<PostFavorite> otherFavorite = postFavoriteRepository.findByMemberIdAndPostId(otherId, post.getId());
 
-    assertThat(deletedPost).isEmpty();
+    assertThat(deletedPost.get().getPostStatus()).isEqualTo(PostStatus.REMOVED);
     assertThat(writerFavorite).isEmpty();
     assertThat(otherFavorite).isEmpty();
   }

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -70,7 +70,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
-@Import(RedisContainerConfig.class)
 @DisplayName("게시글 서비스 통합 테스트")
 @Transactional
 @SpringBootTest
@@ -348,8 +347,6 @@ class PostServiceIntgTest extends TestContainerSupport {
           WHERE post_status = 'REMOVED'
         """, Long.class
     );
-    System.out.println("모든 게시글: " + allPostsCount);
-    System.out.println("삭제 게시글: " + removedPostsCount);
 
     ReadFilteredPostsQuery query = defaultReadFilteredPostsQuery(); // 기본 게시글 조회 쿼리 (app 기본)
     pageable = PageRequest.of(0, Integer.MAX_VALUE); // 모든 게시글 개수 조회를 위한 page limit 수정

--- a/src/test/intg/resources/application-intg.yml
+++ b/src/test/intg/resources/application-intg.yml
@@ -51,3 +51,6 @@ sse:
 
 app:
   base-url: "https://base"
+
+oauth:
+  entrance: entrance

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS members (
     password VARCHAR(255) NOT NULL,
     nickname VARCHAR(20) NOT NULL,
     profile_image_url VARCHAR(255),
+    provider ENUM('GOOGLE', 'NAVER'),
     created_at DATETIME
 );
 
@@ -39,7 +40,7 @@ CREATE TABLE IF NOT EXISTS categories (
 -- ========================
 CREATE TABLE IF NOT EXISTS posts (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    post_status ENUM('READY', 'IN_PROGRESS', 'COMPLETED') NOT NULL,
+    post_status ENUM('READY', 'IN_PROGRESS', 'COMPLETED', 'REMOVED') NOT NULL,
     category_id INT NOT NULL,
     seller_id BINARY(16) NOT NULL,
     thumbnail_url VARCHAR(255) NOT NULL,
@@ -320,6 +321,8 @@ INSERT INTO posts (book_id, seller_id, category_id, book_status, post_status, se
 (4, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'BEST', 'IN_PROGRESS', 16000, '거래 진행중 상태', 213, 'https://image/10.png', now()),
 (5, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'HIGH', 'READY', 17000, '책 상태 상', 213, 'https://image/11.png', now()),
 (6, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'LOW', 'READY', 18000, '책 상태 하', 213, 'https://image/12.png', now()),
+(1, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'BEST', 'REMOVED', 10000, '삭제된 게시글1', 213, 'https://image/1.png', now()),
+(1, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'BEST', 'REMOVED', 10000, '삭제된 게시글2', 213, 'https://image/1.png', now()),
 (1, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'BEST', 'READY', 10000, '오래된 게시글', 213, 'https://image/old.png', '2023-01-01 10:00:00'),
 (2, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'HIGH', 'READY', 12000, '중간 게시글', 213, 'https://image/mid.png', '2023-06-01 10:00:00'),
 (3, UUID_TO_BIN('0197365f-8074-7d24-a332-95c9ebd1f5c0'), 1, 'LOW', 'READY', 14000, '최신 게시글', 213, 'https://image/new.png', '2024-01-01 10:00:00'),

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS members (
     nickname VARCHAR(20) NOT NULL,
     profile_image_url VARCHAR(255),
     provider ENUM('GOOGLE', 'NAVER'),
+    is_remove BOOLEAN DEFAULT FALSE,
     created_at DATETIME
 );
 
@@ -51,6 +52,7 @@ CREATE TABLE IF NOT EXISTS posts (
     registration_area_id INT,
     view_count INT DEFAULT 0,
     scrap_count INT DEFAULT 0,
+    is_withhold BOOLEAN DEFAULT FALSE,
     created_at DATETIME,
     FOREIGN KEY (category_id) REFERENCES categories(id),
     FOREIGN KEY (seller_id) REFERENCES members(id),

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -14,6 +14,7 @@ import static com.bob.support.fixture.domain.EmdAreaFixture.EMD_AREA_ID;
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
 import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
+import static com.bob.support.fixture.domain.MemberFixture.removedMember;
 import static com.bob.support.fixture.query.MemberQueryFixture.defaultReadProfileQuery;
 import static com.bob.support.fixture.response.MemberAreaSummaryResponseFixture.DEFAULT_AREA_SUMMARY_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,7 @@ import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
@@ -38,7 +40,9 @@ import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
 import com.bob.domain.member.service.reader.MemberReader;
+import com.bob.global.event.application.dto.RemoveMemberEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -48,6 +52,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @DisplayName("사용자 서비스 테스트")
@@ -71,6 +77,9 @@ class MemberServiceTest {
 
   @Mock
   private MemberAreaPort areaPort;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @Mock
   private BCryptPasswordEncoder encoder;
@@ -189,6 +198,25 @@ class MemberServiceTest {
   }
 
   @Test
+  void 탈퇴한_사용자의_프로필_조회_테스트() {
+    // given
+    Member member = removedMember();
+    ReadProfileQuery query = defaultReadProfileQuery();
+
+    given(memberReader.readMemberById(query.memberId())).willReturn(member);
+    given(areaPort.readMemberAreaSummary(MEMBER_ID)).willReturn(DEFAULT_AREA_SUMMARY_RESPONSE);
+
+    // when
+    MemberProfileResponse response = memberService.readProfileProcess(query);
+
+    // then
+    then(memberReader).should(times(1)).readMemberById(query.memberId());
+    assertThat(response.memberId()).isEqualTo(member.getId());
+    assertThat(response.nickname()).isEqualTo("(알 수 없음)");
+    assertThat(response.profileImageUrl()).isNull();
+  }
+
+  @Test
   @DisplayName("프로필 변경 - 성공 테스트")
   void 닉네임이_다르면_프로필을_변경할_수_있다() {
     // given
@@ -293,5 +321,31 @@ class MemberServiceTest {
     assertThatThrownBy(() -> memberService.changePasswordProcess(command))
         .isInstanceOf(ApplicationException.class)
         .hasMessage(INVALID_OLD_PASSWORD.getMessage());
+  }
+
+  @Test
+  void 회원_삭제_테스트() {
+    // given
+    Member member = defaultIdMember();
+    given(memberReader.readMemberById(member.getId())).willReturn(member);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    RemoveMemberCommand command = new RemoveMemberCommand(member.getId());
+
+    // when
+    memberService.softRemoveMemberProcess(command, response);
+
+    // then
+    assertThat(member.isRemove()).isTrue();
+
+    then(memberReader).should(times(1)).readMemberById(member.getId());
+    then(eventPublisher).should(times(1)).publishEvent(any(RemoveMemberEvent.class));
+
+    List<String> setCookies = response.getHeaders("Set-Cookie");
+    assertThat(setCookies).anySatisfy(h ->
+        assertThat(h).contains("AUTHORIZATION=").contains("Max-Age=0")
+    );
+    assertThat(setCookies).anySatisfy(h ->
+        assertThat(h).contains("REFRESH_KEY=").contains("Max-Age=0")
+    );
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/entity/PostTest.java
+++ b/src/test/unit/java/com/bob/domain/post/entity/PostTest.java
@@ -71,4 +71,16 @@ class PostTest {
     assertThat(post.getBookStatus().name()).isEqualTo(newBookStatus);
     assertThat(post.getDescription()).isEqualTo(newDescription);
   }
+
+  @Test
+  void 게시글_보류_상태_변경_테스트() {
+    // given
+    Post post = defaultPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID);
+
+    // when
+    post.updateIsWithhold(true);
+
+    // then
+    assertThat(post.isWithhold()).isTrue();
+  }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -43,6 +43,7 @@ import com.bob.domain.post.service.dto.command.ChangePostStatusCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.command.RemovePostCommand;
+import com.bob.domain.post.service.dto.command.WithholdPostStatusCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
@@ -57,9 +58,13 @@ import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -353,6 +358,42 @@ class PostServiceTest {
     then(postFavoriteService).should(times(1)).isFavorite(otherMemberId, post.getId());
   }
 
+  @ParameterizedTest(name = "클라이언트는 [{index}] {0}의 게시글 조회 불가")
+  @MethodSource("inaccessiblePostCases")
+  void 보류_삭제_상태_게시글_상세조회_테스트(String caseName, boolean isRemoved) {
+    // given
+    Post post = isRemoved
+        ? customStatusPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID, PostStatus.REMOVED)
+        : defaultPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID);
+
+    if (!isRemoved) {
+      post.updateIsWithhold(true);
+    }
+
+    ReadPostDetailQuery query = new ReadPostDetailQuery(UUID.randomUUID(), post.getId(), true);
+
+    given(postReader.readPostById(post.getId())).willReturn(post);
+    willDoNothing().given(postRepository).increaseViewCount(post.getId());
+
+    // when & then
+    assertThatThrownBy(() -> postService.readPostDetailProcess(query))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.NOT_ACCESSIBLE_POST.getMessage());
+
+    then(postRepository).should(times(1)).increaseViewCount(post.getId());
+    then(postReader).should(times(1)).readPostById(post.getId());
+    then(memberPort).shouldHaveNoInteractions();
+    then(filePort).shouldHaveNoInteractions();
+    then(postFavoriteService).shouldHaveNoInteractions();
+  }
+
+  private static Stream<Arguments> inaccessiblePostCases() {
+    return Stream.of(
+        Arguments.of("삭제 상태", true),  // isRemoved = true
+        Arguments.of("보류 상태", false)  // isRemoved = false (withhold = true)
+    );
+  }
+
   @DisplayName("게시글 수정 - 성공 테스트")
   @Test
   void 게시글_작성자는_게시글을_수정할_수_있다() {
@@ -442,9 +483,8 @@ class PostServiceTest {
     assertThat(post.getPostStatus()).isEqualTo(PostStatus.READY);
   }
 
-  @DisplayName("게시글 삭제 - 실패 테스트 (예약 상태의 게시글)")
   @Test
-  void 예약_상태의_게시글은_삭제할_수_없다() {
+  void 예약_상태_게시글_삭제_테스트() {
     // given
     Post post = customStatusPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID, PostStatus.IN_PROGRESS);
     RemovePostCommand command = new RemovePostCommand(MEMBER_ID, post.getId());
@@ -460,9 +500,8 @@ class PostServiceTest {
     assertThat(post.getPostStatus()).isEqualTo(PostStatus.IN_PROGRESS);
   }
 
-  @DisplayName("게시글 삭제 - 실패 테스트 (삭제 상태의 게시글)")
   @Test
-  void 삭제_상태의_게시글을_삭제하는_경우_예외를_발생시킨다() {
+  void 삭제_상태_게시글_삭제_테스트() {
     // given
     Post post = customStatusPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID, PostStatus.REMOVED);
     RemovePostCommand command = new RemovePostCommand(MEMBER_ID, post.getId());
@@ -476,5 +515,23 @@ class PostServiceTest {
     then(postReader).should(times(1)).readPostById(post.getId());
     then(postFavoriteService).shouldHaveNoInteractions();
     assertThat(post.getPostStatus()).isEqualTo(PostStatus.REMOVED);
+  }
+
+  @Test
+  void 탈퇴회원_관련_게시글_처리_테스트() {
+    // given
+    List<Post> posts = DEFAULT_MOCK_POSTS(); // size = 2
+    given(postReader.readPostsByMember(MEMBER_ID)).willReturn(posts);
+    WithholdPostStatusCommand command = new WithholdPostStatusCommand(MEMBER_ID);
+
+    // when
+    postService.withholdPostProcess(command);
+
+    // then
+    assertThat(posts.get(0).isWithhold()).isTrue();
+    assertThat(posts.get(1).isWithhold()).isTrue();
+    then(postFavoriteService).should(times(1)).removePostFavoriteProcess(1L);
+    then(postFavoriteService).should(times(1)).removePostFavoriteProcess(2L);
+    then(postReader).should(times(1)).readPostsByMember(MEMBER_ID);
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -14,6 +14,7 @@ import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.PostFixture.DEFAULT_MOCK_POSTS;
 import static com.bob.support.fixture.domain.PostFixture.defaultIdPost;
 import static com.bob.support.fixture.domain.PostFixture.defaultPost;
+import static com.bob.support.fixture.domain.PostFixture.customStatusPost;
 import static com.bob.support.fixture.query.PostQueryFixture.defaultReadFilteredPostsQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.defaultReadMemberFavoritePostsQuery;
 import static com.bob.support.fixture.query.PostQueryFixture.searchCategoryQuery;
@@ -417,7 +418,7 @@ class PostServiceTest {
     // then
     then(postReader).should(times(1)).readPostById(post.getId());
     then(postFavoriteService).should(times(1)).removePostFavoriteProcess(post.getId());
-    then(postRepository).should(times(1)).deleteById(post.getId());
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.REMOVED);
   }
 
   @DisplayName("게시글 삭제 - 실패 테스트 (작성자 X)")
@@ -438,6 +439,42 @@ class PostServiceTest {
 
     then(postReader).should(times(1)).readPostById(post.getId());
     then(postFavoriteService).shouldHaveNoInteractions();
-    then(postRepository).shouldHaveNoInteractions();
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.READY);
+  }
+
+  @DisplayName("게시글 삭제 - 실패 테스트 (예약 상태의 게시글)")
+  @Test
+  void 예약_상태의_게시글은_삭제할_수_없다() {
+    // given
+    Post post = customStatusPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID, PostStatus.IN_PROGRESS);
+    RemovePostCommand command = new RemovePostCommand(MEMBER_ID, post.getId());
+    given(postReader.readPostById(command.postId())).willReturn(post);
+
+    // when & then
+    assertThatThrownBy(() -> postService.removePostProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.UNREMOVABLE_POST_STATE.getMessage());
+
+    then(postReader).should(times(1)).readPostById(post.getId());
+    then(postFavoriteService).shouldHaveNoInteractions();
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.IN_PROGRESS);
+  }
+
+  @DisplayName("게시글 삭제 - 실패 테스트 (삭제 상태의 게시글)")
+  @Test
+  void 삭제_상태의_게시글을_삭제하는_경우_예외를_발생시킨다() {
+    // given
+    Post post = customStatusPost(defaultCategory(), defaultBook(), MEMBER_ID, EMD_AREA_ID, PostStatus.REMOVED);
+    RemovePostCommand command = new RemovePostCommand(MEMBER_ID, post.getId());
+    given(postReader.readPostById(command.postId())).willReturn(post);
+
+    // when & then
+    assertThatThrownBy(() -> postService.removePostProcess(command))
+        .isInstanceOf(ApplicationException.class)
+        .hasMessage(ApplicationError.ALREADY_REMOVED_POST_STATE.getMessage());
+
+    then(postReader).should(times(1)).readPostById(post.getId());
+    then(postFavoriteService).shouldHaveNoInteractions();
+    assertThat(post.getPostStatus()).isEqualTo(PostStatus.REMOVED);
   }
 }

--- a/src/test/unit/java/com/bob/domain/post/service/event/PostEventHandlerTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/event/PostEventHandlerTest.java
@@ -1,0 +1,43 @@
+package com.bob.domain.post.service.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.bob.domain.post.service.PostService;
+import com.bob.domain.post.service.dto.command.WithholdPostStatusCommand;
+import com.bob.global.event.application.dto.RemoveMemberEvent;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("PostEventHandler 테스트")
+@ExtendWith(MockitoExtension.class)
+class PostEventHandlerTest {
+
+  @InjectMocks
+  private PostEventHandler postEventHandler;
+
+  @Mock
+  private PostService postService;
+
+  @Test
+  void 회원_탈퇴_이벤트_처리_테스트() {
+    // given
+    UUID memberId = UUID.randomUUID();
+    RemoveMemberEvent event = RemoveMemberEvent.of(memberId);
+
+    // when
+    postEventHandler.handleMemberRemoveEvent(event);
+
+    // then
+    ArgumentCaptor<WithholdPostStatusCommand> captor = ArgumentCaptor.forClass(WithholdPostStatusCommand.class);
+    then(postService).should(times(1)).withholdPostProcess(captor.capture());
+    assertThat(captor.getValue().memberId()).isEqualTo(memberId);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/post/service/reader/PostReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/reader/PostReaderTest.java
@@ -1,6 +1,7 @@
 package com.bob.domain.post.service.reader;
 
 import static com.bob.global.exception.response.ApplicationError.NOT_EXIST_POST;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.PostFixture.DEFAULT_MOCK_POSTS;
 import static com.bob.support.fixture.query.PostQueryFixture.defaultReadFilteredPostsQuery;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,11 +28,13 @@ import org.springframework.data.domain.Pageable;
 @ExtendWith(MockitoExtension.class)
 class PostReaderTest {
 
-  private final Pageable pageable = PageRequest.of(0, 10);
   @InjectMocks
   private PostReader postReader;
+
   @Mock
   private PostRepository postRepository;
+
+  private Pageable pageable = PageRequest.of(0, 10);
 
   @Test
   @DisplayName("게시글 목록 조회 테스트")
@@ -80,5 +83,20 @@ class PostReaderTest {
         .hasMessage(NOT_EXIST_POST.getMessage());
 
     then(postRepository).should().findById(invalidId);
+  }
+
+  @Test
+  @DisplayName("회원 ID로 게시글 목록 조회 - 성공 테스트")
+  void readPostsByMember_success() {
+    // given
+    List<Post> posts = DEFAULT_MOCK_POSTS();
+    given(postRepository.findAllBySellerId(MEMBER_ID)).willReturn(posts);
+
+    // when
+    List<Post> result = postReader.readPostsByMember(MEMBER_ID);
+
+    // then
+    assertThat(result).hasSize(posts.size()).isEqualTo(posts);
+    then(postRepository).should().findAllBySellerId(MEMBER_ID);
   }
 }

--- a/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
@@ -1,6 +1,7 @@
 package com.bob.infra.auth.filter;
 
 import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
+import static com.bob.global.exception.response.AuthenticationError.IS_REMOVED_MEMBER;
 import static com.bob.support.fixture.auth.CookieFixture.ACCESS_VALUE;
 import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE;
 import static com.bob.support.fixture.auth.CookieFixture.SET_COOKIE_HEADER;
@@ -38,6 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.DelegatingServletInputStream;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -75,7 +77,7 @@ class LoginFilterTest {
   @Mock
   private HttpServletRequest request;
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @BeforeEach
   void setUp() {
@@ -83,8 +85,7 @@ class LoginFilterTest {
   }
 
   @Test
-  @DisplayName("로그인 요청 - 성공 테스트")
-  void 로그인_요청을_시도할_수_있다() throws Exception {
+  void 로그인_인증_시도_테스트() throws Exception {
     // given
     LoginRequest loginRequest = defaultLoginRequest();
     byte[] loginRequestBytes = objectMapper.writeValueAsBytes(loginRequest);
@@ -101,11 +102,10 @@ class LoginFilterTest {
   }
 
   @Test
-  @DisplayName("로그인 인증 - 성공 테스트")
-  void 인증에_성공하면_토큰을_발급하고_Security_Context에_정보를_저장한다() {
+  void 로그인_인증_성공_테스트() {
     // given
     FilterChain filterChain = mock(FilterChain.class);
-    MemberDetails memberDetails = new MemberDetails(UUID.randomUUID());
+    MemberDetails memberDetails = new MemberDetails(UUID.randomUUID(), true);
     Authentication authentication = new UsernamePasswordAuthenticationToken(
         memberDetails, null, memberDetails.getAuthorities()
     );
@@ -125,8 +125,7 @@ class LoginFilterTest {
   }
 
   @Test
-  @DisplayName("로그인 인증 - 실패 테스트")
-  void 인증에_실패하면_예외_핸들러를_호출한다() throws Exception {
+  void 로그인_인증_실패_테스트() throws Exception {
     // given
     AuthenticationException failed = mock(AuthenticationException.class);
 
@@ -136,6 +135,21 @@ class LoginFilterTest {
     // then
     then(authenticationEntryPoint).should().commence(eq(request), eq(response),
         argThat(e -> ((ApplicationAuthenticationException) e).getError() == FAILED_AUTHENTICATION)
+    );
+    then(redisPort).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void 탈퇴_계정_로그인_테스트() throws Exception {
+    // given
+    AuthenticationException ex = new DisabledException("disabled");
+
+    // when
+    loginFilter.unsuccessfulAuthentication(request, response, ex);
+
+    // then
+    then(authenticationEntryPoint).should().commence(eq(request), eq(response),
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == IS_REMOVED_MEMBER)
     );
     then(redisPort).shouldHaveNoInteractions();
   }

--- a/src/test/unit/java/com/bob/infra/auth/service/MemberDetailsServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/MemberDetailsServiceTest.java
@@ -30,26 +30,42 @@ class MemberDetailsServiceTest {
   private MemberRepository memberRepository;
 
   @Test
-  @DisplayName("회원 조회 - 성공 테스트")
-  void 이메일로_회원정보를_조회할_수_있다() {
+  void 정상_회원_조회_테스트() {
     // given
     Member member = defaultIdMember();
     memberRepository.save(member);
     given(memberRepository.findByEmail("test@email.com")).willReturn(Optional.of(member));
 
     // when
-    MemberDetails userDetails = (MemberDetails) memberDetailsService.loadUserByUsername(member.getEmail());
+    MemberDetails memberDetails = (MemberDetails) memberDetailsService.loadUserByUsername(member.getEmail());
 
     // then
-    assertThat(userDetails).isNotNull();
-    assertThat(userDetails.id()).isEqualTo(MEMBER_ID);
-    assertThat(userDetails.email()).isEqualTo(member.getEmail());
-    assertThat(userDetails.password()).isEqualTo(member.getPassword());
+    assertThat(memberDetails).isNotNull();
+    assertThat(memberDetails.id()).isEqualTo(MEMBER_ID);
+    assertThat(memberDetails.email()).isEqualTo(member.getEmail());
+    assertThat(memberDetails.password()).isEqualTo(member.getPassword());
+    assertThat(memberDetails.enabled()).isTrue();
   }
 
   @Test
-  @DisplayName("회원 조회 - 실패 테스트(이메일 존재 X)")
-  void 이메일로_회원을_찾지_못하면_예외를_던진다() {
+  void 탈퇴_회원_조회_테스트() {
+    // given
+    Member member = defaultIdMember();
+    member.updateRemoveStatus(true);
+    memberRepository.save(member);
+    given(memberRepository.findByEmail("test@email.com")).willReturn(Optional.of(member));
+
+    // when
+    MemberDetails memberDetails = (MemberDetails) memberDetailsService.loadUserByUsername(member.getEmail());
+
+    // then
+    assertThat(memberDetails).isNotNull();
+    assertThat(memberDetails.id()).isEqualTo(MEMBER_ID);
+    assertThat(memberDetails.enabled()).isFalse(); // 로그인 필터에서 DisabledException 처리
+  }
+
+  @Test
+  void 존재하지_않는_회원_조회_테스트() {
     // given
     given(memberRepository.findByEmail("unknown@email.com")).willReturn(Optional.empty());
 

--- a/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
@@ -48,4 +48,13 @@ public class MemberFixture {
         .nickname("tester")
         .build();
   }
+
+  public static Member removedMember() {
+    return Member.builder()
+        .email("test@email.com")
+        .password("password")
+        .nickname("tester")
+        .isRemove(true)
+        .build();
+  }
 }

--- a/src/test/unit/java/com/bob/support/fixture/domain/PostFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/PostFixture.java
@@ -41,6 +41,20 @@ public class PostFixture {
         .build();
   }
 
+  public static Post customStatusPost(Category category, Book book, UUID sellerId, Integer emdId, PostStatus status) {
+    return Post.builder()
+        .book(book)
+        .sellerId(sellerId)
+        .category(category)
+        .bookStatus(BookStatus.BEST)
+        .postStatus(status)
+        .sellPrice(30000)
+        .description("Description")
+        .registrationAreaId(emdId)
+        .thumbnailUrl("https://image/1.png")
+        .build();
+  }
+
   public static List<Post> DEFAULT_MOCK_POSTS() {
     return List.of(
         Post.builder()

--- a/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -18,9 +19,11 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
+import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.usecase.MemberModifyUseCase;
 import com.bob.domain.member.usecase.MemberReadUseCase;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -197,5 +200,19 @@ class MemberControllerTest {
         .andExpect(status().isOk());
 
     verify(modifyUseCase, times(1)).changeMemberProfileImageProcess(any());
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 API 호출 테스트")
+  void 회원_탈퇴_API를_호출할_수_있다() throws Exception {
+    // when & then
+    mvc.perform(delete("/members/me")
+            .requestAttr("memberId", MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("DELETED"));
+
+    verify(modifyUseCase, times(1))
+        .softRemoveMemberProcess(any(RemoveMemberCommand.class), any(HttpServletResponse.class));
   }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
#90 

### 📜 작업 내용
- [x] 회원 탈퇴 기능 (soft delete) 
- [x] 게시글 `REMOVED` 상태 추가 및 삭제 기능 수정 (hard -> soft delete)
- [x] 게시글 보류 상태 추가 및 회원 탈퇴 시 적용
- [x] 탈퇴 계정의 로그인 시도 시 예외 처리

### 📄 참고
- 게시글 목록 조회 시 탈퇴 회원 게시글(보류 상태) 제외, 계정 복구(미구현) 시 정상 조회 가능
- 탈퇴 회원의 프로필 조회 시 `nickname`: `(알 수 없음)`, `profile`: `null` 통일

### ⚠️ 종료할 이슈
this closes #90 
