### PR TITLE
chore: sse 구독 유지 시간 변경

### DIFF
--- a/src/main/java/com/bob/global/event/sse/manager/EmitterManager.java
+++ b/src/main/java/com/bob/global/event/sse/manager/EmitterManager.java
@@ -53,7 +53,7 @@ public class EmitterManager implements Runnable {
       removeEmitter(old, key, repository);
     }
 
-    SseEmitter emitter = new SseEmitter(defaultTimeout);
+    SseEmitter emitter = new SseEmitter(defaultTimeout * 1000);
     setupEmitter(emitter, key, repository);
     repository.save(key, emitter);
     sendEvent(type, key, CONNECT, "connected");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,6 @@ spring:
     time-zone: Asia/Seoul
 
 sse:
-  heartbeat-interval: 10 # 10초
-  default-timeout: 60000 # 1분
+  heartbeat-interval: 30 # 30초
+  default-timeout: 1800 # 30분
 


### PR DESCRIPTION
this closes #114 

### 작업 내용
- [x] sse 구독 유지 시간 변경, 1분 -> 30분
- [x] 하트비트 전송 시간 변경, 10초 -> 30초 변경
  - 헬스체크는 서버 이벤트 발신 전 따로 진행