### PR TITLE
feat: 게시글 목록 조회 시 거래 진행 여부 반영

### DIFF
--- a/src/main/java/com/bob/domain/post/service/PostService.java
+++ b/src/main/java/com/bob/domain/post/service/PostService.java
@@ -30,7 +30,7 @@ import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
 import com.bob.domain.post.service.dto.response.PostCreateResponse;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
 import com.bob.domain.post.service.dto.response.PostFavoritesResponse;
-import com.bob.domain.post.service.dto.response.PostsResponse;
+import com.bob.domain.post.service.dto.response.PostsResult;
 import com.bob.domain.post.service.dto.response.internal.PostAreaSummaryResponse;
 import com.bob.domain.post.service.dto.response.internal.PostBookSummaryResponse;
 import com.bob.domain.post.service.dto.response.internal.PostFileSummaryResponse;
@@ -118,12 +118,12 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
   }
 
   @Transactional(readOnly = true)
-  public PostsResponse readFilteredPostsProcess(ReadFilteredPostsQuery query, Pageable pageable) {
+  public PostsResult readFilteredPostsProcess(ReadFilteredPostsQuery query, Pageable pageable) {
     addChildCategoryIds(query);
     addBookIds(query);
     List<Post> posts = postReader.readFilteredPosts(query, pageable);
     Long totalCount = postRepository.countFilteredPosts(query);
-    return PostsResponse.of(totalCount, posts);
+    return PostsResult.of(totalCount, posts, query.authenticatorId());
   }
 
   private void addChildCategoryIds(ReadFilteredPostsQuery query) {
@@ -149,9 +149,9 @@ public class PostService implements PostWriteUseCase, PostReadUseCase, PostModif
   }
 
   @Transactional(readOnly = true)
-  public PostsResponse readPostFavoritesProcess(ReadPostFavoritesQuery query, Pageable pageable) {
+  public PostsResult readPostFavoritesProcess(ReadPostFavoritesQuery query, Pageable pageable) {
     PostFavoritesResponse response = postFavoriteService.readMemberFavoritePosts(query.memberId(), pageable);
-    return new PostsResponse(response.totalCount(), response.postFavorites());
+    return new PostsResult(response.totalCount(), response.postFavorites());
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/post/service/dto/query/ReadFilteredPostsQuery.java
+++ b/src/main/java/com/bob/domain/post/service/dto/query/ReadFilteredPostsQuery.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 
 @Builder
 public record ReadFilteredPostsQuery(
+    UUID authenticatorId,
     SearchKey key,
     String keyword,
     UUID memberId,

--- a/src/main/java/com/bob/domain/post/service/dto/response/PostSummary.java
+++ b/src/main/java/com/bob/domain/post/service/dto/response/PostSummary.java
@@ -2,6 +2,8 @@ package com.bob.domain.post.service.dto.response;
 
 import com.bob.domain.post.entity.Post;
 import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
@@ -13,7 +15,8 @@ public record PostSummary(
     String thumbnailUrl,
     String bookStatus,
     Integer sellPrice,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    String participation
 ) {
 
   public static PostSummary from(Post post) {
@@ -26,6 +29,22 @@ public record PostSummary(
         .bookStatus(post.getBookStatus().name())
         .sellPrice(post.getSellPrice())
         .createdAt(post.getCreatedAt())
+        .participation("NONE")
+        .build();
+  }
+
+  public static PostSummary from(Post post, UUID memberId) {
+    String participation = Objects.equals(post.getSellerId(), memberId) ? "OWNER" : "NONE";
+    return PostSummary.builder()
+        .postId(post.getId())
+        .categoryId(post.getCategory().getId())
+        .postTitle(post.getTitle())
+        .postStatus(post.getTradeProgress().name())
+        .thumbnailUrl(post.getThumbnailUrl())
+        .bookStatus(post.getBookStatus().name())
+        .sellPrice(post.getSellPrice())
+        .createdAt(post.getCreatedAt())
+        .participation(participation)
         .build();
   }
 }

--- a/src/main/java/com/bob/domain/post/service/dto/response/PostsResult.java
+++ b/src/main/java/com/bob/domain/post/service/dto/response/PostsResult.java
@@ -2,17 +2,18 @@ package com.bob.domain.post.service.dto.response;
 
 import com.bob.domain.post.entity.Post;
 import java.util.List;
+import java.util.UUID;
 
-public record PostsResponse(
+public record PostsResult(
     Long totalCount,
     List<PostSummary> posts
 ) {
 
-  public static PostsResponse of(Long totalCount, List<Post> postList) {
+  public static PostsResult of(Long totalCount, List<Post> postList, UUID memberId) {
     List<PostSummary> summaries = postList.stream()
-        .map(PostSummary::from)
+        .map(post -> PostSummary.from(post, memberId))
         .toList();
 
-    return new PostsResponse(totalCount, summaries);
+    return new PostsResult(totalCount, summaries);
   }
 }

--- a/src/main/java/com/bob/domain/post/usecase/PostReadUseCase.java
+++ b/src/main/java/com/bob/domain/post/usecase/PostReadUseCase.java
@@ -4,14 +4,14 @@ import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
-import com.bob.domain.post.service.dto.response.PostsResponse;
+import com.bob.domain.post.service.dto.response.PostsResult;
 import org.springframework.data.domain.Pageable;
 
 public interface PostReadUseCase {
 
-  PostsResponse readFilteredPostsProcess(ReadFilteredPostsQuery query, Pageable pageable);
+  PostsResult readFilteredPostsProcess(ReadFilteredPostsQuery query, Pageable pageable);
 
-  PostsResponse readPostFavoritesProcess(ReadPostFavoritesQuery query, Pageable pageable);
+  PostsResult readPostFavoritesProcess(ReadPostFavoritesQuery query, Pageable pageable);
 
   PostDetailResponse readPostDetailProcess(ReadPostDetailQuery query);
 }

--- a/src/main/java/com/bob/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/bob/domain/trade/repository/TradeRepository.java
@@ -28,4 +28,6 @@ public interface TradeRepository extends CrudRepository<Trade, Long>, CustomTrad
          AND t.buyerId = :buyerId
       """)
   Optional<Long> findIdByPostIdAndBuyerId(Long postId, UUID buyerId);
+
+  List<Trade> findAllByBuyerIdAndPostIdIn(UUID buyerId, List<Long> postIds);
 }

--- a/src/main/java/com/bob/domain/trade/service/TradeService.java
+++ b/src/main/java/com/bob/domain/trade/service/TradeService.java
@@ -21,6 +21,7 @@ import static com.bob.global.exception.response.ApplicationError.TRADE_POST_REMO
 import static com.bob.global.exception.response.ApplicationError.TRADE_STATUS_UNCHANGED;
 import static com.bob.global.exception.response.ApplicationError.UNCHANGEABLE_TRADE_ITEM;
 import static java.time.LocalDateTime.now;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import com.bob.domain.trade.entity.Trade;
 import com.bob.domain.trade.entity.status.Status;
@@ -30,12 +31,14 @@ import com.bob.domain.trade.service.dto.command.ChangeTradeItemsCommand;
 import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import com.bob.domain.trade.service.dto.command.CreateTradeItemsCommand;
+import com.bob.domain.trade.service.dto.query.ReadParticipateTradeStatusQuery;
 import com.bob.domain.trade.service.dto.query.ReadPostTradesQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.domain.trade.service.dto.response.CreateTradeResponse;
 import com.bob.domain.trade.service.dto.response.PostTradesResponse;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradeStatusMapResult;
 import com.bob.domain.trade.service.dto.response.TradesResponse;
 import com.bob.domain.trade.service.dto.response.internal.PostTradeSummary;
 import com.bob.domain.trade.service.dto.response.internal.TradeItemSummary;
@@ -155,6 +158,13 @@ public class TradeService implements TradeWriteUseCase, TradeReadUseCase, TradeM
         TradeDetailResponse.Trader.from(seller, sellerItemsWorth, sellerItems),
         TradeDetailResponse.Trader.from(buyer, buyerItemsWorth, buyerItems)
     );
+  }
+
+  @Transactional(readOnly = true)
+  public TradeStatusMapResult readTradeStatusProcess(ReadParticipateTradeStatusQuery query) {
+    List<Trade> trades = tradeReader.readTradesByBuyerIdAndPostId(query.memberId(), query.postIds());
+    Map<Long, String> map = trades.stream().collect(toUnmodifiableMap(Trade::getPostId, t -> t.getStatus().name()));
+    return TradeStatusMapResult.of(map);
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/trade/service/dto/query/ReadParticipateTradeStatusQuery.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/query/ReadParticipateTradeStatusQuery.java
@@ -1,0 +1,14 @@
+package com.bob.domain.trade.service.dto.query;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ReadParticipateTradeStatusQuery(
+    UUID memberId,
+    List<Long> postIds
+) {
+
+  public static ReadParticipateTradeStatusQuery of(UUID memberId, List<Long> ids) {
+    return new ReadParticipateTradeStatusQuery(memberId, ids);
+  }
+}

--- a/src/main/java/com/bob/domain/trade/service/dto/response/TradeStatusMapResult.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/TradeStatusMapResult.java
@@ -1,0 +1,12 @@
+package com.bob.domain.trade.service.dto.response;
+
+import java.util.Map;
+
+public record TradeStatusMapResult(
+    Map<Long, String> statusMap
+) {
+
+  public static TradeStatusMapResult of(Map<Long, String> map) {
+    return new TradeStatusMapResult(map);
+  }
+}

--- a/src/main/java/com/bob/domain/trade/service/reader/TradeReader.java
+++ b/src/main/java/com/bob/domain/trade/service/reader/TradeReader.java
@@ -6,6 +6,7 @@ import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,10 @@ public class TradeReader {
 
   public List<Trade> readTradesByPostId(Long postId) {
     return tradeRepository.findAllByPostId(postId);
+  }
+
+  public List<Trade> readTradesByBuyerIdAndPostId(UUID memberId, List<Long> postIds) {
+    return tradeRepository.findAllByBuyerIdAndPostIdIn(memberId, postIds);
   }
 
   public Trade readTradeById(Long id) {

--- a/src/main/java/com/bob/domain/trade/usecase/TradeReadUseCase.java
+++ b/src/main/java/com/bob/domain/trade/usecase/TradeReadUseCase.java
@@ -1,10 +1,12 @@
 package com.bob.domain.trade.usecase;
 
+import com.bob.domain.trade.service.dto.query.ReadParticipateTradeStatusQuery;
 import com.bob.domain.trade.service.dto.query.ReadPostTradesQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
 import com.bob.domain.trade.service.dto.response.PostTradesResponse;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradeStatusMapResult;
 import com.bob.domain.trade.service.dto.response.TradesResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -15,4 +17,6 @@ public interface TradeReadUseCase {
   TradesResponse readTradesProcess(ReadTradesQuery query, Pageable pageable);
 
   TradeDetailResponse readTradeDetailProcess(ReadTradeDetailQuery query);
+
+  TradeStatusMapResult readTradeStatusProcess(ReadParticipateTradeStatusQuery query);
 }

--- a/src/main/java/com/bob/infra/config/registry/OptionalRegistry.java
+++ b/src/main/java/com/bob/infra/config/registry/OptionalRegistry.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class OptionalRegistry {
   private final List<RequestMatcher> optionalAuthMatchers = List.of(
       new AntPathRequestMatcher("/areas/**", HttpMethod.PATCH.name()),
+      new AntPathRequestMatcher("/posts", GET.name()),
       new AntPathRequestMatcher("/posts/{postId:\\d+}", GET.name())
   );
 

--- a/src/main/java/com/bob/infra/config/registry/PermitAllRegistry.java
+++ b/src/main/java/com/bob/infra/config/registry/PermitAllRegistry.java
@@ -20,7 +20,6 @@ public class PermitAllRegistry {
       new AntPathRequestMatcher("/members", POST.name()),
       new AntPathRequestMatcher("/ai/**", GET.name()),
       new AntPathRequestMatcher("/members/{memberId:\\d+}", GET.name()),
-      new AntPathRequestMatcher("/posts", GET.name()),
       new AntPathRequestMatcher("/members/temp/**", PATCH.name()),
       new AntPathRequestMatcher("/members/recover", PATCH.name())
   );

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -8,11 +8,14 @@ import static com.bob.web.post.request.RegisterPostFavoriteRequest.toCommand;
 
 import com.bob.domain.post.service.dto.response.PostCreateResponse;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
-import com.bob.domain.post.service.dto.response.PostsResponse;
+import com.bob.domain.post.service.dto.response.PostSummary;
+import com.bob.domain.post.service.dto.response.PostsResult;
 import com.bob.domain.post.usecase.PostDeleteUseCase;
 import com.bob.domain.post.usecase.PostModifyUseCase;
 import com.bob.domain.post.usecase.PostReadUseCase;
 import com.bob.domain.post.usecase.PostWriteUseCase;
+import com.bob.domain.trade.service.dto.query.ReadParticipateTradeStatusQuery;
+import com.bob.domain.trade.usecase.TradeReadUseCase;
 import com.bob.web.common.AuthenticationId;
 import com.bob.web.common.CommonResponse;
 import com.bob.web.common.symbol.ResponseSymbol;
@@ -21,7 +24,11 @@ import com.bob.web.post.request.CreatePostRequest;
 import com.bob.web.post.request.ReadFilteredPostsRequest;
 import com.bob.web.post.request.ReadPostFavoritesRequest;
 import com.bob.web.post.request.RemovePostRequest;
+import com.bob.web.post.response.PostsResponse;
 import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -47,6 +54,8 @@ public class PostController {
   private final PostModifyUseCase modifyUseCase;
   private final PostDeleteUseCase deleteUseCase;
 
+  private final TradeReadUseCase tradeReadUseCase;
+
   @PostMapping
   public ResponseEntity<PostCreateResponse> handleCreatePost(
       @Valid @RequestBody CreatePostRequest request,
@@ -69,13 +78,22 @@ public class PostController {
   @GetMapping
   public ResponseEntity<PostsResponse> handleReadFilteredPosts(
       ReadFilteredPostsRequest request,
-      Pageable pageable
+      Pageable pageable,
+      @AuthenticationId UUID memberId
   ) {
-    return ResponseEntity.ok(readUseCase.readFilteredPostsProcess(request.toQuery(), pageable));
+    PostsResult result = readUseCase.readFilteredPostsProcess(request.toQuery(memberId), pageable);
+    List<Long> ids = result.posts().stream().map(PostSummary::postId).toList();
+
+    Map<Long, String> statusMap = new HashMap<>();
+    if (memberId != null && !ids.isEmpty()) {
+      ReadParticipateTradeStatusQuery query = ReadParticipateTradeStatusQuery.of(memberId, ids);
+      statusMap.putAll(tradeReadUseCase.readTradeStatusProcess(query).statusMap());
+    }
+    return ResponseEntity.ok(PostsResponse.from(result, statusMap));
   }
 
   @GetMapping("/favorites")
-  public ResponseEntity<PostsResponse> handleReadMemberFavoritePosts(
+  public ResponseEntity<PostsResult> handleReadMemberFavoritePosts(
       @AuthenticationId UUID memberId,
       Pageable pageable
   ) {

--- a/src/main/java/com/bob/web/post/controller/PostController.java
+++ b/src/main/java/com/bob/web/post/controller/PostController.java
@@ -85,7 +85,7 @@ public class PostController {
     List<Long> ids = result.posts().stream().map(PostSummary::postId).toList();
 
     Map<Long, String> statusMap = new HashMap<>();
-    if (memberId != null && !ids.isEmpty()) {
+    if (memberId != null) {
       ReadParticipateTradeStatusQuery query = ReadParticipateTradeStatusQuery.of(memberId, ids);
       statusMap.putAll(tradeReadUseCase.readTradeStatusProcess(query).statusMap());
     }

--- a/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
+++ b/src/main/java/com/bob/web/post/request/ReadFilteredPostsRequest.java
@@ -20,8 +20,9 @@ public record ReadFilteredPostsRequest(
     String sort
 ) {
 
-  public ReadFilteredPostsQuery toQuery() {
+  public ReadFilteredPostsQuery toQuery(UUID authenticatorId) {
     return ReadFilteredPostsQuery.builder()
+        .authenticatorId(authenticatorId)
         .key(SearchKey.from(key).orElse(SearchKey.ALL))
         .keyword(keyword)
         .memberId(memberId)

--- a/src/main/java/com/bob/web/post/response/PostsResponse.java
+++ b/src/main/java/com/bob/web/post/response/PostsResponse.java
@@ -1,0 +1,50 @@
+package com.bob.web.post.response;
+
+import com.bob.domain.post.service.dto.response.PostSummary;
+import com.bob.domain.post.service.dto.response.PostsResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public record PostsResponse(
+    Long totalCount,
+    List<PostResponse> posts
+) {
+
+  public static PostsResponse from(PostsResult result, Map<Long, String> statusMap) {
+    List<PostResponse> list = result.posts().stream()
+        .map(p -> {
+          String resolved = "OWNER".equals(p.participation()) ? "OWNER" : statusMap.getOrDefault(p.postId(), "NONE");
+          return PostResponse.from(p, resolved);
+        }).toList();
+
+    return new PostsResponse(result.totalCount(), list);
+  }
+
+  public record PostResponse(
+      Long postId,
+      Integer categoryId,
+      String postTitle,
+      String postStatus,
+      String thumbnailUrl,
+      String bookStatus,
+      Integer sellPrice,
+      LocalDateTime createdAt,
+      String participation
+  ) {
+
+    public static PostResponse from(PostSummary summary, String participation) {
+      return new PostResponse(
+          summary.postId(),
+          summary.categoryId(),
+          summary.postTitle(),
+          summary.postStatus(),
+          summary.thumbnailUrl(),
+          summary.bookStatus(),
+          summary.sellPrice(),
+          summary.createdAt(),
+          participation
+      );
+    }
+  }
+}

--- a/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/post/service/PostServiceIntgTest.java
@@ -32,10 +32,10 @@ import static org.mockito.BDDMockito.then;
 import com.bob.domain.book.entity.Book;
 import com.bob.domain.book.repository.BookRepository;
 import com.bob.domain.post.entity.Category;
-import com.bob.domain.post.repository.CategoryRepository;
 import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.PostFavorite;
 import com.bob.domain.post.entity.status.TradeProgress;
+import com.bob.domain.post.repository.CategoryRepository;
 import com.bob.domain.post.repository.PostFavoriteRepository;
 import com.bob.domain.post.repository.PostRepository;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
@@ -48,12 +48,11 @@ import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
 import com.bob.domain.post.service.dto.response.PostSummary;
-import com.bob.domain.post.service.dto.response.PostsResponse;
+import com.bob.domain.post.service.dto.response.PostsResult;
 import com.bob.domain.post.service.port.out.PostAreaPort;
 import com.bob.domain.post.service.port.out.PostFilePort;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.support.TestContainerSupport;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.time.LocalDateTime;
@@ -173,7 +172,7 @@ class PostServiceIntgTest extends TestContainerSupport {
     ReadPostFavoritesQuery query = ReadPostFavoritesQuery.of(memberId);
 
     // when
-    PostsResponse response = postService.readPostFavoritesProcess(query, pageable);
+    PostsResult response = postService.readPostFavoritesProcess(query, pageable);
 
     // then
     assertThat(response.totalCount()).isEqualTo(2);
@@ -190,7 +189,7 @@ class PostServiceIntgTest extends TestContainerSupport {
     ReadPostFavoritesQuery query = ReadPostFavoritesQuery.of(memberId);
 
     // when
-    PostsResponse response = postService.readPostFavoritesProcess(query, pageable);
+    PostsResult response = postService.readPostFavoritesProcess(query, pageable);
 
     // then
     assertThat(response.totalCount()).isEqualTo(0);
@@ -273,7 +272,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("제목 검색 - '오브젝트' 포함 게시글 조회")
   void 제목으로_게시글을_검색할_수_있다() {
     ReadFilteredPostsQuery query = searchTitleQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::postTitle)
@@ -284,7 +283,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("저자 검색 - '김영한' 포함 게시글 조회")
   void 저자로_게시글을_검색할_수_있다() {
     ReadFilteredPostsQuery query = searchAuthorQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::postTitle)
@@ -295,7 +294,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("가격 필터 - 5000원 이하 게시글 조회")
   void 가격이_5000원이하인_게시글만_조회할_수_있다() {
     ReadFilteredPostsQuery query = searchUnder5000PriceQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::sellPrice)
@@ -306,7 +305,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("가격 필터 - 5000원 이상, 10000원 이하 게시글 조회")
   void 가격이_5000원이상_10000원이하인_게시글만_조회할_수_있다() {
     ReadFilteredPostsQuery query = searchBetween_5000_10000_PriceQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::sellPrice)
@@ -317,7 +316,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("카테고리 필터 - categoryId = 1")
   void 카테고리별_게시글을_조회할_수_있다() {
     ReadFilteredPostsQuery query = searchCategoryQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(query.categoryIds()).contains(1, 12, 13, 14, 15, 16); // 1의 자식 카테고리는 12, 13, 14, 15, 16
     assertThat(result.posts())
@@ -329,7 +328,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("거래 상태 필터 - 거래 완료")
   void 거래상태로_게시글을_조회할_수_있다() {
     ReadFilteredPostsQuery query = searchTradeStatusQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::postStatus)
@@ -351,7 +350,7 @@ class PostServiceIntgTest extends TestContainerSupport {
     pageable = PageRequest.of(0, Integer.MAX_VALUE); // 모든 게시글 개수 조회를 위한 page limit 수정
 
     // when
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     // then
     assertThat(removedPostsCount).isNotZero();
@@ -362,7 +361,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("책 상태 필터 - 최상")
   void 책상태로_게시글을_조회할_수_있다() {
     ReadFilteredPostsQuery query = searchBookStatusQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     assertThat(result.posts())
         .extracting(PostSummary::bookStatus)
@@ -373,7 +372,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("정렬 - 최신순 (createdAt DESC)")
   void 최신순으로_게시글을_정렬할_수_있다() {
     ReadFilteredPostsQuery query = searchNewestQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     List<LocalDateTime> createdAtList = result.posts().stream()
         .map(PostSummary::createdAt)
@@ -386,7 +385,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("정렬 - 오래된 순 (createdAt ASC)")
   void 오래된순으로_게시글을_정렬할_수_있다() {
     ReadFilteredPostsQuery query = searchOldestQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     List<LocalDateTime> createdAtList = result.posts().stream()
         .map(PostSummary::createdAt)
@@ -399,7 +398,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("정렬 - 낮은 가격순")
   void 가격이_낮은_순으로_게시글을_정렬할_수_있다() {
     ReadFilteredPostsQuery query = searchLowPriceQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     List<Integer> prices = result.posts().stream()
         .map(PostSummary::sellPrice)
@@ -412,7 +411,7 @@ class PostServiceIntgTest extends TestContainerSupport {
   @DisplayName("정렬 - 높은 가격순")
   void 가격이_높은_순으로_게시글을_정렬할_수_있다() {
     ReadFilteredPostsQuery query = searchHighPriceQuery();
-    PostsResponse result = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     List<Integer> prices = result.posts().stream()
         .map(PostSummary::sellPrice)

--- a/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/post/service/PostServiceTest.java
@@ -42,28 +42,28 @@ import static org.mockito.Mockito.times;
 
 import com.bob.domain.member.service.dto.command.RegisterMemberBookCommand;
 import com.bob.domain.post.entity.Category;
-import com.bob.domain.post.service.dto.query.condition.SearchKey;
-import com.bob.domain.post.service.port.out.PostBookPort;
-import com.bob.domain.post.service.reader.CategoryReader;
 import com.bob.domain.post.entity.Post;
 import com.bob.domain.post.entity.status.Status;
 import com.bob.domain.post.entity.status.TradeProgress;
 import com.bob.domain.post.repository.PostRepository;
+import com.bob.domain.post.service.dto.command.ChangeMemberPostStatusCommand;
 import com.bob.domain.post.service.dto.command.ChangePostCommand;
 import com.bob.domain.post.service.dto.command.ChangeTradeProgressCommand;
 import com.bob.domain.post.service.dto.command.CreatePostCommand;
 import com.bob.domain.post.service.dto.command.RegisterPostFavoriteCommand;
 import com.bob.domain.post.service.dto.command.RemovePostCommand;
-import com.bob.domain.post.service.dto.command.ChangeMemberPostStatusCommand;
 import com.bob.domain.post.service.dto.query.ReadFilteredPostsQuery;
 import com.bob.domain.post.service.dto.query.ReadPostDetailQuery;
 import com.bob.domain.post.service.dto.query.ReadPostFavoritesQuery;
+import com.bob.domain.post.service.dto.query.condition.SearchKey;
 import com.bob.domain.post.service.dto.response.PostCreateResponse;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
-import com.bob.domain.post.service.dto.response.PostsResponse;
+import com.bob.domain.post.service.dto.response.PostsResult;
 import com.bob.domain.post.service.port.out.PostAreaPort;
+import com.bob.domain.post.service.port.out.PostBookPort;
 import com.bob.domain.post.service.port.out.PostFilePort;
 import com.bob.domain.post.service.port.out.PostMemberPort;
+import com.bob.domain.post.service.reader.CategoryReader;
 import com.bob.domain.post.service.reader.PostReader;
 import com.bob.global.exception.exceptions.ApplicationException;
 import com.bob.global.exception.response.ApplicationError;
@@ -281,10 +281,10 @@ class PostServiceTest {
     given(postRepository.countFilteredPosts(query)).willReturn(2L);
 
     // when
-    PostsResponse response = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     // then
-    assertThat(response.totalCount()).isEqualTo(2L);
+    assertThat(result.totalCount()).isEqualTo(2L);
     then(postReader).should(times(1)).readFilteredPosts(query, pageable);
     then(postRepository).should(times(1)).countFilteredPosts(query);
   }
@@ -298,7 +298,7 @@ class PostServiceTest {
     given(postRepository.countFilteredPosts(query)).willReturn(2L);
 
     // when
-    PostsResponse response = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     // then
     then(categoryReader).should(times(1)).readChildCategoryIds(query.categoryIds().get(0));
@@ -306,7 +306,7 @@ class PostServiceTest {
 
     then(postReader).should(times(1)).readFilteredPosts(query, pageable);
     then(postRepository).should(times(1)).countFilteredPosts(query);
-    assertThat(response.totalCount()).isEqualTo(2L);
+    assertThat(result.totalCount()).isEqualTo(2L);
   }
 
   @Test
@@ -322,11 +322,11 @@ class PostServiceTest {
     given(postRepository.countFilteredPosts(query)).willReturn(2L);
 
     // when
-    PostsResponse res = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     // then
     assertThat(query.bookIds()).containsExactly(1L, 2L);
-    assertThat(res.totalCount()).isEqualTo(2L);
+    assertThat(result.totalCount()).isEqualTo(2L);
     then(bookPort).should(times(1)).searchBookIds(query.key().name(), query.keyword());
     then(postReader).should(times(1)).readFilteredPosts(query, pageable);
     then(postRepository).should(times(1)).countFilteredPosts(query);
@@ -340,10 +340,10 @@ class PostServiceTest {
     given(postRepository.countFilteredPosts(query)).willReturn(0L);
 
     // when
-    PostsResponse res = postService.readFilteredPostsProcess(query, pageable);
+    PostsResult result = postService.readFilteredPostsProcess(query, pageable);
 
     // then
-    assertThat(res.totalCount()).isEqualTo(0L);
+    assertThat(result.totalCount()).isEqualTo(0L);
     then(bookPort).should(times(1)).searchBookIds(query.key().name(), query.keyword());
 
     assertThat(query.bookIds()).isEmpty();
@@ -371,10 +371,10 @@ class PostServiceTest {
     given(postFavoriteService.readMemberFavoritePosts(memberId, pageable)).willReturn(DEFAULT_FAVORITE_RESPONSE());
 
     // when
-    PostsResponse response = postService.readPostFavoritesProcess(query, pageable);
+    PostsResult result = postService.readPostFavoritesProcess(query, pageable);
 
     // then
-    assertThat(response.totalCount()).isEqualTo(2L);
+    assertThat(result.totalCount()).isEqualTo(2L);
     then(postFavoriteService).should(times(1)).readMemberFavoritePosts(query.memberId(), pageable);
   }
 

--- a/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/trade/service/TradeServiceTest.java
@@ -43,6 +43,7 @@ import com.bob.domain.trade.service.dto.command.ChangeTradeItemsCommand;
 import com.bob.domain.trade.service.dto.command.ChangeTradeStatusCommand;
 import com.bob.domain.trade.service.dto.command.CreateTradeCommand;
 import com.bob.domain.trade.service.dto.command.CreateTradeItemsCommand;
+import com.bob.domain.trade.service.dto.query.ReadParticipateTradeStatusQuery;
 import com.bob.domain.trade.service.dto.query.ReadPostTradesQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradeDetailQuery;
 import com.bob.domain.trade.service.dto.query.ReadTradesQuery;
@@ -50,6 +51,7 @@ import com.bob.domain.trade.service.dto.query.SearchKey;
 import com.bob.domain.trade.service.dto.response.CreateTradeResponse;
 import com.bob.domain.trade.service.dto.response.PostTradesResponse;
 import com.bob.domain.trade.service.dto.response.TradeDetailResponse;
+import com.bob.domain.trade.service.dto.response.TradeStatusMapResult;
 import com.bob.domain.trade.service.dto.response.TradesResponse;
 import com.bob.domain.trade.service.port.out.TradeMemberPort;
 import com.bob.domain.trade.service.port.out.TradePostPort;
@@ -290,6 +292,28 @@ class TradeServiceTest {
     then(tradeItemService).shouldHaveNoInteractions();
     then(memberPort).shouldHaveNoInteractions();
     then(postPort).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void 거래_상태_조회() {
+    // given
+    UUID memberId = MEMBER_ID;
+    List<Long> postIds = List.of(10L, 20L);
+    List<Trade> trades = List.of(REQUESTED_TRADE(1L, 10L), RESERVED_TRADE(2L, 20L));
+    given(tradeReader.readTradesByBuyerIdAndPostId(memberId, postIds)).willReturn(trades);
+
+    ReadParticipateTradeStatusQuery query = ReadParticipateTradeStatusQuery.of(memberId, postIds);
+
+    // when
+    TradeStatusMapResult result = tradeService.readTradeStatusProcess(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.statusMap()).hasSize(2)
+        .containsEntry(10L, "REQUESTED")
+        .containsEntry(20L, "RESERVED");
+
+    then(tradeReader).should().readTradesByBuyerIdAndPostId(memberId, postIds);
   }
 
   @Test

--- a/src/test/unit/java/com/bob/support/auth/WithAuthMember.java
+++ b/src/test/unit/java/com/bob/support/auth/WithAuthMember.java
@@ -1,0 +1,18 @@
+package com.bob.support.auth;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+
+import com.bob.support.auth.extension.WithAuthMemberExtension;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({TYPE, METHOD})
+@ExtendWith(WithAuthMemberExtension.class)
+public @interface WithAuthMember {
+
+  String id() default "00000000-0000-0000-0000-000000000000";
+}

--- a/src/test/unit/java/com/bob/support/auth/extension/WithAuthMemberExtension.java
+++ b/src/test/unit/java/com/bob/support/auth/extension/WithAuthMemberExtension.java
@@ -1,0 +1,44 @@
+package com.bob.support.auth.extension;
+
+import com.bob.infra.auth.response.MemberDetails;
+import com.bob.support.auth.WithAuthMember;
+import java.util.UUID;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class WithAuthMemberExtension implements BeforeEachCallback, AfterEachCallback {
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    WithAuthMember annotation = find(context);
+    if (annotation == null) {
+      return;
+    }
+
+    UUID id = UUID.fromString(annotation.id());
+    MemberDetails principal = new MemberDetails(id, true);
+    Authentication auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+    SecurityContext ctx = SecurityContextHolder.createEmptyContext();
+    ctx.setAuthentication(auth);
+    SecurityContextHolder.setContext(ctx);
+  }
+
+  private WithAuthMember find(ExtensionContext ctx) {
+    return ctx.getElement()
+        .map(el -> el.getAnnotation(WithAuthMember.class))
+        .or(() -> ctx.getTestClass().map(c -> c.getAnnotation(WithAuthMember.class)))
+        .orElse(null);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    SecurityContextHolder.clearContext();
+  }
+
+}

--- a/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
+++ b/src/test/unit/java/com/bob/web/post/controller/PostControllerTest.java
@@ -13,9 +13,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.bob.domain.post.service.PostService;
 import com.bob.domain.post.service.dto.response.PostDetailResponse;
-import com.bob.domain.post.service.dto.response.PostsResponse;
+import com.bob.domain.post.service.dto.response.PostsResult;
+import com.bob.domain.post.usecase.PostDeleteUseCase;
+import com.bob.domain.post.usecase.PostModifyUseCase;
+import com.bob.domain.post.usecase.PostReadUseCase;
+import com.bob.domain.post.usecase.PostWriteUseCase;
+import com.bob.domain.trade.service.dto.response.TradeStatusMapResult;
+import com.bob.domain.trade.usecase.TradeReadUseCase;
+import com.bob.support.auth.WithAuthMember;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -37,20 +45,34 @@ class PostControllerTest {
   private PostController postController;
 
   @Mock
-  private PostService postService;
+  private PostWriteUseCase writeUseCase;
+
+  @Mock
+  private PostReadUseCase readUseCase;
+
+  @Mock
+  private PostModifyUseCase modifyUseCase;
+
+  @Mock
+  private PostDeleteUseCase deleteUseCase;
+
+  @Mock
+  private TradeReadUseCase tradeReadUseCase;
 
   private MockMvc mvc;
 
   @BeforeEach
   void setUp() {
     mvc = MockMvcBuilders.standaloneSetup(postController)
-        .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+        .setCustomArgumentResolvers(
+            new PageableHandlerMethodArgumentResolver(),
+            new AuthenticationPrincipalArgumentResolver()
+        )
         .build();
   }
 
   @Test
-  @DisplayName("게시글 생성 API 호출 테스트")
-  void 게시글_생성_API를_호출할_수_있다() throws Exception {
+  void 게시글_생성_API_호출() throws Exception {
     // given
     String json = """
         {
@@ -77,12 +99,11 @@ class PostControllerTest {
             .requestAttr("memberId", UUID.randomUUID()))
         .andExpect(status().isCreated());
 
-    verify(postService, times(1)).createPostProcess(any());
+    verify(writeUseCase, times(1)).createPostProcess(any());
   }
 
   @Test
-  @DisplayName("게시글 좋아요 API 호출 테스트")
-  void 게시글_좋아요_API를_호출할_수_있다() throws Exception {
+  void 게시글_좋아요_등록_API_호출() throws Exception {
     Long postId = 1L;
     UUID memberId = UUID.randomUUID();
 
@@ -93,12 +114,11 @@ class PostControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.result").value("CREATED"));
 
-    verify(postService, times(1)).registerPostFavoriteProcess(any());
+    verify(writeUseCase, times(1)).registerPostFavoriteProcess(any());
   }
 
   @Test
-  @DisplayName("게시글 좋아요 해제 API 호출 테스트")
-  void 게시글_좋아요_해제_API를_호출할_수_있다() throws Exception {
+  void 게시글_좋아요_해제_API_호출() throws Exception {
     // given
     Long postId = 1L;
     UUID memberId = UUID.randomUUID();
@@ -110,23 +130,22 @@ class PostControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.result").value("DELETED"));
 
-    verify(postService, times(1)).unregisterPostFavoriteProcess(any());
+    verify(deleteUseCase, times(1)).unregisterPostFavoriteProcess(any());
   }
 
   @Test
-  @DisplayName("게시글 목록 필터 조회 API 호출 테스트")
-  void 게시글_목록_필터_조회_API를_호출할_수_있다() throws Exception {
+  void 게시글_목록_조회_API_호출() throws Exception {
     // given
-    PostsResponse response = new PostsResponse(2L, DEFAULT_POST_SUMMARY());
-    given(postService.readFilteredPostsProcess(any(), any())).willReturn(response);
+    PostsResult result = new PostsResult(2L, DEFAULT_POST_SUMMARY());
+    given(readUseCase.readFilteredPostsProcess(any(), any())).willReturn(result);
 
     // when & then
     mvc.perform(get("/posts")
             .param("key", "TITLE")
-            .param("keyword", "객체지향")
-            .param("emdId", "11010")
-            .param("categoryId", "1")
-            .param("price", "0")
+            .param("keyword", "")
+            .param("emdId", "")
+            .param("categoryId", "")
+            .param("price", "")
             .param("postStatus", "READY")
             .param("bookStatus", "BEST")
             .param("sort", "RECENT")
@@ -138,17 +157,46 @@ class PostControllerTest {
         .andExpect(jsonPath("$.posts[0].postTitle").value("객체지향의 사실과 오해"))
         .andExpect(jsonPath("$.posts[1].postTitle").value("오브젝트"));
 
-    verify(postService, times(1)).readFilteredPostsProcess(any(), any());
+    verify(readUseCase, times(1)).readFilteredPostsProcess(any(), any());
   }
 
   @Test
-  @DisplayName("게시글 상세 조회 API 호출 테스트")
-  void 게시글_상세_조회_API를_호출할_수_있다() throws Exception {
+  @WithAuthMember
+  void 게시글_목록_조회_API_호출_시_로그인_상태면_거래_상태_매핑() throws Exception {
+    // given
+    PostsResult result = new PostsResult(2L, DEFAULT_POST_SUMMARY());
+    TradeStatusMapResult tradeStatusResult = TradeStatusMapResult.of(Map.of());
+    given(readUseCase.readFilteredPostsProcess(any(), any())).willReturn(result);
+    given(tradeReadUseCase.readTradeStatusProcess(any())).willReturn(tradeStatusResult);
+
+    // when & then
+    mvc.perform(get("/posts")
+            .param("key", "TITLE")
+            .param("keyword", "")
+            .param("emdId", "")
+            .param("categoryId", "")
+            .param("price", "")
+            .param("postStatus", "READY")
+            .param("bookStatus", "BEST")
+            .param("sort", "RECENT")
+            .param("page", "0")
+            .param("size", "12"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalCount").value(2))
+        .andExpect(jsonPath("$.posts[0].postTitle").value("객체지향의 사실과 오해"))
+        .andExpect(jsonPath("$.posts[1].postTitle").value("오브젝트"));
+
+    verify(readUseCase, times(1)).readFilteredPostsProcess(any(), any());
+    verify(tradeReadUseCase, times(1)).readTradeStatusProcess(any());
+  }
+
+  @Test
+  void 게시글_상세_조회_API_호출() throws Exception {
     // given
     Long postId = 1L;
     UUID memberId = UUID.randomUUID();
     PostDetailResponse response = DEFAULT_POST_DETAIL_RESPONSE(postId);
-    given(postService.readPostDetailProcess(any())).willReturn(response);
+    given(readUseCase.readPostDetailProcess(any())).willReturn(response);
 
     // when & then
     mvc.perform(get("/posts/{postId}", postId)
@@ -169,12 +217,11 @@ class PostControllerTest {
         .andExpect(jsonPath("$.isOwner").value(false))
         .andExpect(jsonPath("$.createdAt[0]").value(2024));
 
-    verify(postService, times(1)).readPostDetailProcess(any());
+    verify(readUseCase, times(1)).readPostDetailProcess(any());
   }
 
   @Test
-  @DisplayName("게시글 수정 API 호출 테스트")
-  void 게시글_수정_API를_호출할_수_있다() throws Exception {
+  void 게시글_수정_API_호출() throws Exception {
     // given
     Long postId = 1L;
     UUID memberId = UUID.randomUUID();
@@ -197,12 +244,11 @@ class PostControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.result").value("OK"));
 
-    verify(postService, times(1)).changePostProcess(any());
+    verify(modifyUseCase, times(1)).changePostProcess(any());
   }
 
   @Test
-  @DisplayName("게시글 삭제 API 호출 테스트")
-  void 게시글_삭제_API를_호출할_수_있다() throws Exception {
+  void 게시글_삭제_API_호출() throws Exception {
     // given
     Long postId = 1L;
     UUID memberId = UUID.randomUUID();
@@ -214,6 +260,6 @@ class PostControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.result").value("DELETED"));
 
-    verify(postService, times(1)).removePostProcess(any());
+    verify(deleteUseCase, times(1)).removePostProcess(any());
   }
 }


### PR DESCRIPTION
this closes #118 

### 작업 내용
- [x] 게시글 목록 조회 시 사용자 거래 진행 여부 매핑
- [x] 게시글 목록 조회 시 domain, web response 분리

---

### 참고
> 추가적으로 해야 할 작업

리팩토링 시 모든 domain, web response 분리