### PR TITLE
fix: 탈퇴 회원의 소셜 로그인 실패 처리

### DIFF
--- a/src/main/java/com/bob/domain/member/entity/Member.java
+++ b/src/main/java/com/bob/domain/member/entity/Member.java
@@ -44,8 +44,9 @@ public class Member extends BaseTime {
   @Column
   private String profileImageUrl;
 
+  @Enumerated(EnumType.STRING)
   @Column
-  private boolean isRemove;
+  private Status status;
 
   public void updatePassword(String newPassword) {
     password = newPassword;
@@ -59,8 +60,8 @@ public class Member extends BaseTime {
     profileImageUrl = newProfileImageUrl;
   }
 
-  public void updateRemoveStatus(boolean isRemove) {
-    this.isRemove = isRemove;
+  public void updateStatus(Status status) {
+    this.status = status;
   }
 
   public boolean isEqualsNickname(String oldNickname) {

--- a/src/main/java/com/bob/domain/member/entity/Status.java
+++ b/src/main/java/com/bob/domain/member/entity/Status.java
@@ -1,0 +1,5 @@
+package com.bob.domain.member.entity;
+
+public enum Status {
+  ACTIVE, WITHDRAW, BANNED
+}

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.bob.domain.member.service;
 
+import static com.bob.domain.member.entity.Status.WITHDRAW;
 import static com.bob.global.exception.response.ApplicationError.ALREADY_EXISTS_EMAIL;
 import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PASSWORD;
 import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
@@ -19,6 +20,7 @@ import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberAreaSummaryResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
@@ -29,7 +31,6 @@ import com.bob.domain.member.usecase.MemberWriteUseCase;
 import com.bob.global.event.application.dto.RemoveMemberEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -78,13 +79,13 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
   }
 
   @Transactional
-  public UUID socialLoginProcess(SocialLoginCommand command) {
+  public SocialLoginResponse socialLoginProcess(SocialLoginCommand command) {
     return memberRepository.findByEmail(command.email())
-        .map(Member::getId)
+        .map(SocialLoginResponse::from)
         .orElseGet(() -> {
           Member member = memberRepository.save(command.toMember(encoder.encode(generateCode(12))));
           areaPort.createNonAuthenticatedActivityArea(member.getId(), command.emdId());
-          return member.getId();
+          return SocialLoginResponse.from(member);
         });
   }
 
@@ -138,7 +139,7 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
   @Transactional
   public void softRemoveMemberProcess(RemoveMemberCommand command, HttpServletResponse response) {
     Member member = memberReader.readMemberById(command.memberId());
-    member.updateRemoveStatus(true);
+    member.updateStatus(WITHDRAW);
     eventPublisher.publishEvent(RemoveMemberEvent.of(member.getId()));
     removeCookie(response, "AUTHORIZATION");
     removeCookie(response, "REFRESH_KEY");

--- a/src/main/java/com/bob/domain/member/service/dto/command/CreateMemberCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/CreateMemberCommand.java
@@ -1,5 +1,7 @@
 package com.bob.domain.member.service.dto.command;
 
+import static com.bob.domain.member.entity.Status.ACTIVE;
+
 import com.bob.domain.member.entity.Member;
 
 public record CreateMemberCommand(
@@ -11,6 +13,7 @@ public record CreateMemberCommand(
 
   public Member toMember(String encodedPassword) {
     return Member.builder()
+        .status(ACTIVE)
         .email(email)
         .password(encodedPassword)
         .nickname(nickname)

--- a/src/main/java/com/bob/domain/member/service/dto/command/SocialLoginCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/SocialLoginCommand.java
@@ -1,5 +1,7 @@
 package com.bob.domain.member.service.dto.command;
 
+import static com.bob.domain.member.entity.Status.ACTIVE;
+
 import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.entity.SocialProvider;
 import lombok.Builder;
@@ -23,6 +25,7 @@ public record SocialLoginCommand(
 
   public Member toMember(String encodedPassword) {
     return Member.builder()
+        .status(ACTIVE)
         .provider(SocialProvider.valueOf(provider))
         .email(email)
         .password(encodedPassword)

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
@@ -1,5 +1,7 @@
 package com.bob.domain.member.service.dto.response;
 
+import static com.bob.domain.member.entity.Status.WITHDRAW;
+
 import com.bob.domain.member.entity.Member;
 import java.time.LocalDate;
 import java.util.UUID;
@@ -14,7 +16,7 @@ public record MemberProfileResponse(
 ) {
 
   public static MemberProfileResponse from(Member member, MemberAreaSummaryResponse areaSummary) {
-    final boolean removed = Boolean.TRUE.equals(member.isRemove());
+    final boolean removed = member.getStatus() == WITHDRAW;
     final String nickname = removed ? "(알 수 없음)" : member.getNickname();
     final String profileImageUrl = removed ? null : member.getProfileImageUrl();
 

--- a/src/main/java/com/bob/domain/member/service/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/SocialLoginResponse.java
@@ -1,0 +1,19 @@
+package com.bob.domain.member.service.dto.response;
+
+import com.bob.domain.member.entity.Member;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record SocialLoginResponse(
+    UUID memberId,
+    String status
+) {
+
+  public static SocialLoginResponse from(Member member) {
+    return SocialLoginResponse.builder()
+        .memberId(member.getId())
+        .status(member.getStatus().name())
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/member/usecase/MemberWriteUseCase.java
+++ b/src/main/java/com/bob/domain/member/usecase/MemberWriteUseCase.java
@@ -2,11 +2,11 @@ package com.bob.domain.member.usecase;
 
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
-import java.util.UUID;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 
 public interface MemberWriteUseCase {
 
   void signupProcess(CreateMemberCommand command);
 
-  UUID socialLoginProcess(SocialLoginCommand command);
+  SocialLoginResponse socialLoginProcess(SocialLoginCommand command);
 }

--- a/src/main/java/com/bob/global/exception/response/AuthenticationError.java
+++ b/src/main/java/com/bob/global/exception/response/AuthenticationError.java
@@ -9,7 +9,8 @@ public enum AuthenticationError {
   FAILED_AUTHENTICATION("E001", "인증에 실패하였습니다."),
   IS_EXPIRED_TOKEN("E002", "인증 정보가 만료되었습니다."),
   FAILED_GET_AUTHENTICATION_INFORMATION("E003", "인증 정보를 확인할 수 없습니다. 다시 로그인 해주세요."),
-  IS_REMOVED_MEMBER("E004", "탈퇴한 계정입니다.");
+  IS_REMOVED_MEMBER("E004", "탈퇴한 계정입니다."),
+  IS_BANNED_MEMBER("E004", "제재된 계정입니다.");
 
   private String code;
   private String message;

--- a/src/main/java/com/bob/global/exception/response/AuthenticationError.java
+++ b/src/main/java/com/bob/global/exception/response/AuthenticationError.java
@@ -9,7 +9,7 @@ public enum AuthenticationError {
   FAILED_AUTHENTICATION("E001", "인증에 실패하였습니다."),
   IS_EXPIRED_TOKEN("E002", "인증 정보가 만료되었습니다."),
   FAILED_GET_AUTHENTICATION_INFORMATION("E003", "인증 정보를 확인할 수 없습니다. 다시 로그인 해주세요."),
-  IS_REMOVED_MEMBER("E004", "탈퇴한 계정입니다."),
+  IS_WITHDRAWN_MEMBER("E004", "탈퇴한 계정입니다."),
   IS_BANNED_MEMBER("E004", "제재된 계정입니다.");
 
   private String code;

--- a/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
+++ b/src/main/java/com/bob/infra/auth/filter/LoginFilter.java
@@ -65,7 +65,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
   private static AuthenticationError setAuthenticationError(AuthenticationException ex) {
     if (ex instanceof DisabledException) {
-      return AuthenticationError.IS_REMOVED_MEMBER;
+      return AuthenticationError.IS_WITHDRAWN_MEMBER;
     }
     return AuthenticationError.FAILED_AUTHENTICATION;
   }

--- a/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandler.java
+++ b/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandler.java
@@ -2,33 +2,32 @@ package com.bob.infra.auth.oauth.handler;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
 import com.bob.global.exception.response.AuthenticationError;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
-@RequiredArgsConstructor
 @Component
 public class SocialAuthFailureHandler implements AuthenticationFailureHandler {
-
-  private final AuthenticationEntryPoint authenticationEntryPoint;
 
   @Value("${app.base-url}")
   private String baseUrl;
 
   @Override
-  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-    if (exception instanceof ApplicationAuthenticationException ex) {
-      AuthenticationError error = ex.getError();
-      authenticationEntryPoint.commence(request, response, new ApplicationAuthenticationException(error) {});
-      return;
-    }
-    response.sendRedirect(baseUrl + "/error?cause=" + exception.getMessage());
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+    final AuthenticationError error = (exception instanceof ApplicationAuthenticationException appEx)
+        ? appEx.getError()
+        : AuthenticationError.FAILED_AUTHENTICATION;
+
+    response.sendRedirect(UriComponentsBuilder.fromUriString(baseUrl)
+        .path("/error")
+        .queryParam("cause", error.name())
+        .build(true)
+        .toUriString()
+    );
   }
 }

--- a/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandler.java
+++ b/src/main/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandler.java
@@ -1,7 +1,7 @@
 package com.bob.infra.auth.oauth.handler;
 
-import static com.bob.global.utils.web.CookieUtils.removeCookie;
-
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,6 +9,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
@@ -16,17 +17,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class SocialAuthFailureHandler implements AuthenticationFailureHandler {
 
-  private static final String ACCESS_COOKIE_NAME = "AUTHORIZATION";
-  private static final String REFRESH_COOKIE_NAME = "REFRESH_KEY";
+  private final AuthenticationEntryPoint authenticationEntryPoint;
 
   @Value("${app.base-url}")
   private String baseUrl;
 
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-    exception.printStackTrace();
-    removeCookie(response, ACCESS_COOKIE_NAME);
-    removeCookie(response, REFRESH_COOKIE_NAME);
-    response.sendRedirect(baseUrl + "/error");
+    if (exception instanceof ApplicationAuthenticationException ex) {
+      AuthenticationError error = ex.getError();
+      authenticationEntryPoint.commence(request, response, new ApplicationAuthenticationException(error) {});
+      return;
+    }
+    response.sendRedirect(baseUrl + "/error?cause=" + exception.getMessage());
   }
 }

--- a/src/main/java/com/bob/infra/auth/service/MemberDetailsService.java
+++ b/src/main/java/com/bob/infra/auth/service/MemberDetailsService.java
@@ -1,5 +1,7 @@
 package com.bob.infra.auth.service;
 
+import static com.bob.domain.member.entity.Status.ACTIVE;
+
 import com.bob.domain.member.entity.Member;
 import com.bob.domain.member.repository.MemberRepository;
 import com.bob.infra.auth.response.MemberDetails;
@@ -20,6 +22,6 @@ public class MemberDetailsService implements UserDetailsService {
     Member member = memberRepository.findByEmail(username)
         .orElseThrow(() -> new UsernameNotFoundException(username));
 
-    return new MemberDetails(member.getId(), member.getEmail(), member.getPassword(), !member.isRemove());
+    return new MemberDetails(member.getId(), member.getEmail(), member.getPassword(), member.getStatus() == ACTIVE);
   }
 }

--- a/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
+++ b/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
@@ -1,11 +1,13 @@
 package com.bob.infra.auth.service;
 
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
 import com.bob.infra.auth.oauth.provider.GoogleProfile;
 import com.bob.infra.auth.oauth.provider.NaverProfile;
 import com.bob.infra.auth.oauth.provider.SocialProvider;
 import com.bob.infra.auth.service.port.AuthMemberPort;
 import java.util.Map;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -36,14 +38,20 @@ public class SocialAuthService implements OAuth2UserService<OAuth2UserRequest, O
       default -> throw new OAuth2AuthenticationException(new OAuth2Error("000"), "해당 로그인 방법은 지원하지 않습니다.");
     };
 
-    final UUID memberId = memberPort.socialLoginProcess(provider.toUpperCase(), profile.email(), profile.nickname());
-    final Map<String, Object> principalAttrs = Map.of("memberId", memberId.toString());
-    return new DefaultOAuth2User(null, principalAttrs, "memberId");
+    final SocialLoginResponse response = memberPort.socialLoginProcess(provider.toUpperCase(), profile.email(), profile.nickname());
+    switch (response.status()) {
+      case "WITHDRAW" -> throw new ApplicationAuthenticationException(AuthenticationError.IS_REMOVED_MEMBER) {};
+      case "BANNED" -> throw new ApplicationAuthenticationException(AuthenticationError.IS_BANNED_MEMBER) {};
+      default -> {
+        final Map<String, Object> principalAttrs = Map.of("memberId", response.memberId().toString());
+        return new DefaultOAuth2User(null, principalAttrs, "memberId");
+      }
+    }
   }
 
   private static void verifyProvider(String provider) {
     if (!"google".equalsIgnoreCase(provider) && !"naver".equalsIgnoreCase(provider)) {
-      throw new OAuth2AuthenticationException(new OAuth2Error("001"), "해당 로그인 방법은 지원하지 않습니다.");
+      throw new OAuth2AuthenticationException(new OAuth2Error("OE01"), "해당 로그인 방법은 지원하지 않습니다.");
     }
   }
 }

--- a/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
+++ b/src/main/java/com/bob/infra/auth/service/SocialAuthService.java
@@ -40,7 +40,7 @@ public class SocialAuthService implements OAuth2UserService<OAuth2UserRequest, O
 
     final SocialLoginResponse response = memberPort.socialLoginProcess(provider.toUpperCase(), profile.email(), profile.nickname());
     switch (response.status()) {
-      case "WITHDRAW" -> throw new ApplicationAuthenticationException(AuthenticationError.IS_REMOVED_MEMBER) {};
+      case "WITHDRAW" -> throw new ApplicationAuthenticationException(AuthenticationError.IS_WITHDRAWN_MEMBER) {};
       case "BANNED" -> throw new ApplicationAuthenticationException(AuthenticationError.IS_BANNED_MEMBER) {};
       default -> {
         final Map<String, Object> principalAttrs = Map.of("memberId", response.memberId().toString());

--- a/src/main/java/com/bob/infra/auth/service/port/AuthMemberPort.java
+++ b/src/main/java/com/bob/infra/auth/service/port/AuthMemberPort.java
@@ -1,8 +1,8 @@
 package com.bob.infra.auth.service.port;
 
-import java.util.UUID;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 
 public interface AuthMemberPort {
 
-  UUID socialLoginProcess(String provider, String email, String nickname);
+  SocialLoginResponse socialLoginProcess(String provider, String email, String nickname);
 }

--- a/src/main/java/com/bob/web/member/adapter/in/AuthMemberAdapter.java
+++ b/src/main/java/com/bob/web/member/adapter/in/AuthMemberAdapter.java
@@ -1,9 +1,9 @@
 package com.bob.web.member.adapter.in;
 
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
 import com.bob.infra.auth.service.port.AuthMemberPort;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,7 +14,7 @@ public class AuthMemberAdapter implements AuthMemberPort {
   private final MemberWriteUseCase writeUseCase;
 
   @Override
-  public UUID socialLoginProcess(String provider, String email, String nickname) {
+  public SocialLoginResponse socialLoginProcess(String provider, String email, String nickname) {
     return writeUseCase.socialLoginProcess(SocialLoginCommand.of(provider, email, nickname));
   }
 }

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -1,5 +1,6 @@
 package com.bob.domain.member.service;
 
+import static com.bob.domain.member.entity.Status.WITHDRAW;
 import static com.bob.support.fixture.command.ChangeProfileCommandFixture.defaultChangeProfileCommand;
 import static com.bob.support.fixture.command.ChangeProfileCommandFixture.sameNicknameChangeProfileCommand;
 import static com.bob.support.fixture.command.ChangeProfileImageUrlCommandFixture.customChangeProfileImageUrlCommand;
@@ -29,6 +30,7 @@ import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
@@ -36,7 +38,6 @@ import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,13 +126,14 @@ class MemberServiceIntgTest extends TestContainerSupport {
     SocialLoginCommand command = SocialLoginCommand.of("NAVER", email, nickname);
 
     // when
-    UUID result = memberService.socialLoginProcess(command);
+    SocialLoginResponse result = memberService.socialLoginProcess(command);
 
     // then
     Member saved = memberRepository.findByEmail(email).orElseThrow();
     assertThat(saved.getEmail()).isEqualTo(email);
     assertThat(saved.getNickname()).isEqualTo(nickname);
-    assertThat(result).isEqualTo(saved.getId());
+    assertThat(result.memberId()).isEqualTo(saved.getId());
+    assertThat(result.status()).isEqualTo(saved.getStatus().name());
     then(areaPort).should(times(1)).createNonAuthenticatedActivityArea(saved.getId(), command.emdId());
   }
 
@@ -144,10 +146,11 @@ class MemberServiceIntgTest extends TestContainerSupport {
     SocialLoginCommand command = SocialLoginCommand.of("GOOGLE", email, "foo");
 
     // when
-    UUID result = memberService.socialLoginProcess(command);
+    SocialLoginResponse result = memberService.socialLoginProcess(command);
 
     // then
-    assertThat(result).isEqualTo(existing.getId());
+    assertThat(result.memberId()).isEqualTo(existing.getId());
+    assertThat(result.status()).isEqualTo(existing.getStatus().name());
     then(areaPort).should(never()).createNonAuthenticatedActivityArea(any(), any());
   }
 
@@ -294,7 +297,7 @@ class MemberServiceIntgTest extends TestContainerSupport {
 
     // then
     Member after = memberRepository.findById(member.getId()).orElseThrow();
-    assertThat(after.isRemove()).isTrue();
+    assertThat(after.getStatus()).isEqualTo(WITHDRAW);
     List<String> setCookies = response.getHeaders("Set-Cookie");
     assertThat(setCookies).anySatisfy(h ->
         assertThat(h).contains("AUTHORIZATION=").contains("Max-Age=0"));

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.bob.domain.member.service;
 
+import static com.bob.domain.member.entity.Status.WITHDRAW;
 import static com.bob.global.exception.response.ApplicationError.ALREADY_EXISTS_EMAIL;
 import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PASSWORD;
 import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
@@ -36,6 +37,7 @@ import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
 import com.bob.domain.member.service.dto.query.ReadProfileQuery;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
@@ -44,7 +46,6 @@ import com.bob.global.event.application.dto.RemoveMemberEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -135,8 +136,7 @@ class MemberServiceTest {
   }
 
   @Test
-  @DisplayName("소셜 로그인 - 존재하지 않는 회원의 회원가입 테스트")
-  void 동일한_이메일을_가진_회원이_존재하지_않는_경우_회원가입을_진행한다() {
+  void 소셜_로그인_회원가입_및_정보_반환() {
     // given
     SocialLoginCommand command = SocialLoginCommand.of("NAVER", "test@naver.com", "foo");
     given(memberRepository.findByEmail("test@naver.com")).willReturn(Optional.empty());
@@ -146,7 +146,7 @@ class MemberServiceTest {
     given(memberRepository.save(any(Member.class))).willReturn(saved);
 
     // when
-    UUID result = memberService.socialLoginProcess(command);
+    SocialLoginResponse result = memberService.socialLoginProcess(command);
 
     // then
     ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
@@ -157,21 +157,22 @@ class MemberServiceTest {
     assertThat(toSave.getNickname()).isEqualTo("foo");
     assertThat(toSave.getPassword()).isEqualTo("$2a$encodedDummy");
     then(areaPort).should(times(1)).createNonAuthenticatedActivityArea(saved.getId(), command.emdId());
-    assertThat(result).isEqualTo(saved.getId());
+    assertThat(result.memberId()).isEqualTo(saved.getId());
+    assertThat(result.status()).isEqualTo(saved.getStatus().name());
   }
 
   @Test
-  @DisplayName("소셜 로그인 - 존재하는 회원의 로그인 테스트")
-  void 동일한_이메일을_가진_회원이_존재하는_경우_회원_ID를_반환한다() {
+  void 소셜_로그인_정보_반환() {
     // given
     SocialLoginCommand command = SocialLoginCommand.of("GOOGLE", "test@google.com", "foo");
     given(memberRepository.findByEmail("test@google.com")).willReturn(Optional.of(defaultIdMember()));
 
     // when
-    UUID result = memberService.socialLoginProcess(command);
+    SocialLoginResponse result = memberService.socialLoginProcess(command);
 
     // then
-    assertThat(result).isEqualTo(defaultIdMember().getId());
+    assertThat(result.memberId()).isEqualTo(defaultIdMember().getId());
+    assertThat(result.status()).isEqualTo(defaultIdMember().getStatus().name());
     then(memberRepository).should(never()).save(any(Member.class));
     then(areaPort).should(never()).createNonAuthenticatedActivityArea(any(), any());
   }
@@ -335,7 +336,7 @@ class MemberServiceTest {
     memberService.softRemoveMemberProcess(command, response);
 
     // then
-    assertThat(member.isRemove()).isTrue();
+    assertThat(member.getStatus()).isEqualTo(WITHDRAW);
 
     then(memberReader).should(times(1)).readMemberById(member.getId());
     then(eventPublisher).should(times(1)).publishEvent(any(RemoveMemberEvent.class));

--- a/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/filter/LoginFilterTest.java
@@ -1,7 +1,7 @@
 package com.bob.infra.auth.filter;
 
 import static com.bob.global.exception.response.AuthenticationError.FAILED_AUTHENTICATION;
-import static com.bob.global.exception.response.AuthenticationError.IS_REMOVED_MEMBER;
+import static com.bob.global.exception.response.AuthenticationError.IS_WITHDRAWN_MEMBER;
 import static com.bob.support.fixture.auth.CookieFixture.ACCESS_VALUE;
 import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE;
 import static com.bob.support.fixture.auth.CookieFixture.SET_COOKIE_HEADER;
@@ -149,7 +149,7 @@ class LoginFilterTest {
 
     // then
     then(authenticationEntryPoint).should().commence(eq(request), eq(response),
-        argThat(e -> ((ApplicationAuthenticationException) e).getError() == IS_REMOVED_MEMBER)
+        argThat(e -> ((ApplicationAuthenticationException) e).getError() == IS_WITHDRAWN_MEMBER)
     );
     then(redisPort).shouldHaveNoInteractions();
   }

--- a/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandlerTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandlerTest.java
@@ -1,20 +1,24 @@
 package com.bob.infra.auth.oauth.handler;
 
-import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE_NAME;
-import static com.bob.support.fixture.auth.CookieFixture.REFRESH_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
-import jakarta.servlet.http.Cookie;
-import java.util.Arrays;
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("소셜 로그인 실패 핸들러 테스트")
@@ -23,6 +27,9 @@ class SocialAuthFailureHandlerTest {
 
   @InjectMocks
   private SocialAuthFailureHandler handler;
+
+  @Mock
+  private AuthenticationEntryPoint authenticationEntryPoint;
 
   private MockHttpServletRequest request;
 
@@ -39,33 +46,49 @@ class SocialAuthFailureHandlerTest {
   }
 
   @Test
-  @DisplayName("소셜 로그인 실패 - 에러 페이지 리다이렉트")
-  void 소셜로그인_실패시_에러페이지로_리다이렉트한다() throws Exception {
+  void 탈퇴_계정_소셜_로그인_예외_테스트() throws Exception {
     // given
-    AuthenticationException ex = new AuthenticationException("oauth failed") {};
+    AuthenticationException ex = new ApplicationAuthenticationException(AuthenticationError.IS_REMOVED_MEMBER);
 
     // when
     handler.onAuthenticationFailure(request, response, ex);
 
     // then
-    assertThat(response.getRedirectedUrl()).isEqualTo(baseUrl + "/error");
+    ArgumentCaptor<ApplicationAuthenticationException> captor = ArgumentCaptor.forClass(ApplicationAuthenticationException.class);
+    then(authenticationEntryPoint).should().commence(any(), any(), captor.capture());
+
+    ApplicationAuthenticationException captured = captor.getValue();
+    assertThat(captured).isNotNull();
+    assertThat(captured.getError()).isEqualTo(AuthenticationError.IS_REMOVED_MEMBER);
   }
 
   @Test
-  @DisplayName("소셜 로그인 실패 - 쿠키 삭제")
-  void 소셜로그인_실패시_쿠키를_삭제한다() throws Exception {
+  void 제재_계정_소셜_로그인_예외_테스트() throws Exception {
+    // given
+    AuthenticationException ex = new ApplicationAuthenticationException(AuthenticationError.IS_BANNED_MEMBER);
+
     // when
-    handler.onAuthenticationFailure(request, response, new AuthenticationException("any") {});
+    handler.onAuthenticationFailure(request, response, ex);
 
     // then
-    Cookie[] cookies = response.getCookies();
-    assertThat(cookies).isNotNull();
+    ArgumentCaptor<ApplicationAuthenticationException> captor = ArgumentCaptor.forClass(ApplicationAuthenticationException.class);
+    then(authenticationEntryPoint).should().commence(any(), any(), captor.capture());
 
-    Cookie accessCookie = Arrays.stream(cookies).filter(c -> AUTH_COOKIE_NAME.equals(c.getName())).findFirst().orElse(null);
-    Cookie refreshCookie = Arrays.stream(cookies).filter(c -> REFRESH_COOKIE_NAME.equals(c.getName())).findFirst().orElse(null);
-    assertThat(accessCookie).isNotNull();
-    assertThat(refreshCookie).isNotNull();
-    assertThat(accessCookie.getMaxAge()).isZero();
-    assertThat(refreshCookie.getMaxAge()).isZero();
+    ApplicationAuthenticationException captured = captor.getValue();
+    assertThat(captured).isNotNull();
+    assertThat(captured.getError()).isEqualTo(AuthenticationError.IS_BANNED_MEMBER);
+  }
+
+  @Test
+  void 처리되지_않은_예외_테스트() throws Exception {
+    // given
+    AuthenticationException ex = new AuthenticationException("unknown") {};
+
+    // when
+    handler.onAuthenticationFailure(request, response, ex);
+
+    // then
+    then(authenticationEntryPoint).should(never()).commence(any(), any(), any());
+    assertThat(response.getRedirectedUrl()).contains("/error?cause=unknown");
   }
 }

--- a/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandlerTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/oauth/handler/SocialAuthFailureHandlerTest.java
@@ -1,9 +1,6 @@
 package com.bob.infra.auth.oauth.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
 import com.bob.global.exception.response.AuthenticationError;
@@ -11,14 +8,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("소셜 로그인 실패 핸들러 테스트")
@@ -27,9 +21,6 @@ class SocialAuthFailureHandlerTest {
 
   @InjectMocks
   private SocialAuthFailureHandler handler;
-
-  @Mock
-  private AuthenticationEntryPoint authenticationEntryPoint;
 
   private MockHttpServletRequest request;
 
@@ -40,47 +31,38 @@ class SocialAuthFailureHandlerTest {
   @BeforeEach
   void setUp() {
     ReflectionTestUtils.setField(handler, "baseUrl", baseUrl);
-
     request = new MockHttpServletRequest();
     response = new MockHttpServletResponse();
   }
 
   @Test
-  void 탈퇴_계정_소셜_로그인_예외_테스트() throws Exception {
+  void 탈퇴_계정_소셜_로그인_예외() throws Exception {
     // given
-    AuthenticationException ex = new ApplicationAuthenticationException(AuthenticationError.IS_REMOVED_MEMBER);
+    AuthenticationException ex = new ApplicationAuthenticationException(AuthenticationError.IS_WITHDRAWN_MEMBER) {};
 
     // when
     handler.onAuthenticationFailure(request, response, ex);
 
     // then
-    ArgumentCaptor<ApplicationAuthenticationException> captor = ArgumentCaptor.forClass(ApplicationAuthenticationException.class);
-    then(authenticationEntryPoint).should().commence(any(), any(), captor.capture());
-
-    ApplicationAuthenticationException captured = captor.getValue();
-    assertThat(captured).isNotNull();
-    assertThat(captured.getError()).isEqualTo(AuthenticationError.IS_REMOVED_MEMBER);
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getRedirectedUrl()).isEqualTo("https://base/error?cause=IS_WITHDRAWN_MEMBER");
   }
 
   @Test
-  void 제재_계정_소셜_로그인_예외_테스트() throws Exception {
+  void 제재_계정_소셜_로그인_예외() throws Exception {
     // given
-    AuthenticationException ex = new ApplicationAuthenticationException(AuthenticationError.IS_BANNED_MEMBER);
+    AuthenticationException ex = new ApplicationAuthenticationException(AuthenticationError.IS_BANNED_MEMBER) {};
 
     // when
     handler.onAuthenticationFailure(request, response, ex);
 
     // then
-    ArgumentCaptor<ApplicationAuthenticationException> captor = ArgumentCaptor.forClass(ApplicationAuthenticationException.class);
-    then(authenticationEntryPoint).should().commence(any(), any(), captor.capture());
-
-    ApplicationAuthenticationException captured = captor.getValue();
-    assertThat(captured).isNotNull();
-    assertThat(captured.getError()).isEqualTo(AuthenticationError.IS_BANNED_MEMBER);
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getRedirectedUrl()).isEqualTo("https://base/error?cause=IS_BANNED_MEMBER");
   }
 
   @Test
-  void 처리되지_않은_예외_테스트() throws Exception {
+  void 기본_예외() throws Exception {
     // given
     AuthenticationException ex = new AuthenticationException("unknown") {};
 
@@ -88,7 +70,7 @@ class SocialAuthFailureHandlerTest {
     handler.onAuthenticationFailure(request, response, ex);
 
     // then
-    then(authenticationEntryPoint).should(never()).commence(any(), any(), any());
-    assertThat(response.getRedirectedUrl()).contains("/error?cause=unknown");
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getRedirectedUrl()).isEqualTo("https://base/error?cause=FAILED_AUTHENTICATION");
   }
 }

--- a/src/test/unit/java/com/bob/infra/auth/service/MemberDetailsServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/MemberDetailsServiceTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.entity.Status;
 import com.bob.domain.member.repository.MemberRepository;
 import com.bob.infra.auth.response.MemberDetails;
 import java.util.Optional;
@@ -51,7 +52,7 @@ class MemberDetailsServiceTest {
   void 탈퇴_회원_조회_테스트() {
     // given
     Member member = defaultIdMember();
-    member.updateRemoveStatus(true);
+    member.updateStatus(Status.WITHDRAW);
     memberRepository.save(member);
     given(memberRepository.findByEmail("test@email.com")).willReturn(Optional.of(member));
 

--- a/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
@@ -1,14 +1,21 @@
 package com.bob.infra.auth.service;
 
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static com.bob.support.fixture.response.oauth.SocialLoginResponseFixture.BANNED_MEMBER_RESPONSE;
+import static com.bob.support.fixture.response.oauth.SocialLoginResponseFixture.WITHDRAWN_MEMBER_RESPONSE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
 
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
+import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.global.exception.response.AuthenticationError;
 import com.bob.infra.auth.service.port.AuthMemberPort;
 import java.time.Instant;
 import java.util.Map;
@@ -48,7 +55,6 @@ class SocialAuthServiceTest {
   }
 
   @Test
-  @DisplayName("구글 로그인 테스트")
   void 구글_소셜_로그인() {
     // given
     ClientRegistration registration = googleRegistration();
@@ -56,7 +62,7 @@ class SocialAuthServiceTest {
     Map<String, Object> attrs = Map.of("sub", "1", "email", "test@google.com", "name", "foo");
     OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "sub");
     given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
-    given(memberPort.socialLoginProcess(eq("GOOGLE"), eq("test@google.com"), eq("foo"))).willReturn(MEMBER_ID);
+    given(memberPort.socialLoginProcess(eq("GOOGLE"), eq("test@google.com"), eq("foo"))).willReturn(SocialLoginResponse.from(defaultIdMember()));
 
     // when
     OAuth2User principal = socialAuthService.loadUser(request);
@@ -68,7 +74,6 @@ class SocialAuthServiceTest {
   }
 
   @Test
-  @DisplayName("네이버 로그인 테스트")
   void 네이버_소셜_로그인() {
     // given
     ClientRegistration registration = naverRegistration();
@@ -77,7 +82,7 @@ class SocialAuthServiceTest {
     Map<String, Object> attrs = Map.of("response", response);
     OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "response");
     given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
-    given(memberPort.socialLoginProcess(eq("NAVER"), eq("test@naver.com"), eq("foo"))).willReturn(MEMBER_ID);
+    given(memberPort.socialLoginProcess(eq("NAVER"), eq("test@naver.com"), eq("foo"))).willReturn(SocialLoginResponse.from(defaultIdMember()));
 
     // when
     OAuth2User principal = socialAuthService.loadUser(request);
@@ -89,8 +94,7 @@ class SocialAuthServiceTest {
   }
 
   @Test
-  @DisplayName("지원하지 않는 소셜 서비스 로그인 테스트")
-  void 지원하지_않는_provider는_예외를_발생시킨다() {
+  void 미지원_소셜_로그인() {
     // given
     ClientRegistration registration = kakaoRegistration();
     OAuth2UserRequest request = requestOf(registration);
@@ -99,6 +103,39 @@ class SocialAuthServiceTest {
     assertThatThrownBy(() -> socialAuthService.loadUser(request))
         .isInstanceOf(OAuth2AuthenticationException.class)
         .hasMessage("해당 로그인 방법은 지원하지 않습니다.");
+  }
+
+  @Test
+  void 탈퇴계정_예외_발생() {
+    // given
+    ClientRegistration registration = googleRegistration();
+    OAuth2UserRequest request = requestOf(registration);
+    Map<String, Object> attrs = Map.of("sub", "1", "email", "test@google.com", "name", "tester");
+    OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "sub");
+    given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
+    given(memberPort.socialLoginProcess(anyString(), anyString(), anyString())).willReturn(WITHDRAWN_MEMBER_RESPONSE);
+
+    // when & then
+    assertThatThrownBy(() -> socialAuthService.loadUser(request))
+        .isInstanceOf(ApplicationAuthenticationException.class)
+        .hasMessage(AuthenticationError.IS_REMOVED_MEMBER.getMessage());
+  }
+
+  @Test
+  void 제재계정_예외_발생() {
+    // given
+    ClientRegistration registration = naverRegistration();
+    OAuth2UserRequest request = requestOf(registration);
+    Map<String, Object> response = Map.of("id", "1", "email", "test@naver.com", "nickname", "tester");
+    Map<String, Object> attrs = Map.of("response", response);
+    OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "response");
+    given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
+    given(memberPort.socialLoginProcess(anyString(), anyString(), anyString())).willReturn(BANNED_MEMBER_RESPONSE);
+
+    // when & then
+    assertThatThrownBy(() -> socialAuthService.loadUser(request))
+        .isInstanceOf(ApplicationAuthenticationException.class)
+        .hasMessage(AuthenticationError.IS_BANNED_MEMBER.getMessage());
   }
 
   private static OAuth2UserRequest requestOf(ClientRegistration registration) {

--- a/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
+++ b/src/test/unit/java/com/bob/infra/auth/service/SocialAuthServiceTest.java
@@ -118,7 +118,7 @@ class SocialAuthServiceTest {
     // when & then
     assertThatThrownBy(() -> socialAuthService.loadUser(request))
         .isInstanceOf(ApplicationAuthenticationException.class)
-        .hasMessage(AuthenticationError.IS_REMOVED_MEMBER.getMessage());
+        .hasMessage(AuthenticationError.IS_WITHDRAWN_MEMBER.getMessage());
   }
 
   @Test

--- a/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/MemberFixture.java
@@ -1,5 +1,8 @@
 package com.bob.support.fixture.domain;
 
+import static com.bob.domain.member.entity.Status.ACTIVE;
+import static com.bob.domain.member.entity.Status.WITHDRAW;
+
 import com.bob.domain.member.entity.Member;
 import java.util.UUID;
 
@@ -10,6 +13,7 @@ public class MemberFixture {
 
   public static Member defaultMember() {
     return Member.builder()
+        .status(ACTIVE)
         .email("test@email.com")
         .password("password")
         .nickname("tester")
@@ -19,6 +23,7 @@ public class MemberFixture {
   public static Member defaultIdMember() {
     return Member.builder()
         .id(MEMBER_ID)
+        .status(ACTIVE)
         .email("test@email.com")
         .password("password")
         .nickname("tester")
@@ -27,6 +32,7 @@ public class MemberFixture {
 
   public static Member otherMember() {
     return Member.builder()
+        .status(ACTIVE)
         .email("unknown@email.com")
         .password("password")
         .nickname("anonymous")
@@ -35,6 +41,7 @@ public class MemberFixture {
 
   public static Member customEmailMember(String email) {
     return Member.builder()
+        .status(ACTIVE)
         .email(email)
         .password("password")
         .nickname("tester")
@@ -43,6 +50,7 @@ public class MemberFixture {
 
   public static Member encryptPasswordMember(String encryptedPassword) {
     return Member.builder()
+        .status(ACTIVE)
         .email("test@email.com")
         .password(encryptedPassword)
         .nickname("tester")
@@ -51,10 +59,10 @@ public class MemberFixture {
 
   public static Member removedMember() {
     return Member.builder()
+        .status(WITHDRAW)
         .email("test@email.com")
         .password("password")
         .nickname("tester")
-        .isRemove(true)
         .build();
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/response/oauth/SocialLoginResponseFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/oauth/SocialLoginResponseFixture.java
@@ -1,0 +1,18 @@
+package com.bob.support.fixture.response.oauth;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
+
+public class SocialLoginResponseFixture {
+
+  public static final SocialLoginResponse WITHDRAWN_MEMBER_RESPONSE = SocialLoginResponse.builder()
+      .memberId(MEMBER_ID)
+      .status("WITHDRAW")
+      .build();
+
+  public static final SocialLoginResponse BANNED_MEMBER_RESPONSE = SocialLoginResponse.builder()
+      .memberId(MEMBER_ID)
+      .status("BANNED")
+      .build();
+}

--- a/src/test/unit/java/com/bob/web/member/adapter/in/AuthMemberAdapterTest.java
+++ b/src/test/unit/java/com/bob/web/member/adapter/in/AuthMemberAdapterTest.java
@@ -1,13 +1,14 @@
 package com.bob.web.member.adapter.in;
 
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.bob.domain.member.service.dto.command.SocialLoginCommand;
+import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,13 +31,14 @@ class AuthMemberAdapterTest {
   void 소셜_로그인_메서드_호출() {
     // given
     SocialLoginCommand command = SocialLoginCommand.of("GOOGLE", "test@google.com", "foo");
-    given(writeUseCase.socialLoginProcess(command)).willReturn(MEMBER_ID);
+    given(writeUseCase.socialLoginProcess(command)).willReturn(SocialLoginResponse.from(defaultIdMember()));
 
     // when
-    UUID result = authMemberAdapter.socialLoginProcess("GOOGLE", "test@google.com", "foo");
+    SocialLoginResponse response = authMemberAdapter.socialLoginProcess("GOOGLE", "test@google.com", "foo");
 
     // then
     then(writeUseCase).should().socialLoginProcess(command);
-    assertThat(result).isEqualTo(MEMBER_ID);
+    assertThat(response.memberId()).isEqualTo(MEMBER_ID);
+    assertThat(response.status()).isEqualTo(defaultIdMember().getStatus().toString());
   }
 }


### PR DESCRIPTION
this fixes #100 

### 작업 내용
- [x] 회원 활성 상태 컬럼 추가
- [x] 탈퇴 회원의 소셜 로그인 예외 처리 

---

### 참고
일반 로그인의 탈퇴 회원 처리와의 차이점: `/error?cause=IS_WITHDRAWN_MEMBER` 리다이렉트