### PR TITLE
feat: 회원 관심사 등록, 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ def jacocoExcludes = [
         'com.bob.**.provider.**',
         'com.bob.**.dsl.**',
         'com.bob.**.Q*',
+        'com.bob.**.projection.**',
         'com.bob.**.dummy.**'
 ]
 
@@ -176,7 +177,8 @@ def jacocoExcludesForReport = [
         "**/*provider*/**",
         "**/*dsl*/**",
         "**/Q*",
-        "**/*dummy*/**",
+        "**/*projection*/**",
+        "**/*dummy*/**"
 ]
 
 jacocoTestReport {

--- a/src/main/java/com/bob/domain/member/entity/Interest.java
+++ b/src/main/java/com/bob/domain/member/entity/Interest.java
@@ -1,0 +1,40 @@
+package com.bob.domain.member.entity;
+
+import com.bob.global.audit.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "interests")
+public class Interest extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 120)
+  private String canonicalName;
+
+  public static Interest of(String rawName) {
+    return Interest.builder()
+        .canonicalName(canonicalize(rawName))
+        .build();
+  }
+
+  public static String canonicalize(String value) {
+    return value.trim().toLowerCase().replaceAll("\\s+", " ");
+  }
+}

--- a/src/main/java/com/bob/domain/member/entity/MemberInterest.java
+++ b/src/main/java/com/bob/domain/member/entity/MemberInterest.java
@@ -1,0 +1,45 @@
+package com.bob.domain.member.entity;
+
+import com.bob.global.audit.BaseTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "member_interests")
+public class MemberInterest extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private UUID memberId;
+
+  @Column(nullable = false)
+  private Long interestId;
+
+  @Column(nullable = false, length = 100)
+  private String displayName;
+
+  public static MemberInterest of(UUID memberId, Long interestId, String displayName) {
+    return MemberInterest.builder()
+        .memberId(memberId)
+        .interestId(interestId)
+        .displayName(displayName)
+        .build();
+  }
+}

--- a/src/main/java/com/bob/domain/member/repository/InterestRepository.java
+++ b/src/main/java/com/bob/domain/member/repository/InterestRepository.java
@@ -1,0 +1,24 @@
+package com.bob.domain.member.repository;
+
+import com.bob.domain.member.entity.Interest;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface InterestRepository extends CrudRepository<Interest, Long> {
+
+  List<Interest> findByCanonicalNameIn(Collection<String> canonicalNames);
+
+  // DB 변경 시 애플리케이션 try-catch 고려
+  @Modifying
+  @Query(value = """
+        INSERT INTO interests (canonical_name)
+        VALUES (:canonical)
+        ON DUPLICATE KEY UPDATE id = id
+      """, nativeQuery = true
+  )
+  int upsert(@Param("canonical") String canonical);
+}

--- a/src/main/java/com/bob/domain/member/repository/MemberInterestRepository.java
+++ b/src/main/java/com/bob/domain/member/repository/MemberInterestRepository.java
@@ -1,0 +1,46 @@
+package com.bob.domain.member.repository;
+
+import com.bob.domain.member.entity.MemberInterest;
+import com.bob.domain.member.repository.projection.InterestEntry;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberInterestRepository extends CrudRepository<MemberInterest, Long> {
+
+  @Query("""
+      SELECT mi.displayName
+      FROM MemberInterest mi
+      WHERE mi.memberId = :memberId
+      ORDER BY mi.id ASC
+      """)
+  List<String> findDisplayNamesByMemberId(@Param("memberId") UUID memberId);
+
+  @Query("""
+      SELECT new com.bob.domain.member.repository.projection.InterestEntry(i.id, i.canonicalName)
+      FROM MemberInterest mi
+        JOIN Interest i ON i.id = mi.interestId
+      WHERE mi.memberId = :memberId
+      """)
+  List<InterestEntry> findCanonicalNameWithId(@Param("memberId") UUID memberId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("""
+      DELETE FROM MemberInterest mi
+      WHERE mi.memberId = :memberId
+        AND mi.interestId IN :interestIds
+      """)
+  void deleteByMemberIdAndInterestIds(@Param("memberId") UUID memberId, @Param("interestIds") Collection<Long> interestIds);
+
+  /*@Query("""
+      SELECT DISTINCT mi.memberId
+      FROM MemberInterest mi
+        JOIN Interest i ON i.id = mi.interestId
+      WHERE i.canonicalName IN :canonicals
+      """)
+  List<UUID> findDistinctMemberIdsByCanonicals(@Param("canonicals") Collection<String> canonicals);*/
+}

--- a/src/main/java/com/bob/domain/member/repository/projection/InterestEntry.java
+++ b/src/main/java/com/bob/domain/member/repository/projection/InterestEntry.java
@@ -1,0 +1,8 @@
+package com.bob.domain.member.repository.projection;
+
+public record InterestEntry(
+    Long interestId,
+    String canonicalName
+) {
+
+}

--- a/src/main/java/com/bob/domain/member/service/MemberInterestService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberInterestService.java
@@ -1,0 +1,98 @@
+package com.bob.domain.member.service;
+
+import com.bob.domain.member.entity.Interest;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.entity.MemberInterest;
+import com.bob.domain.member.repository.InterestRepository;
+import com.bob.domain.member.repository.MemberInterestRepository;
+import com.bob.domain.member.repository.projection.InterestEntry;
+import com.bob.domain.member.service.reader.MemberReader;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberInterestService {
+
+  private final MemberReader memberReader;
+  private final InterestRepository interestRepository;
+  private final MemberInterestRepository memberInterestRepository;
+
+  @Transactional
+  public void changeMemberInterests(UUID memberId, List<String> rawNames) {
+    Member member = memberReader.readMemberById(memberId);
+    final Set<String> displayNames = normalizeNames(rawNames);
+    //final Set<String> displayNames = new HashSet<>(rawNames);
+    final Set<String> canonicalNames = convertCanonicalNames(displayNames);
+
+    Map<String, Long> currentInterestsMap = memberInterestRepository.findCanonicalNameWithId(memberId).stream()
+        .collect(Collectors.toMap(InterestEntry::canonicalName, InterestEntry::interestId));
+
+    Set<String> newCanonicals = new LinkedHashSet<>(canonicalNames);
+    newCanonicals.removeAll(currentInterestsMap.keySet());
+    addInterests(member, newCanonicals, displayNames);
+
+    Set<String> removeCanonicals = new LinkedHashSet<>(currentInterestsMap.keySet());
+    removeCanonicals.removeAll(canonicalNames);
+    removeMemberInterests(member, removeCanonicals, currentInterestsMap);
+  }
+
+  private static Set<String> normalizeNames(List<String> names) {
+    if (names == null) {
+      return Set.of();
+    }
+    return names.stream()
+        .filter(Objects::nonNull)
+        .map(String::trim)
+        .filter(v -> !v.isEmpty())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static Set<String> convertCanonicalNames(Set<String> names) {
+    return names.stream()
+        .map(Interest::canonicalize)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private void addInterests(Member member, Set<String> newCanonicalNames, Set<String> displayNames) {
+    if (newCanonicalNames.isEmpty()) {
+      return;
+    }
+    Map<String, String> canonicalToDisplay = displayNames.stream()
+        .collect(Collectors.toMap(Interest::canonicalize, s -> s, (a, b) -> a, LinkedHashMap::new));
+
+    newCanonicalNames.forEach(interestRepository::upsert);
+
+    Map<String, Interest> interestDict = interestRepository.findByCanonicalNameIn(newCanonicalNames).stream()
+        .collect(Collectors.toMap(Interest::getCanonicalName, Function.identity()));
+
+    memberInterestRepository.saveAll(newCanonicalNames.stream()
+        .map(c -> MemberInterest.of(member.getId(), interestDict.get(c).getId(), canonicalToDisplay.get(c))).toList());
+  }
+
+  private void removeMemberInterests(Member member, Set<String> removeCanonicals, Map<String, Long> currentInterestsMap) {
+    final List<Long> removeInterestIds = removeCanonicals.stream()
+        .map(currentInterestsMap::get)
+        .filter(Objects::nonNull)
+        .toList();
+
+    if (!removeInterestIds.isEmpty()) {
+      memberInterestRepository.deleteByMemberIdAndInterestIds(member.getId(), removeInterestIds);
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public List<String> readMemberInterests(UUID memberId) {
+    return memberInterestRepository.findDisplayNamesByMemberId(memberId);
+  }
+}

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -3,7 +3,7 @@ package com.bob.domain.member.service;
 import static com.bob.domain.member.entity.Status.ACTIVE;
 import static com.bob.domain.member.entity.Status.BANNED;
 import static com.bob.domain.member.entity.Status.WITHDRAW;
-import static com.bob.global.event.application.dto.member.type.AccountEventType.*;
+import static com.bob.global.event.application.dto.member.type.AccountEventType.RECOVER;
 import static com.bob.global.exception.response.ApplicationError.ALREADY_EXISTS_EMAIL;
 import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PASSWORD;
 import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
@@ -37,6 +37,10 @@ import com.bob.global.event.application.dto.member.type.AccountEventType;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -49,6 +53,8 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
 
   private final MemberRepository memberRepository;
   private final MemberReader memberReader;
+
+  private final MemberInterestService memberInterestService;
 
   private final MemberAreaPort areaPort;
   private final MemberMailPort mailPort;
@@ -98,19 +104,24 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
   @Transactional(readOnly = true)
   public MemberProfileResponse readProfileProcess(ReadProfileQuery query) {
     Member member = memberReader.readMemberById(query.memberId());
+    List<String> interests = memberInterestService.readMemberInterests(member.getId());
     MemberAreaSummaryResponse areaSummary = areaPort.readMemberAreaSummary(query.memberId());
-    return MemberProfileResponse.from(member, areaSummary);
+    return MemberProfileResponse.from(member, interests, areaSummary);
   }
 
   @Transactional
   public void changeProfileProcess(ChangeProfileCommand command) {
     Member member = memberReader.readMemberById(command.memberId());
-    verifyNickname(member, command.nickname());
+    List<String> interests = memberInterestService.readMemberInterests(member.getId());
+    verifyIsSameRequest(member, command.nickname(), interests, command.interests());
     member.updateNickname(command.nickname());
+    memberInterestService.changeMemberInterests(member.getId(), command.interests());
   }
 
-  private void verifyNickname(Member member, String nickname) {
-    if (member.isEqualsNickname(nickname)) {
+  private static void verifyIsSameRequest(Member member, String nickname, List<String> oldInterests, List<String> interests) {
+    Set<String> oldLower = oldInterests.stream().map(String::toLowerCase).collect(Collectors.toSet());
+    Set<String> newLower = interests.stream().map(String::toLowerCase).collect(Collectors.toSet());
+    if (member.isEqualsNickname(nickname) && Objects.equals(oldLower, newLower)) {
       throw new ApplicationException(IS_SAME_REQUEST);
     }
   }

--- a/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileCommand.java
+++ b/src/main/java/com/bob/domain/member/service/dto/command/ChangeProfileCommand.java
@@ -1,10 +1,12 @@
 package com.bob.domain.member.service.dto.command;
 
+import java.util.List;
 import java.util.UUID;
 
 public record ChangeProfileCommand(
     UUID memberId,
-    String nickname
+    String nickname,
+    List<String> interests
 ) {
 
 }

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
@@ -4,6 +4,7 @@ import static com.bob.domain.member.entity.Status.WITHDRAW;
 
 import com.bob.domain.member.entity.Member;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -12,18 +13,21 @@ public record MemberProfileResponse(
     UUID memberId,
     String nickname,
     String profileImageUrl,
+    List<String> interests,
     Area area
 ) {
 
-  public static MemberProfileResponse from(Member member, MemberAreaSummaryResponse areaSummary) {
+  public static MemberProfileResponse from(Member member, List<String> interestNames, MemberAreaSummaryResponse areaSummary) {
     final boolean removed = member.getStatus() == WITHDRAW;
     final String nickname = removed ? "(알 수 없음)" : member.getNickname();
     final String profileImageUrl = removed ? null : member.getProfileImageUrl();
+    final List<String> interests = removed ? List.of() : interestNames;
 
     return MemberProfileResponse.builder()
         .memberId(member.getId())
         .nickname(nickname)
         .profileImageUrl(profileImageUrl)
+        .interests(interests)
         .area(Area.of(areaSummary.emdId(), areaSummary.validity(), areaSummary.authenticatedAt()))
         .build();
   }

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
@@ -10,7 +10,9 @@ import lombok.Builder;
 
 @Builder
 public record MemberProfileResponse(
+    boolean isSocial,
     UUID memberId,
+    String email,
     String nickname,
     String profileImageUrl,
     List<String> interests,
@@ -20,11 +22,14 @@ public record MemberProfileResponse(
   public static MemberProfileResponse from(Member member, List<String> interestNames, MemberAreaSummaryResponse areaSummary) {
     final boolean removed = member.getStatus() == WITHDRAW;
     final String nickname = removed ? "(알 수 없음)" : member.getNickname();
+    final String email = removed ? "delete" : member.getEmail();
     final String profileImageUrl = removed ? null : member.getProfileImageUrl();
     final List<String> interests = removed ? List.of() : interestNames;
 
     return MemberProfileResponse.builder()
+        .isSocial(member.getProvider() != null)
         .memberId(member.getId())
+        .email(email)
         .nickname(nickname)
         .profileImageUrl(profileImageUrl)
         .interests(interests)

--- a/src/main/java/com/bob/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bob/global/exception/GlobalExceptionHandler.java
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
     BindingResult bindingResult = ex.getBindingResult();
 
     String detailMessage = bindingResult.getFieldErrors().stream()
-        .map(error -> String.format("[%s] %s", error.getField(), error.getDefaultMessage()))
+        .map(error -> String.format("%s", error.getDefaultMessage()))
         .findFirst()
         .orElse(VALIDATION_ERROR.getMessage());
 

--- a/src/main/java/com/bob/web/member/request/ChangeProfileRequest.java
+++ b/src/main/java/com/bob/web/member/request/ChangeProfileRequest.java
@@ -2,16 +2,23 @@ package com.bob.web.member.request;
 
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import java.util.UUID;
 
 public record ChangeProfileRequest(
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(max = 12, message = "닉네임은 12자 이하로 입력해 주세요.")
-    String nickname
+    String nickname,
+
+    @NotNull(message = "관심사 목록은 필수입니다.")
+    @Size(max = 20, message = "관심사는 최대 20개까지 등록 가능합니다.")
+    List<@Pattern(regexp = "^(?!\\s)(.*\\S)?$", message = "관심사는 앞뒤에 공백이 올 수 없습니다.") String> interests
 ) {
 
   public ChangeProfileCommand toCommand(UUID memberId) {
-    return new ChangeProfileCommand(memberId, nickname);
+    return new ChangeProfileCommand(memberId, nickname, interests);
   }
 }

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -2,8 +2,6 @@ package com.bob.domain.member.service;
 
 import static com.bob.domain.member.entity.Status.ACTIVE;
 import static com.bob.domain.member.entity.Status.WITHDRAW;
-import static com.bob.support.fixture.command.ChangeProfileCommandFixture.defaultChangeProfileCommand;
-import static com.bob.support.fixture.command.ChangeProfileCommandFixture.sameNicknameChangeProfileCommand;
 import static com.bob.support.fixture.command.ChangeProfileImageUrlCommandFixture.customChangeProfileImageUrlCommand;
 import static com.bob.support.fixture.command.MemberCommandFixture.customChangePasswordCommand;
 import static com.bob.support.fixture.command.MemberCommandFixture.defaultCreateMemberCommand;
@@ -21,6 +19,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.repository.MemberInterestRepository;
 import com.bob.domain.member.repository.MemberRepository;
 import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
@@ -36,11 +35,12 @@ import com.bob.domain.member.service.dto.response.SocialLoginResponse;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
-import com.bob.global.event.application.dto.member.AccountEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import com.bob.support.TestContainerSupport;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +60,12 @@ class MemberServiceIntgTest extends TestContainerSupport {
 
   @Autowired
   private MemberRepository memberRepository;
+
+  @Autowired
+  private MemberInterestService memberInterestService;
+
+  @Autowired
+  private MemberInterestRepository memberInterestRepository;
 
   @Autowired
   private PasswordEncoder passwordEncoder;
@@ -173,37 +179,53 @@ class MemberServiceIntgTest extends TestContainerSupport {
     assertThat(response.memberId()).isEqualTo(member.getId());
     assertThat(response.nickname()).isEqualTo(member.getNickname());
     assertThat(response.profileImageUrl()).isEqualTo(member.getProfileImageUrl());
+    assertThat(response.interests()).isNotNull();
     assertThat(response.area()).isNotNull();
   }
 
   @Test
-  @DisplayName("프로필 변경 - 성공 테스트")
-  void 닉네임이_다르면_프로필을_변경할_수_있다() {
+  void 프로필_수정_별명_관심사_수정() {
     // given
     Member member = defaultMember();
     memberRepository.save(member);
-    ChangeProfileCommand command = defaultChangeProfileCommand(member.getId());
+    memberInterestService.changeMemberInterests(member.getId(), List.of("Java", "Spring"));
+    ChangeProfileCommand command = new ChangeProfileCommand(member.getId(), "newTester", List.of("Kotlin", "Go"));
 
     // when
     memberService.changeProfileProcess(command);
 
     // then
-    assertThat(member.getNickname()).isEqualTo(command.nickname());
+    Member reloaded = memberRepository.findById(member.getId()).orElseThrow();
+    assertThat(reloaded.getNickname()).isEqualTo("newTester");
+
+    List<String> savedInterests = memberInterestRepository.findDisplayNamesByMemberId(member.getId());
+    assertThat(toLowerSet(savedInterests)).isEqualTo(Set.of("kotlin", "go"));
   }
 
   @Test
-  @DisplayName("프로필 변경 - 실패 테스트(동일한 닉네임)")
-  void 닉네임이_동일하면_프로필_변경에_실패한다() {
+  void 프로필_수정_동일_수정() {
     // given
     Member member = defaultMember();
     memberRepository.save(member);
+    List<String> initiInterests = List.of("Java", "Spring");
+    memberInterestService.changeMemberInterests(member.getId(), initiInterests);
 
-    ChangeProfileCommand command = sameNicknameChangeProfileCommand(member.getId());
+    ChangeProfileCommand command = new ChangeProfileCommand(member.getId(), member.getNickname(), List.of("Java", "Spring"));
 
     // when & then
     assertThatThrownBy(() -> memberService.changeProfileProcess(command))
         .isInstanceOf(ApplicationException.class)
         .hasMessage(ApplicationError.IS_SAME_REQUEST.getMessage());
+
+    Member reloaded = memberRepository.findById(member.getId()).orElseThrow();
+    assertThat(reloaded.getNickname()).isEqualTo(member.getNickname());
+
+    List<String> savedInterests = memberInterestRepository.findDisplayNamesByMemberId(member.getId());
+    assertThat(toLowerSet(savedInterests)).isEqualTo(toLowerSet(initiInterests));
+  }
+
+  private static Set<String> toLowerSet(List<String> src) {
+    return src.stream().map(String::toLowerCase).collect(Collectors.toSet());
   }
 
   @Test

--- a/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberServiceIntgTest.java
@@ -164,8 +164,7 @@ class MemberServiceIntgTest extends TestContainerSupport {
   }
 
   @Test
-  @DisplayName("사용자 프로필 조회 - 성공 테스트")
-  void 회원은_자신의_프로필을_조회할_수_있다() {
+  void 프로필_조회() {
     // given
     Member member = defaultMember();
     memberRepository.save(member);
@@ -176,7 +175,9 @@ class MemberServiceIntgTest extends TestContainerSupport {
     MemberProfileResponse response = memberService.readProfileProcess(query);
 
     // then
+    assertThat(response.isSocial()).isFalse();
     assertThat(response.memberId()).isEqualTo(member.getId());
+    assertThat(response.email()).isEqualTo(member.getEmail());
     assertThat(response.nickname()).isEqualTo(member.getNickname());
     assertThat(response.profileImageUrl()).isEqualTo(member.getProfileImageUrl());
     assertThat(response.interests()).isNotNull();

--- a/src/test/intg/resources/sql/schema.sql
+++ b/src/test/intg/resources/sql/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS books (
 );
 
 -- ========================
--- 🧑 MEMBERS TABLE (UUID로 수정됨)
+-- 🧑 MEMBERS TABLE
 -- ========================
 CREATE TABLE IF NOT EXISTS members (
     id BINARY(16) PRIMARY KEY,
@@ -24,6 +24,30 @@ CREATE TABLE IF NOT EXISTS members (
     provider ENUM('GOOGLE', 'NAVER'),
     status ENUM('ACTIVE', 'WITHDRAW', 'BANNED'),
     created_at DATETIME
+);
+
+-- ========================
+-- INTERESTS TABLE
+-- ========================
+CREATE TABLE IF NOT EXISTS interests (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    canonical_name VARCHAR(120) NOT NULL,
+    created_at     DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT uk_interests_canonical UNIQUE KEY (canonical_name)
+);
+
+-- ========================
+-- MEMBER INTERESTS TABLE
+-- ========================
+CREATE TABLE IF NOT EXISTS member_interests (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    member_id   BINARY(16) NOT NULL,
+    interest_id BIGINT     NOT NULL,
+    display_name VARCHAR(100) NOT NULL,
+    created_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT fk_mi_member   FOREIGN KEY (member_id)  REFERENCES members(id)   ON DELETE CASCADE,
+    CONSTRAINT fk_mi_interest FOREIGN KEY (interest_id) REFERENCES interests(id),
+    CONSTRAINT uk_member_interest UNIQUE KEY (member_id, interest_id)
 );
 
 -- ========================

--- a/src/test/unit/java/com/bob/domain/member/entity/InterestTest.java
+++ b/src/test/unit/java/com/bob/domain/member/entity/InterestTest.java
@@ -1,0 +1,46 @@
+package com.bob.domain.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class InterestTest {
+
+  @ParameterizedTest(name = "canonicalize(\"{0}\") => \"{1}\"")
+  @MethodSource("canonicalizeCases")
+  void canonicalize_테스트(String input, String expected) {
+    // when
+    String actual = Interest.canonicalize(input);
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> canonicalizeCases() {
+    return Stream.of(
+        Arguments.of("Java", "java"),
+        Arguments.of("  Java  ", "java"),
+        Arguments.of("  JAVA  SPRING  ", "java spring"),
+        Arguments.of("Go\tLang", "go lang"),
+        Arguments.of("  KOTLIN\nCOROUTINES  ", "kotlin coroutines"),
+        Arguments.of(" sql   server ", "sql server")
+    );
+  }
+
+  @Test
+  void 관심사_생성() {
+    // given
+    String raw = "  Java   Spring  ";
+
+    // when
+    Interest interest = Interest.of(raw);
+
+    // then
+    assertThat(interest.getId()).isNull();
+    assertThat(interest.getCanonicalName()).isEqualTo("java spring");
+  }
+}

--- a/src/test/unit/java/com/bob/domain/member/entity/MemberInterestTest.java
+++ b/src/test/unit/java/com/bob/domain/member/entity/MemberInterestTest.java
@@ -1,0 +1,37 @@
+package com.bob.domain.member.entity;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MemberInterestTest {
+
+  @Test
+  void 회원_관심사_생성() {
+    // given
+    Long id = 123L;
+    String displayName = "Java";
+
+    // when
+    MemberInterest memberInterest = MemberInterest.of(MEMBER_ID, id, displayName);
+
+    // then
+    assertThat(memberInterest.getMemberId()).isEqualTo(MEMBER_ID);
+    assertThat(memberInterest.getInterestId()).isEqualTo(id);
+    assertThat(memberInterest.getDisplayName()).isEqualTo("Java");
+  }
+
+  @Test
+  void 회원_관심사_이름_표현() {
+    // given
+    Long interestId = 99L;
+    String rawDisplay = "  Java  ";
+
+    // when
+    MemberInterest mi = MemberInterest.of(MEMBER_ID, interestId, rawDisplay);
+
+    // then
+    assertThat(mi.getDisplayName()).isEqualTo("  Java  ");
+  }
+}

--- a/src/test/unit/java/com/bob/domain/member/service/MemberInterestServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberInterestServiceTest.java
@@ -1,0 +1,195 @@
+package com.bob.domain.member.service;
+
+import static com.bob.support.fixture.domain.InterestFixture.customInterest;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.domain.MemberFixture.defaultIdMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyCollection;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.bob.domain.member.entity.Interest;
+import com.bob.domain.member.entity.Member;
+import com.bob.domain.member.entity.MemberInterest;
+import com.bob.domain.member.repository.InterestRepository;
+import com.bob.domain.member.repository.MemberInterestRepository;
+import com.bob.domain.member.repository.projection.InterestEntry;
+import com.bob.domain.member.service.reader.MemberReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("회원 관심사 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class MemberInterestServiceTest {
+
+  @InjectMocks
+  MemberInterestService service;
+
+  @Mock
+  MemberInterestRepository memberInterestRepository;
+
+  @Mock
+  InterestRepository interestRepository;
+
+  @Mock
+  MemberReader memberReader;
+
+  @Test
+  void 관심사_변경_신규_추가() {
+    // given
+    Member member = defaultIdMember();
+    given(memberReader.readMemberById(member.getId())).willReturn(member);
+    given(memberInterestRepository.findCanonicalNameWithId(member.getId())).willReturn(List.of());
+
+    List<String> raw = List.of("JAVA", "Go");
+    List<Interest> foundAfterUpsert = List.of(customInterest(1L, "java"), customInterest(2L, "go"));
+    given(interestRepository.findByCanonicalNameIn(new LinkedHashSet<>(List.of("java", "go")))).willReturn(foundAfterUpsert);
+
+    ArgumentCaptor<Collection<MemberInterest>> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+
+    // when
+    service.changeMemberInterests(member.getId(), raw);
+
+    // then
+    then(interestRepository).should().upsert("java");
+    then(interestRepository).should().upsert("go");
+    then(interestRepository).should().findByCanonicalNameIn(new LinkedHashSet<>(List.of("java", "go")));
+    then(memberInterestRepository).should().saveAll(saveCaptor.capture());
+
+    List<MemberInterest> saved = new ArrayList<>(saveCaptor.getValue());
+    assertThat(saved).hasSize(2);
+    assertThat(saved.stream().map(MemberInterest::getDisplayName)).containsExactlyInAnyOrder("JAVA", "Go");
+    assertThat(saved.stream().map(MemberInterest::getInterestId)).containsExactlyInAnyOrder(1L, 2L);
+  }
+
+  @Test
+  void 관심사_변경_일부_추가_일부_삭제() {
+    // given
+    Member member = defaultIdMember();
+    given(memberReader.readMemberById(member.getId())).willReturn(member);
+
+    InterestEntry entry1 = new InterestEntry(1L, "java");
+    InterestEntry entry2 = new InterestEntry(2L, "spring");
+    given(memberInterestRepository.findCanonicalNameWithId(MEMBER_ID)).willReturn(List.of(entry1, entry2));
+
+    List<String> raw = List.of("Java", "Kotlin");
+    given(interestRepository.findByCanonicalNameIn(anyCollection())).willReturn(List.of(customInterest(3L, "kotlin")));
+
+    ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+    ArgumentCaptor<Collection> deleteCaptor = ArgumentCaptor.forClass(Collection.class);
+
+    // when
+    service.changeMemberInterests(MEMBER_ID, raw);
+
+    // then
+    then(interestRepository).should().upsert("kotlin");
+    then(interestRepository).should(never()).upsert("java");
+    then(memberInterestRepository).should().saveAll(saveCaptor.capture());
+
+    List<MemberInterest> saved = new ArrayList<>(saveCaptor.getValue());
+    assertThat(saved).hasSize(1);
+    assertThat(saved.get(0).getInterestId()).isEqualTo(3L);
+    assertThat(saved.get(0).getDisplayName()).isEqualTo("Kotlin");
+
+    then(memberInterestRepository).should().deleteByMemberIdAndInterestIds(eq(MEMBER_ID), deleteCaptor.capture());
+    assertThat(deleteCaptor.getValue()).containsExactly(2L); // spring
+  }
+
+  @Test
+  void 관심사_변경_대소문자_중복_시_단일_처리() {
+    // given
+    Member member = defaultIdMember();
+    given(memberReader.readMemberById(member.getId())).willReturn(member);
+    given(memberInterestRepository.findCanonicalNameWithId(MEMBER_ID)).willReturn(List.of());
+
+    List<String> raw = List.of("Java", "java");
+    given(interestRepository.findByCanonicalNameIn(new LinkedHashSet<>(List.of("java"))))
+        .willReturn(List.of(customInterest(1L, "java")));
+    ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+
+    // when
+    service.changeMemberInterests(MEMBER_ID, raw);
+
+    // then
+    then(interestRepository).should().upsert("java");
+    then(memberInterestRepository).should().saveAll(saveCaptor.capture());
+
+    List<MemberInterest> saved = new ArrayList<>(saveCaptor.getValue());
+    assertThat(saved).hasSize(1);
+    assertThat(saved.get(0).getDisplayName()).isEqualTo("Java");
+    assertThat(saved.get(0).getInterestId()).isEqualTo(1L);
+  }
+
+  @Test
+  void 관심사_변경_공백_Null_정리() {
+    // given
+    Member member = defaultIdMember();
+    given(memberReader.readMemberById(member.getId())).willReturn(member);
+    given(memberInterestRepository.findCanonicalNameWithId(MEMBER_ID)).willReturn(List.of());
+
+    List<String> raw = Arrays.asList(null, "  ", "  Java  ", "", "Go");
+    given(interestRepository.findByCanonicalNameIn(new LinkedHashSet<>(List.of("java", "go"))))
+        .willReturn(List.of(customInterest(1L, "java"), customInterest(2L, "go")));
+    ArgumentCaptor<Collection> saveCaptor = ArgumentCaptor.forClass(Collection.class);
+
+    // when
+    service.changeMemberInterests(MEMBER_ID, raw);
+
+    // then
+    then(interestRepository).should().upsert("java");
+    then(interestRepository).should().upsert("go");
+    then(memberInterestRepository).should().saveAll(saveCaptor.capture());
+
+    List<MemberInterest> saved = new ArrayList<>(saveCaptor.getValue());
+    assertThat(saved).hasSize(2);
+    assertThat(saved.stream().map(MemberInterest::getDisplayName)).containsExactlyInAnyOrder("Java", "Go");
+    assertThat(saved.stream().map(MemberInterest::getInterestId)).containsExactlyInAnyOrder(1L, 2L);
+  }
+
+  @Test
+  void 관심사_변경_없음() {
+    // given
+    Member member = defaultIdMember();
+    given(memberReader.readMemberById(member.getId())).willReturn(member);
+
+    List<String> raw = List.of("JAVA");
+    InterestEntry entry = new InterestEntry(1L, "java");
+    given(memberInterestRepository.findCanonicalNameWithId(MEMBER_ID)).willReturn(List.of(entry));
+
+    // when
+    service.changeMemberInterests(MEMBER_ID, raw);
+
+    // then
+    then(interestRepository).should(never()).upsert(anyString());
+    then(memberInterestRepository).should(never()).saveAll(anyCollection());
+    then(memberInterestRepository).should(never()).deleteByMemberIdAndInterestIds(any(), anyCollection());
+  }
+
+  @Test
+  void 관심사_조회() {
+    // given
+    List<String> displays = List.of("Java", "Spring");
+    given(memberInterestRepository.findDisplayNamesByMemberId(MEMBER_ID)).willReturn(displays);
+
+    // when
+    List<String> result = service.readMemberInterests(MEMBER_ID);
+
+    // then
+    assertThat(result).containsExactlyElementsOf(displays);
+    then(memberInterestRepository).should().findDisplayNamesByMemberId(MEMBER_ID);
+  }
+}

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -7,8 +7,7 @@ import static com.bob.global.exception.response.ApplicationError.INVALID_OLD_PAS
 import static com.bob.global.exception.response.ApplicationError.IS_SAME_REQUEST;
 import static com.bob.global.exception.response.ApplicationError.NOT_EXISTS_MEMBER;
 import static com.bob.global.exception.response.ApplicationError.UNVERIFIED_EMAIL;
-import static com.bob.support.fixture.command.ChangeProfileCommandFixture.defaultChangeProfileCommand;
-import static com.bob.support.fixture.command.ChangeProfileCommandFixture.sameNicknameChangeProfileCommand;
+import static com.bob.support.fixture.command.ChangeProfileCommandFixture.sameChangeProfileCommand;
 import static com.bob.support.fixture.command.MemberCommandFixture.defaultChangePasswordCommand;
 import static com.bob.support.fixture.command.MemberCommandFixture.defaultCreateMemberCommand;
 import static com.bob.support.fixture.command.MemberCommandFixture.defaultIssuePasswordCommand;
@@ -19,9 +18,11 @@ import static com.bob.support.fixture.domain.MemberFixture.defaultMember;
 import static com.bob.support.fixture.domain.MemberFixture.removedMember;
 import static com.bob.support.fixture.query.MemberQueryFixture.defaultReadProfileQuery;
 import static com.bob.support.fixture.response.MemberAreaSummaryResponseFixture.DEFAULT_AREA_SUMMARY_RESPONSE;
+import static com.bob.support.fixture.response.interest.InterestNamesFixture.DEFAULT_INTEREST_DISPLAY_NAMES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -48,9 +49,14 @@ import com.bob.global.event.application.dto.member.AccountEvent;
 import com.bob.global.exception.exceptions.ApplicationException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -65,6 +71,9 @@ class MemberServiceTest {
 
   @InjectMocks
   private MemberService memberService;
+
+  @Mock
+  private MemberInterestService memberInterestService;
 
   @Mock
   private MemberRepository memberRepository;
@@ -187,6 +196,7 @@ class MemberServiceTest {
     ReadProfileQuery query = defaultReadProfileQuery();
 
     given(memberReader.readMemberById(query.memberId())).willReturn(member);
+    given(memberInterestService.readMemberInterests(member.getId())).willReturn(DEFAULT_INTEREST_DISPLAY_NAMES());
     given(areaPort.readMemberAreaSummary(MEMBER_ID)).willReturn(DEFAULT_AREA_SUMMARY_RESPONSE);
 
     // when
@@ -196,6 +206,7 @@ class MemberServiceTest {
     then(memberReader).should(times(1)).readMemberById(query.memberId());
     assertThat(response.memberId()).isEqualTo(member.getId());
     assertThat(response.nickname()).isEqualTo(member.getNickname());
+    assertThat(response.interests()).hasSize(DEFAULT_INTEREST_DISPLAY_NAMES().size());
     assertThat(response.area().emdId()).isEqualTo(EMD_AREA_ID);
     assertThat(response.area().isAuthentication()).isTrue();
   }
@@ -207,6 +218,7 @@ class MemberServiceTest {
     ReadProfileQuery query = defaultReadProfileQuery();
 
     given(memberReader.readMemberById(query.memberId())).willReturn(member);
+    given(memberInterestService.readMemberInterests(member.getId())).willReturn(DEFAULT_INTEREST_DISPLAY_NAMES());
     given(areaPort.readMemberAreaSummary(MEMBER_ID)).willReturn(DEFAULT_AREA_SUMMARY_RESPONSE);
 
     // when
@@ -217,38 +229,63 @@ class MemberServiceTest {
     assertThat(response.memberId()).isEqualTo(member.getId());
     assertThat(response.nickname()).isEqualTo("(알 수 없음)");
     assertThat(response.profileImageUrl()).isNull();
+    assertThat(response.interests()).hasSize(0);
   }
 
-  @Test
-  @DisplayName("프로필 변경 - 성공 테스트")
-  void 닉네임이_다르면_프로필을_변경할_수_있다() {
+  @ParameterizedTest(name = "프로필 변경 성공 케이스: {0}")
+  @MethodSource("provideChangeProfileSuccessCases")
+  void 프로필_변경(String caseName, String newNickname, List<String> newInterests) {
     // given
     Member member = defaultIdMember();
-    ChangeProfileCommand command = defaultChangeProfileCommand(member.getId());
+    ChangeProfileCommand command = new ChangeProfileCommand(member.getId(), newNickname, newInterests);
 
     given(memberReader.readMemberById(member.getId())).willReturn(member);
+    given(memberInterestService.readMemberInterests(member.getId())).willReturn(DEFAULT_INTEREST_DISPLAY_NAMES());
 
     // when
     memberService.changeProfileProcess(command);
 
     // then
     then(memberReader).should().readMemberById(member.getId());
+    then(memberInterestService).should().readMemberInterests(member.getId());
+    then(memberInterestService).should().changeMemberInterests(member.getId(), command.interests());
     assertThat(member.getNickname()).isEqualTo(command.nickname());
   }
 
   @Test
-  @DisplayName("프로필 변경 - 실패 테스트(동일한 닉네임)")
-  void 닉네임이_동일하면_프로필_변경에_실패한다() {
+  void 프로필_수정_별명_관심사_동일_요청() {
     // given
     Member member = defaultIdMember();
-    ChangeProfileCommand command = sameNicknameChangeProfileCommand(member.getId());
+    ChangeProfileCommand command = sameChangeProfileCommand(member.getId());
 
     given(memberReader.readMemberById(member.getId())).willReturn(member);
+    given(memberInterestService.readMemberInterests(member.getId())).willReturn(DEFAULT_INTEREST_DISPLAY_NAMES());
 
     // when & then
     assertThatThrownBy(() -> memberService.changeProfileProcess(command))
         .isInstanceOf(ApplicationException.class)
         .hasMessage(IS_SAME_REQUEST.getMessage());
+
+    then(memberInterestService).should().readMemberInterests(member.getId());
+    then(memberInterestService).should(never()).changeMemberInterests(any(UUID.class), anyList());
+
+    assertThat(member.getNickname()).isNotNull();
+    assertThat(member.isEqualsNickname(command.nickname())).isTrue();
+  }
+
+  private static Stream<Arguments> provideChangeProfileSuccessCases() {
+    return Stream.of(
+        Arguments.of(
+            "다른 닉네임",
+            "newNickname",
+            List.of("interest1", "interest2")
+        ),
+        Arguments.of(
+            "다른 관심사",
+            "tester",
+            List.of("Kotlin", "Spring")
+        )
+    );
   }
 
   @Test

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -204,7 +204,9 @@ class MemberServiceTest {
 
     // then
     then(memberReader).should(times(1)).readMemberById(query.memberId());
+    assertThat(response.isSocial()).isFalse();
     assertThat(response.memberId()).isEqualTo(member.getId());
+    assertThat(response.email()).isEqualTo(member.getEmail());
     assertThat(response.nickname()).isEqualTo(member.getNickname());
     assertThat(response.interests()).hasSize(DEFAULT_INTEREST_DISPLAY_NAMES().size());
     assertThat(response.area().emdId()).isEqualTo(EMD_AREA_ID);
@@ -227,6 +229,7 @@ class MemberServiceTest {
     // then
     then(memberReader).should(times(1)).readMemberById(query.memberId());
     assertThat(response.memberId()).isEqualTo(member.getId());
+    assertThat(response.email()).isEqualTo("delete");
     assertThat(response.nickname()).isEqualTo("(알 수 없음)");
     assertThat(response.profileImageUrl()).isNull();
     assertThat(response.interests()).hasSize(0);

--- a/src/test/unit/java/com/bob/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/unit/java/com/bob/global/exception/GlobalExceptionHandlerTest.java
@@ -65,7 +65,6 @@ public class GlobalExceptionHandlerTest {
     assertThat(response.getStatusCode()).isEqualTo(VALIDATION_ERROR.getStatus());
     assertThat(response.getBody()).isNotNull();
     assertThat(response.getBody().code()).isEqualTo(VALIDATION_ERROR.getCode());
-    assertThat(response.getBody().message()).contains("email");
   }
 
   @Test

--- a/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileCommandFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/command/ChangeProfileCommandFixture.java
@@ -1,15 +1,12 @@
 package com.bob.support.fixture.command;
 
 import com.bob.domain.member.service.dto.command.ChangeProfileCommand;
+import java.util.List;
 import java.util.UUID;
 
 public class ChangeProfileCommandFixture {
 
-  public static ChangeProfileCommand defaultChangeProfileCommand(UUID memberId) {
-    return new ChangeProfileCommand(memberId, "new-nickname");
-  }
-
-  public static ChangeProfileCommand sameNicknameChangeProfileCommand(UUID memberId) {
-    return new ChangeProfileCommand(memberId, "tester");
+  public static ChangeProfileCommand sameChangeProfileCommand(UUID memberId) {
+    return new ChangeProfileCommand(memberId, "tester", List.of("interest1", "interest2"));
   }
 }

--- a/src/test/unit/java/com/bob/support/fixture/domain/InterestFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/domain/InterestFixture.java
@@ -1,0 +1,13 @@
+package com.bob.support.fixture.domain;
+
+import com.bob.domain.member.entity.Interest;
+
+public class InterestFixture {
+
+  public static Interest customInterest(Long id, String canonicalName) {
+    return Interest.builder()
+        .id(id)
+        .canonicalName(canonicalName)
+        .build();
+  }
+}

--- a/src/test/unit/java/com/bob/support/fixture/response/interest/InterestNamesFixture.java
+++ b/src/test/unit/java/com/bob/support/fixture/response/interest/InterestNamesFixture.java
@@ -1,0 +1,10 @@
+package com.bob.support.fixture.response.interest;
+
+import java.util.List;
+
+public class InterestNamesFixture {
+
+  public static List<String> DEFAULT_INTEREST_DISPLAY_NAMES() {
+    return List.of("interest1", "interest2");
+  }
+}

--- a/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
@@ -127,7 +127,8 @@ class MemberControllerTest {
     // given
     String json = """
         {
-            "nickname": "변경된닉네임"
+            "nickname": "변경된닉네임",
+            "interests": []
         }
         """;
 


### PR DESCRIPTION
this closes #103, closes #104 

### 작업 내용
- [x] 관심사 관리 기능 추가
  - interests, member_interests 테이블 설계 및 생성
  - 알림 도메인 역방향 탐색을 위한 1:N, N:1 관계 설정
- [x] 프로필 수정 시 관심사 등록/변경 기능 구현
- [x] 프로필 조회 시 관심사 조회 기능 구현
- [x] 회원 프로필 응답에 email, isSocial 필드 추가

---

### 참고
기타 협업 참고
> 일반 회원가입으로 생성된 계정은 소셜 로그인 후 프로필을 조회해도 `isSocial` 값이 false로 반환됩니다.
