### PR TITLE
feat: 회원 책장 조회 기능 확장

### DIFF
--- a/src/main/java/com/bob/domain/member/repository/MemberBookRepository.java
+++ b/src/main/java/com/bob/domain/member/repository/MemberBookRepository.java
@@ -9,14 +9,30 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface MemberBookRepository extends CrudRepository<MemberBook, Long> {
 
+  List<MemberBook> findAllByIdIn(List<Long> ids);
+
   @Query("""
       SELECT mb FROM MemberBook mb
-      WHERE mb.memberId = :memberId
-        AND mb.isRemove = false
+       WHERE mb.memberId = :memberId
+         AND mb.isRemove = false
       """)
   List<MemberBook> findByMemberId(UUID memberId);
 
-  List<MemberBook> findAllByIdIn(List<Long> ids);
+  @Query("""
+      SELECT mb FROM MemberBook mb
+       WHERE mb.memberId = :memberId
+         AND mb.isRemove = false
+         AND (mb.usageId IS NULL OR mb.id IN :requires)
+      """)
+  List<MemberBook> findAvailableByMemberId(UUID memberId, List<Long> requires);
+
+  @Query("""
+      SELECT mb FROM MemberBook mb
+       WHERE mb.memberId = :memberId
+         AND mb.isRemove = false
+         AND (mb.usageId IS NOT NULL OR mb.id IN :requires)
+      """)
+  List<MemberBook> findUnavailableByMemberId(UUID memberId, List<Long> requires);
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("""

--- a/src/main/java/com/bob/domain/member/service/MemberBookService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberBookService.java
@@ -54,22 +54,23 @@ public class MemberBookService implements MemberBookWriteUseCase, MemberBookRead
 
   @Transactional(readOnly = true)
   public MemberBooksResponse readMemberBooksProcess(ReadMemberBooksQuery query) {
-    List<MemberBook> memberBooks = memberBookReader.readMemberBooksByMemberId(query.memberId());
-    List<MemberBookSummary> summaries = getMemberBookSummaries(memberBooks);
-    return MemberBooksResponse.of(summaries);
+    List<MemberBook> memberBooks = switch (query.key()) {
+      case ALL -> memberBookReader.readMemberBooksByMemberId(query.memberId());
+      case AVAILABLE -> memberBookReader.readAvailableMemberBooksByMemberId(query.memberId(), query.requires());
+      case UNAVAILABLE -> memberBookReader.readUnavailableMemberBooksByMemberId(query.memberId(), query.requires());
+    };
+    return MemberBooksResponse.of(getMemberBookSummaries(memberBooks));
   }
 
   @Transactional(readOnly = true)
   public MemberBooksResponse readMemberBooksByIdsProcess(ReadMemberBooksByIdQuery query) {
     List<MemberBook> memberBooks = memberBookReader.readMemberBooksByBookIds(query.ids());
-    List<MemberBookSummary> summaries = getMemberBookSummaries(memberBooks);
-    return MemberBooksResponse.of(summaries);
+    return MemberBooksResponse.of(getMemberBookSummaries(memberBooks));
   }
 
   private List<MemberBookSummary> getMemberBookSummaries(List<MemberBook> memberBooks) {
     List<Long> bookIds = memberBooks.stream().map(MemberBook::getBookId).toList();
-    List<MemberBookSummary> summaries = MemberBookSummary.listFrom(memberBooks, bookPort.readBookSummaries(bookIds));
-    return summaries;
+    return MemberBookSummary.listFrom(memberBooks, bookPort.readBookSummaries(bookIds));
   }
 
   // TODO : 할당, 해제 분리

--- a/src/main/java/com/bob/domain/member/service/MemberService.java
+++ b/src/main/java/com/bob/domain/member/service/MemberService.java
@@ -27,7 +27,6 @@ import com.bob.domain.member.service.dto.response.MemberAreaSummaryResponse;
 import com.bob.domain.member.service.dto.response.MemberBooksResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
 import com.bob.domain.member.service.dto.response.SocialLoginResponse;
-import com.bob.domain.member.service.dto.response.internal.MemberBookSummary;
 import com.bob.domain.member.service.port.out.MemberAreaPort;
 import com.bob.domain.member.service.port.out.MemberMailPort;
 import com.bob.domain.member.service.port.out.MemberRedisPort;
@@ -111,11 +110,7 @@ public class MemberService implements MemberWriteUseCase, MemberReadUseCase, Mem
     List<String> interests = memberInterestService.readMemberInterests(member.getId());
     MemberAreaSummaryResponse area = areaPort.readMemberAreaSummary(query.memberId());
     MemberBooksResponse books = memberBookService.readMemberBooksProcess(ReadMemberBooksQuery.of(member.getId()));
-    return MemberProfileResponse.from(member, interests, area, allocateMemberBooks(books, query.isMe()));
-  }
-
-  private List<MemberBookSummary> allocateMemberBooks(MemberBooksResponse response, boolean isMe) {
-    return isMe ? response.books() : null;
+    return MemberProfileResponse.from(member, interests, area, books.bookcase());
   }
 
   @Transactional

--- a/src/main/java/com/bob/domain/member/service/dto/query/ReadMemberBooksQuery.java
+++ b/src/main/java/com/bob/domain/member/service/dto/query/ReadMemberBooksQuery.java
@@ -1,12 +1,19 @@
 package com.bob.domain.member.service.dto.query;
 
+import java.util.List;
 import java.util.UUID;
 
 public record ReadMemberBooksQuery(
-    UUID memberId
+    UUID memberId,
+    SearchKey key,
+    List<Long> requires
 ) {
 
   public static ReadMemberBooksQuery of(UUID memberId) {
-    return new ReadMemberBooksQuery(memberId);
+    return new ReadMemberBooksQuery(memberId, SearchKey.ALL, List.of());
+  }
+
+  public static ReadMemberBooksQuery of(UUID memberId, String key, List<Long> requires) {
+    return new ReadMemberBooksQuery(memberId, SearchKey.of(key), requires);
   }
 }

--- a/src/main/java/com/bob/domain/member/service/dto/query/SearchKey.java
+++ b/src/main/java/com/bob/domain/member/service/dto/query/SearchKey.java
@@ -1,0 +1,12 @@
+package com.bob.domain.member.service.dto.query;
+
+public enum SearchKey {
+  ALL, AVAILABLE, UNAVAILABLE;
+
+  public static SearchKey of(String key) {
+    if (key == null || key.isBlank())
+      return ALL;
+
+    return valueOf(key.trim().toUpperCase());
+  }
+}

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberBooksResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberBooksResponse.java
@@ -4,7 +4,7 @@ import com.bob.domain.member.service.dto.response.internal.MemberBookSummary;
 import java.util.List;
 
 public record MemberBooksResponse(
-    List<MemberBookSummary> books
+    List<MemberBookSummary> bookcase
 ) {
 
   public static MemberBooksResponse of(List<MemberBookSummary> books) {

--- a/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/MemberProfileResponse.java
@@ -32,6 +32,7 @@ public record MemberProfileResponse(
     final String email = removed ? "delete" : member.getEmail();
     final String profileImageUrl = removed ? null : member.getProfileImageUrl();
     final List<String> interests = removed ? List.of() : interestNames;
+    final List<MemberBookSummary> summaries = removed ? List.of() : bookcase;
 
     return MemberProfileResponse.builder()
         .isSocial(member.getProvider() != null)
@@ -41,7 +42,7 @@ public record MemberProfileResponse(
         .profileImageUrl(profileImageUrl)
         .interests(interests)
         .area(Area.of(areaSummary.emdId(), areaSummary.validity(), areaSummary.authenticatedAt()))
-        .bookcase(bookcase)
+        .bookcase(summaries)
         .build();
   }
 

--- a/src/main/java/com/bob/domain/member/service/dto/response/internal/MemberBookSummary.java
+++ b/src/main/java/com/bob/domain/member/service/dto/response/internal/MemberBookSummary.java
@@ -18,7 +18,8 @@ public record MemberBookSummary(
     String author,
     Integer priceStandard,
     String cover,
-    LocalDate pubDate
+    LocalDate pubDate,
+    boolean available
 ) {
 
   public static List<MemberBookSummary> listFrom(List<MemberBook> memberBooks, List<BookResponse> books) {
@@ -43,6 +44,7 @@ public record MemberBookSummary(
         .priceStandard(book.priceStandard())
         .cover(book.cover())
         .pubDate(book.pubDate())
+        .available(!memberBook.isRemove() && memberBook.getUsageId() == null)
         .build();
   }
 }

--- a/src/main/java/com/bob/domain/member/service/reader/MemberBookReader.java
+++ b/src/main/java/com/bob/domain/member/service/reader/MemberBookReader.java
@@ -21,6 +21,14 @@ public class MemberBookReader {
     return repository.findByMemberId(memberId);
   }
 
+  public List<MemberBook> readAvailableMemberBooksByMemberId(UUID memberId, List<Long> requires) {
+    return repository.findAvailableByMemberId(memberId, requires);
+  }
+
+  public List<MemberBook> readUnavailableMemberBooksByMemberId(UUID memberId, List<Long> requires) {
+    return repository.findUnavailableByMemberId(memberId, requires);
+  }
+
   public List<MemberBook> readMemberBooksByBookIds(List<Long> bookIds) {
     return repository.findAllByIdIn(bookIds);
   }

--- a/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeItemSummary.java
+++ b/src/main/java/com/bob/domain/trade/service/dto/response/internal/TradeItemSummary.java
@@ -14,20 +14,9 @@ public record TradeItemSummary(
     String author,
     Integer priceStandard,
     String cover,
-    LocalDate pubDate
+    LocalDate pubDate,
+    boolean available
 ) {
-
-  public static TradeItemSummary from(TradeItemView tradeItem) {
-    return TradeItemSummary.builder()
-        .id(tradeItem.id())
-        .status(tradeItem.status())
-        .title(tradeItem.title())
-        .author(tradeItem.author())
-        .priceStandard(tradeItem.priceStandard())
-        .cover(tradeItem.cover())
-        .pubDate(tradeItem.pubDate())
-        .build();
-  }
 
   public static List<TradeItemSummary> listFrom(List<TradeItemView> tradeItems, List<Long> itemIds) {
     return tradeItems.stream()
@@ -39,5 +28,18 @@ public record TradeItemSummary(
 
   public static List<TradeItemSummary> listFrom(List<TradeItemView> tradeItems) {
     return listFrom(tradeItems, null);
+  }
+
+  public static TradeItemSummary from(TradeItemView tradeItem) {
+    return TradeItemSummary.builder()
+        .id(tradeItem.id())
+        .status(tradeItem.status())
+        .title(tradeItem.title())
+        .author(tradeItem.author())
+        .priceStandard(tradeItem.priceStandard())
+        .cover(tradeItem.cover())
+        .pubDate(tradeItem.pubDate())
+        .available(tradeItem.available())
+        .build();
   }
 }

--- a/src/main/java/com/bob/domain/trade/service/port/view/TradeItemView.java
+++ b/src/main/java/com/bob/domain/trade/service/port/view/TradeItemView.java
@@ -11,10 +11,20 @@ public record TradeItemView(
     String author,
     Integer priceStandard,
     String cover,
-    LocalDate pubDate
+    LocalDate pubDate,
+    boolean available
 ) {
 
-  public static TradeItemView of(Long itemId, String status, String title, String author, Integer priceStandard, String cover, LocalDate pubDate) {
+  public static TradeItemView of(
+      Long itemId,
+      String status,
+      String title,
+      String author,
+      Integer priceStandard,
+      String cover,
+      LocalDate pubDate,
+      boolean available
+  ) {
     return TradeItemView.builder()
         .id(itemId)
         .status(status)
@@ -23,6 +33,7 @@ public record TradeItemView(
         .priceStandard(priceStandard)
         .cover(cover)
         .pubDate(pubDate)
+        .available(available)
         .build();
   }
 }

--- a/src/main/java/com/bob/web/member/adapter/in/TradeMemberAdapter.java
+++ b/src/main/java/com/bob/web/member/adapter/in/TradeMemberAdapter.java
@@ -32,10 +32,10 @@ public class TradeMemberAdapter implements TradeMemberPort {
   @Override
   public List<TradeItemView> readTradeItemSummary(List<Long> ids) {
     MemberBooksResponse response = bookReadUseCase.readMemberBooksByIdsProcess(ReadMemberBooksByIdQuery.of(ids));
-    return response.books().stream()
+    return response.bookcase().stream()
         .map(b -> TradeItemView.of(
             b.id(), b.status(), b.title(), b.author(),
-            b.priceStandard(), b.cover(), b.pubDate()
+            b.priceStandard(), b.cover(), b.pubDate(), b.available()
         ))
         .toList();
   }

--- a/src/main/java/com/bob/web/member/controller/MemberBookController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberBookController.java
@@ -1,0 +1,69 @@
+package com.bob.web.member.controller;
+
+import static com.bob.web.common.symbol.ResponseSymbol.CREATED;
+import static com.bob.web.common.symbol.ResponseSymbol.DELETED;
+
+import com.bob.domain.member.service.dto.command.RemoveMemberBookCommand;
+import com.bob.domain.member.service.dto.query.ReadMemberBooksQuery;
+import com.bob.domain.member.service.dto.response.MemberBooksResponse;
+import com.bob.domain.member.usecase.MemberBookReadUseCase;
+import com.bob.domain.member.usecase.MemberBookRemoveUseCase;
+import com.bob.domain.member.usecase.MemberBookWriteUseCase;
+import com.bob.web.common.AuthenticationId;
+import com.bob.web.common.CommonResponse;
+import com.bob.web.common.symbol.ResponseSymbol;
+import com.bob.web.member.request.ReadMemberBooksRequest;
+import com.bob.web.member.request.RegisterMemberBookRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/members")
+@RestController
+public class MemberBookController {
+
+  private final MemberBookWriteUseCase writeUseCase;
+  private final MemberBookReadUseCase readUseCase;
+  private final MemberBookRemoveUseCase removeUseCase;
+
+  @PostMapping("/books")
+  @ResponseStatus(HttpStatus.CREATED)
+  public CommonResponse<ResponseSymbol> handleCreateMemberBook(
+      @AuthenticationId UUID memberId,
+      @Valid @RequestBody RegisterMemberBookRequest request
+  ) {
+    writeUseCase.registerMemberBookProcess(request.toCommand(memberId));
+    return new CommonResponse<>(true, CREATED);
+  }
+
+  @GetMapping("/{memberId}/books")
+  public ResponseEntity<MemberBooksResponse> handleReadBooks(
+      ReadMemberBooksRequest request,
+      @PathVariable UUID memberId
+  ) {
+    List<Long> requires = request.require() == null ? List.of() : request.require();
+    ReadMemberBooksQuery query = ReadMemberBooksQuery.of(memberId, request.key(), requires);
+    return ResponseEntity.ok(readUseCase.readMemberBooksProcess(query));
+  }
+
+  @DeleteMapping("/books/{memberBookId}")
+  public CommonResponse<ResponseSymbol> handleRemoveMemberBook(
+      @AuthenticationId UUID memberId,
+      @PathVariable Long memberBookId
+  ) {
+    removeUseCase.removeMemberBookProcess(RemoveMemberBookCommand.of(memberId, memberBookId));
+    return new CommonResponse<>(true, DELETED);
+  }
+}

--- a/src/main/java/com/bob/web/member/controller/MemberBookController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberBookController.java
@@ -53,7 +53,7 @@ public class MemberBookController {
       ReadMemberBooksRequest request,
       @PathVariable UUID memberId
   ) {
-    List<Long> requires = request.require() == null ? List.of() : request.require();
+    List<Long> requires = request.require() == null ? List.of(-1L) : request.require();
     ReadMemberBooksQuery query = ReadMemberBooksQuery.of(memberId, request.key(), requires);
     return ResponseEntity.ok(readUseCase.readMemberBooksProcess(query));
   }

--- a/src/main/java/com/bob/web/member/controller/MemberController.java
+++ b/src/main/java/com/bob/web/member/controller/MemberController.java
@@ -6,14 +6,8 @@ import static com.bob.web.common.symbol.ResponseSymbol.SENT;
 import static com.bob.web.common.symbol.ResponseSymbol.UPDATED;
 import static com.bob.web.member.request.ReadProfileRequest.toQuery;
 
-import com.bob.domain.member.service.dto.command.RemoveMemberBookCommand;
 import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
-import com.bob.domain.member.service.dto.query.ReadMemberBooksQuery;
-import com.bob.domain.member.service.dto.response.MemberBooksResponse;
 import com.bob.domain.member.service.dto.response.MemberProfileResponse;
-import com.bob.domain.member.usecase.MemberBookReadUseCase;
-import com.bob.domain.member.usecase.MemberBookRemoveUseCase;
-import com.bob.domain.member.usecase.MemberBookWriteUseCase;
 import com.bob.domain.member.usecase.MemberModifyUseCase;
 import com.bob.domain.member.usecase.MemberReadUseCase;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
@@ -25,7 +19,6 @@ import com.bob.web.member.request.ChangePasswordRequest;
 import com.bob.web.member.request.ChangeProfileRequest;
 import com.bob.web.member.request.IssuePasswordRequest;
 import com.bob.web.member.request.RecoverAccountRequest;
-import com.bob.web.member.request.RegisterMemberBookRequest;
 import com.bob.web.member.request.SignupRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -52,10 +45,6 @@ public class MemberController {
   private final MemberReadUseCase readUseCase;
   private final MemberModifyUseCase modifyUseCase;
 
-  private final MemberBookWriteUseCase bookWriteUseCase;
-  private final MemberBookReadUseCase bookReadUseCase;
-  private final MemberBookRemoveUseCase removeUseCase;
-
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
   public CommonResponse<ResponseSymbol> handleSignup(@Valid @RequestBody SignupRequest request) {
@@ -63,24 +52,9 @@ public class MemberController {
     return new CommonResponse<>(true, CREATED);
   }
 
-  @PostMapping("/books")
-  @ResponseStatus(HttpStatus.CREATED)
-  public CommonResponse<ResponseSymbol> handleCreateMemberBook(
-      @AuthenticationId UUID memberId,
-      @Valid @RequestBody RegisterMemberBookRequest request
-  ) {
-    bookWriteUseCase.registerMemberBookProcess(request.toCommand(memberId));
-    return new CommonResponse<>(true, CREATED);
-  }
-
   @GetMapping("/me")
   public ResponseEntity<MemberProfileResponse> handleReadProfile(@AuthenticationId UUID memberId) {
     return ResponseEntity.ok(readUseCase.readProfileProcess(toQuery(memberId, true)));
-  }
-
-  @GetMapping("/me/books")
-  public ResponseEntity<MemberBooksResponse> handleReadBooks(@AuthenticationId UUID memberId) {
-    return ResponseEntity.ok(bookReadUseCase.readMemberBooksProcess(ReadMemberBooksQuery.of(memberId)));
   }
 
   @GetMapping("/{memberId}")
@@ -136,15 +110,6 @@ public class MemberController {
   ) {
     RemoveMemberCommand command = new RemoveMemberCommand(memberId);
     modifyUseCase.softRemoveMemberProcess(command, response);
-    return new CommonResponse<>(true, DELETED);
-  }
-
-  @DeleteMapping("/books/{memberBookId}")
-  public CommonResponse<ResponseSymbol> handleRemoveMemberBook(
-      @AuthenticationId UUID memberId,
-      @PathVariable Long memberBookId
-  ) {
-    removeUseCase.removeMemberBookProcess(RemoveMemberBookCommand.of(memberId, memberBookId));
     return new CommonResponse<>(true, DELETED);
   }
 }

--- a/src/main/java/com/bob/web/member/request/ReadMemberBooksRequest.java
+++ b/src/main/java/com/bob/web/member/request/ReadMemberBooksRequest.java
@@ -1,0 +1,10 @@
+package com.bob.web.member.request;
+
+import java.util.List;
+
+public record ReadMemberBooksRequest(
+    String key,
+    List<Long> require
+) {
+
+}

--- a/src/test/intg/java/com/bob/domain/member/service/MemberBookServiceIntgTest.java
+++ b/src/test/intg/java/com/bob/domain/member/service/MemberBookServiceIntgTest.java
@@ -13,6 +13,7 @@ import com.bob.domain.member.service.dto.command.RegisterMemberBookCommand;
 import com.bob.domain.member.service.dto.command.RemoveMemberBookCommand;
 import com.bob.domain.member.service.dto.query.ReadMemberBooksByIdQuery;
 import com.bob.domain.member.service.dto.query.ReadMemberBooksQuery;
+import com.bob.domain.member.service.dto.query.SearchKey;
 import com.bob.domain.member.service.dto.response.MemberBooksResponse;
 import com.bob.domain.member.service.dto.response.internal.MemberBookSummary;
 import com.bob.support.TestContainerSupport;
@@ -112,7 +113,7 @@ class MemberBookServiceIntgTest extends TestContainerSupport {
   }
 
   @Test
-  void 회원_소유_책_목록_정상_조회() {
+  void 회원_책장_모든_책_목록_조회() {
     // given
     UUID memberId = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca3");
     MemberBook mb1 = memberBookRepository.save(MemberBook.of(memberId, 1L, "BEST"));
@@ -122,18 +123,80 @@ class MemberBookServiceIntgTest extends TestContainerSupport {
     MemberBooksResponse response = service.readMemberBooksProcess(ReadMemberBooksQuery.of(memberId));
 
     // then
-    List<MemberBookSummary> summaries = response.books();
-    assertThat(summaries).hasSize(2);
+    List<MemberBookSummary> bookcase = response.bookcase();
+    assertThat(bookcase).hasSize(2);
 
-    MemberBookSummary s1 = summaries.get(0);
+    MemberBookSummary s1 = bookcase.get(0);
     assertThat(s1.id()).isEqualTo(mb1.getId());
     assertThat(s1.status()).isEqualTo(BookStatus.BEST.name());
     assertThat(s1.title()).isEqualTo("자바의 정석");
 
-    MemberBookSummary s2 = summaries.get(1);
+    MemberBookSummary s2 = bookcase.get(1);
     assertThat(s2.id()).isEqualTo(mb2.getId());
     assertThat(s2.status()).isEqualTo(BookStatus.HIGH.name());
     assertThat(s2.title()).isEqualTo("자바 ORM 표준 JPA 프로그래밍");
+  }
+
+  @Test
+  void 회원_책장_사용_가능_책_목록_조회() {
+    // given
+    UUID memberId = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca3");
+    memberBookRepository.save(MemberBook.of(memberId, 1L, "BEST"));
+    memberBookRepository.save(MemberBook.of(memberId, 2L, "HIGH"));
+    MemberBook unavailableBook = memberBookRepository.save(MemberBook.of(memberId, 2L, "HIGH"));
+    unavailableBook.updateUsageId(1L);
+    ReadMemberBooksQuery query = ReadMemberBooksQuery.of(memberId, SearchKey.AVAILABLE.name(), List.of(-1L));
+
+    // when
+    MemberBooksResponse result = service.readMemberBooksProcess(query);
+
+    // then
+    List<MemberBookSummary> bookcase = result.bookcase();
+    assertThat(bookcase).hasSize(2);
+    assertThat(bookcase.get(0).available()).isTrue();
+    assertThat(bookcase.get(1).available()).isTrue();
+  }
+
+  @Test
+  void 회원_책장_사용_불가능_책_목록_조회() {
+    // given
+    UUID memberId = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca3");
+    memberBookRepository.save(MemberBook.of(memberId, 1L, "BEST"));
+    memberBookRepository.save(MemberBook.of(memberId, 2L, "HIGH"));
+    MemberBook unavailableBook = memberBookRepository.save(MemberBook.of(memberId, 2L, "HIGH"));
+    unavailableBook.updateUsageId(1L);
+    ReadMemberBooksQuery query = ReadMemberBooksQuery.of(memberId, SearchKey.UNAVAILABLE.name(), List.of(-1L));
+
+    // when
+    MemberBooksResponse result = service.readMemberBooksProcess(query);
+
+    // then
+    List<MemberBookSummary> bookcase = result.bookcase();
+    assertThat(bookcase).hasSize(1);
+    assertThat(bookcase.get(0).available()).isFalse();
+  }
+
+  @Test
+  void 회원_책장_사용_가능_책_목록_조회_필수_포함() {
+    // given
+    UUID memberId = UUID.fromString("0197365f-8074-7d24-ba91-0c5fc1b37ca3");
+    memberBookRepository.save(MemberBook.of(memberId, 1L, "BEST"));
+    memberBookRepository.save(MemberBook.of(memberId, 2L, "HIGH"));
+    MemberBook unavailableBook = memberBookRepository.save(MemberBook.of(memberId, 2L, "HIGH"));
+    unavailableBook.updateUsageId(1L);
+    List<Long> requires = List.of(unavailableBook.getId());
+    ReadMemberBooksQuery.of(memberId, SearchKey.AVAILABLE.name(), requires);
+
+    // when
+    MemberBooksResponse result = service.readMemberBooksProcess(ReadMemberBooksQuery.of(memberId));
+
+    // then
+    assertThat(result.bookcase()).isNotNull();
+
+    List<MemberBookSummary> bookcase = result.bookcase();
+    assertThat(bookcase.get(0).available()).isTrue();
+    assertThat(bookcase.get(1).available()).isTrue();
+    assertThat(bookcase.get(2).available()).isFalse();
   }
 
   @Test
@@ -148,7 +211,7 @@ class MemberBookServiceIntgTest extends TestContainerSupport {
     MemberBooksResponse response = service.readMemberBooksByIdsProcess(query);
 
     // then
-    List<MemberBookSummary> summaries = response.books();
+    List<MemberBookSummary> summaries = response.bookcase();
     assertThat(summaries).hasSize(2);
 
     MemberBookSummary s1 = summaries.get(0);

--- a/src/test/unit/java/com/bob/domain/member/service/MemberBookServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberBookServiceTest.java
@@ -108,7 +108,7 @@ class MemberBookServiceTest {
   }
 
   @Test
-  void 회원_소유_책_목록_조회() {
+  void 회원_책장_모든_책_목록_조회() {
     // given
     UUID memberId = MEMBER_ID;
     MemberBook mb1 = DEFAULT_MEMBER_BOOK();
@@ -123,7 +123,7 @@ class MemberBookServiceTest {
     then(memberBookReader).should().readMemberBooksByMemberId(memberId);
     then(bookPort).should().readBookSummaries(List.of(DEFAULT_MEMBER_BOOK().getBookId(), NEW_MEMBER_BOOK().getBookId()));
 
-    List<MemberBookSummary> summaries = response.books();
+    List<MemberBookSummary> summaries = response.bookcase();
     assertThat(summaries).hasSize(2);
 
     MemberBookSummary s1 = summaries.get(0);
@@ -152,7 +152,7 @@ class MemberBookServiceTest {
     then(memberBookReader).should().readMemberBooksByBookIds(query.ids());
     then(bookPort).should().readBookSummaries(List.of(DEFAULT_MEMBER_BOOK().getBookId(), NEW_MEMBER_BOOK().getBookId()));
 
-    List<MemberBookSummary> summaries = response.books();
+    List<MemberBookSummary> summaries = response.bookcase();
     assertThat(summaries).hasSize(2);
 
     MemberBookSummary s1 = summaries.get(0);

--- a/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/MemberServiceTest.java
@@ -234,6 +234,7 @@ class MemberServiceTest {
     given(memberReader.readMemberById(query.memberId())).willReturn(member);
     given(memberInterestService.readMemberInterests(member.getId())).willReturn(DEFAULT_INTEREST_DISPLAY_NAMES());
     given(areaPort.readMemberAreaSummary(MEMBER_ID)).willReturn(DEFAULT_AREA_SUMMARY_RESPONSE);
+    given(memberBookService.readMemberBooksProcess(any(ReadMemberBooksQuery.class))).willReturn(DEFAULT_MEMBER_BOOKS_RESPONSE);
 
     // when
     MemberProfileResponse response = memberService.readProfileProcess(query);
@@ -247,9 +248,7 @@ class MemberServiceTest {
     assertThat(response.interests()).hasSize(DEFAULT_INTEREST_DISPLAY_NAMES().size());
     assertThat(response.area().emdId()).isEqualTo(EMD_AREA_ID);
     assertThat(response.area().isAuthentication()).isTrue();
-
-    // 타인 프로필 조회 시 소유 도서 목록은 null.
-    assertThat(response.bookcase()).isNull();
+    assertThat(response.bookcase()).isNotNull();
   }
 
   @Test
@@ -261,6 +260,7 @@ class MemberServiceTest {
     given(memberReader.readMemberById(query.memberId())).willReturn(member);
     given(memberInterestService.readMemberInterests(member.getId())).willReturn(DEFAULT_INTEREST_DISPLAY_NAMES());
     given(areaPort.readMemberAreaSummary(MEMBER_ID)).willReturn(DEFAULT_AREA_SUMMARY_RESPONSE);
+    given(memberBookService.readMemberBooksProcess(any(ReadMemberBooksQuery.class))).willReturn(DEFAULT_MEMBER_BOOKS_RESPONSE);
 
     // when
     MemberProfileResponse response = memberService.readProfileProcess(query);
@@ -272,8 +272,7 @@ class MemberServiceTest {
     assertThat(response.nickname()).isEqualTo("(알 수 없음)");
     assertThat(response.profileImageUrl()).isNull();
     assertThat(response.interests()).hasSize(0);
-
-    assertThat(response.bookcase()).isNull();
+    assertThat(response.bookcase()).isNotNull();
   }
 
   @ParameterizedTest(name = "프로필 변경 성공 케이스: {0}")

--- a/src/test/unit/java/com/bob/domain/member/service/reader/MemberBookReaderTest.java
+++ b/src/test/unit/java/com/bob/domain/member/service/reader/MemberBookReaderTest.java
@@ -1,7 +1,10 @@
 package com.bob.domain.member.service.reader;
 
 import static com.bob.support.fixture.domain.MemberBookFixture.DEFAULT_MEMBER_BOOK;
+import static com.bob.support.fixture.domain.MemberBookFixture.DIFF_IN_TRADE_BOOK;
 import static com.bob.support.fixture.domain.MemberBookFixture.NEW_MEMBER_BOOK;
+import static com.bob.support.fixture.domain.MemberBookFixture.SAME_IN_TRADE_BOOK;
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -60,6 +63,38 @@ class MemberBookReaderTest {
     // then
     assertThat(actual).isEmpty();
     then(repository).should().findByMemberId(memberId);
+  }
+
+  @Test
+  void 회원_책장_사용_가능_책_목록_조회() {
+    // given
+    UUID memberId = MEMBER_ID;
+    List<Long> requires = List.of(-1L);
+    given(repository.findAvailableByMemberId(memberId, requires)).willReturn(List.of(DEFAULT_MEMBER_BOOK(), NEW_MEMBER_BOOK()));
+
+    // when
+    List<MemberBook> result = reader.readAvailableMemberBooksByMemberId(memberId, requires);
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getUsageId()).isNull();
+    assertThat(result.get(1).getUsageId()).isNull();
+  }
+
+  @Test
+  void 회원_책장_사용_불가능_책_목록_조회() {
+    // given
+    UUID memberId = MEMBER_ID;
+    List<Long> requires = List.of(-1L);
+    given(repository.findUnavailableByMemberId(memberId, requires)).willReturn(List.of(DIFF_IN_TRADE_BOOK(), SAME_IN_TRADE_BOOK()));
+
+    // when
+    List<MemberBook> result = reader.readUnavailableMemberBooksByMemberId(memberId, requires);
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getUsageId()).isNotNull();
+    assertThat(result.get(1).getUsageId()).isNotNull();
   }
 
   @Test

--- a/src/test/unit/java/com/bob/web/member/controller/MemberBookControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberBookControllerTest.java
@@ -81,19 +81,39 @@ class MemberBookControllerTest {
   }
 
   @Test
-  void 내_보유_도서_목록_조회_기능_호출() throws Exception {
+  void 회원_책장_조회_기능_호출() throws Exception {
     // given
     given(readUseCase.readMemberBooksProcess(any(ReadMemberBooksQuery.class))).willReturn(DEFAULT_MEMBER_BOOKS_RESPONSE);
 
-    int expectedSize = DEFAULT_MEMBER_BOOKS_RESPONSE.books().size();
-    var first = DEFAULT_MEMBER_BOOKS_RESPONSE.books().get(0);
+    int expectedSize = DEFAULT_MEMBER_BOOKS_RESPONSE.bookcase().size();
+    var first = DEFAULT_MEMBER_BOOKS_RESPONSE.bookcase().get(0);
 
     // when & then
     mvc.perform(get("/members/{memberId}/books", MEMBER_ID))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.books.length()").value(expectedSize))
-        .andExpect(jsonPath("$.books[0].id").value(first.id().intValue()))
-        .andExpect(jsonPath("$.books[0].title").value(first.title()));
+        .andExpect(jsonPath("$.bookcase.length()").value(expectedSize))
+        .andExpect(jsonPath("$.bookcase[0].id").value(first.id().intValue()))
+        .andExpect(jsonPath("$.bookcase[0].title").value(first.title()));
+
+    verify(readUseCase, times(1)).readMemberBooksProcess(any(ReadMemberBooksQuery.class));
+  }
+
+  @Test
+  void 회원_책장_조회_require_포함_기능_호출() throws Exception {
+    // given
+    given(readUseCase.readMemberBooksProcess(any(ReadMemberBooksQuery.class))).willReturn(DEFAULT_MEMBER_BOOKS_RESPONSE);
+
+    int expectedSize = DEFAULT_MEMBER_BOOKS_RESPONSE.bookcase().size();
+    var first = DEFAULT_MEMBER_BOOKS_RESPONSE.bookcase().get(0);
+
+    // when & then
+    mvc.perform(get("/members/{memberId}/books", MEMBER_ID)
+            .param("require", "1")
+            .param("require", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.bookcase.length()").value(expectedSize))
+        .andExpect(jsonPath("$.bookcase[0].id").value(first.id().intValue()))
+        .andExpect(jsonPath("$.bookcase[0].title").value(first.title()));
 
     verify(readUseCase, times(1)).readMemberBooksProcess(any(ReadMemberBooksQuery.class));
   }

--- a/src/test/unit/java/com/bob/web/member/controller/MemberBookControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberBookControllerTest.java
@@ -1,0 +1,115 @@
+package com.bob.web.member.controller;
+
+import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
+import static com.bob.support.fixture.response.MemberBooksResponseFixture.DEFAULT_MEMBER_BOOKS_RESPONSE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.bob.domain.member.service.dto.command.RegisterMemberBookCommand;
+import com.bob.domain.member.service.dto.command.RemoveMemberBookCommand;
+import com.bob.domain.member.service.dto.query.ReadMemberBooksQuery;
+import com.bob.domain.member.usecase.MemberBookReadUseCase;
+import com.bob.domain.member.usecase.MemberBookRemoveUseCase;
+import com.bob.domain.member.usecase.MemberBookWriteUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("회원 책장 API 테스트")
+@ExtendWith(MockitoExtension.class)
+class MemberBookControllerTest {
+
+  @InjectMocks
+  private MemberBookController controller;
+
+  @Mock
+  private MemberBookWriteUseCase writeUseCase;
+
+  @Mock
+  private MemberBookReadUseCase readUseCase;
+
+  @Mock
+  private MemberBookRemoveUseCase removeUseCase;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    mvc = standaloneSetup(controller).build();
+  }
+
+  @Test
+  void 회원_도서_등록_기능_호출() throws Exception {
+    // given
+    String json = """
+        {
+          "status": "BEST",
+          "isbn": "9781234567890",
+          "title": "테스트책",
+          "author": "홍길동",
+          "description": "설명",
+          "priceStandard": 15000,
+          "cover": "http://image.url/cover.jpg",
+          "pubDate": "2024-01-02"
+        }
+        """;
+
+    // when & then
+    mvc.perform(post("/members/books")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(json)
+            .requestAttr("memberId", MEMBER_ID))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("CREATED"));
+
+    verify(writeUseCase, times(1)).registerMemberBookProcess(any(RegisterMemberBookCommand.class));
+  }
+
+  @Test
+  void 내_보유_도서_목록_조회_기능_호출() throws Exception {
+    // given
+    given(readUseCase.readMemberBooksProcess(any(ReadMemberBooksQuery.class))).willReturn(DEFAULT_MEMBER_BOOKS_RESPONSE);
+
+    int expectedSize = DEFAULT_MEMBER_BOOKS_RESPONSE.books().size();
+    var first = DEFAULT_MEMBER_BOOKS_RESPONSE.books().get(0);
+
+    // when & then
+    mvc.perform(get("/members/{memberId}/books", MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.books.length()").value(expectedSize))
+        .andExpect(jsonPath("$.books[0].id").value(first.id().intValue()))
+        .andExpect(jsonPath("$.books[0].title").value(first.title()));
+
+    verify(readUseCase, times(1)).readMemberBooksProcess(any(ReadMemberBooksQuery.class));
+  }
+
+  @Test
+  void 회원_소유_도서_삭제_기능_호출() throws Exception {
+    // given
+    long memberBookId = 1L;
+
+    // when & then
+    mvc.perform(delete("/members/books/{memberBookId}", memberBookId)
+            .requestAttr("memberId", MEMBER_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.result").value("DELETED"));
+
+    verify(removeUseCase, times(1)).removeMemberBookProcess(any(RemoveMemberBookCommand.class));
+  }
+}

--- a/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
+++ b/src/test/unit/java/com/bob/web/member/controller/MemberControllerTest.java
@@ -2,7 +2,6 @@ package com.bob.web.member.controller;
 
 import static com.bob.support.fixture.domain.MemberFixture.MEMBER_ID;
 import static com.bob.support.fixture.domain.MemberFixture.OTHER_MEMBER_ID;
-import static com.bob.support.fixture.response.MemberBooksResponseFixture.DEFAULT_MEMBER_BOOKS_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.DEFAULT_MEMBER_PROFILE_RESPONSE;
 import static com.bob.support.fixture.response.MemberProfileResponseFixture.OTHER_MEMBER_PROFILE_RESPONSE;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,13 +19,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 import com.bob.domain.member.service.dto.command.ChangePasswordCommand;
 import com.bob.domain.member.service.dto.command.CreateMemberCommand;
 import com.bob.domain.member.service.dto.command.IssuePasswordCommand;
-import com.bob.domain.member.service.dto.command.RegisterMemberBookCommand;
-import com.bob.domain.member.service.dto.command.RemoveMemberBookCommand;
 import com.bob.domain.member.service.dto.command.RemoveMemberCommand;
-import com.bob.domain.member.service.dto.query.ReadMemberBooksQuery;
-import com.bob.domain.member.usecase.MemberBookReadUseCase;
-import com.bob.domain.member.usecase.MemberBookRemoveUseCase;
-import com.bob.domain.member.usecase.MemberBookWriteUseCase;
 import com.bob.domain.member.usecase.MemberModifyUseCase;
 import com.bob.domain.member.usecase.MemberReadUseCase;
 import com.bob.domain.member.usecase.MemberWriteUseCase;
@@ -58,15 +51,6 @@ class MemberControllerTest {
   @Mock
   private MemberModifyUseCase modifyUseCase;
 
-  @Mock
-  private MemberBookWriteUseCase bookWriteUseCase;
-
-  @Mock
-  private MemberBookReadUseCase bookReadUseCase;
-
-  @Mock
-  private MemberBookRemoveUseCase bookRemoveUseCase;
-
   private MockMvc mvc;
 
   @BeforeEach
@@ -97,34 +81,6 @@ class MemberControllerTest {
 
     // then
     verify(writeUseCase, times(1)).signupProcess(any(CreateMemberCommand.class));
-  }
-
-  @Test
-  void 회원_도서_등록_기능_호출() throws Exception {
-    // given
-    String json = """
-        {
-          "status": "BEST",
-          "isbn": "9781234567890",
-          "title": "테스트책",
-          "author": "홍길동",
-          "description": "설명",
-          "priceStandard": 15000,
-          "cover": "http://image.url/cover.jpg",
-          "pubDate": "2024-01-02"
-        }
-        """;
-
-    // when & then
-    mvc.perform(post("/members/books")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(json)
-            .requestAttr("memberId", MEMBER_ID))
-        .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.result").value("CREATED"));
-
-    verify(bookWriteUseCase, times(1)).registerMemberBookProcess(any(RegisterMemberBookCommand.class));
   }
 
   @Test
@@ -160,26 +116,6 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.area.isAuthentication").value(true));
 
     verify(readUseCase, times(1)).readProfileProcess(any());
-  }
-
-  @Test
-  void 내_보유_도서_목록_조회_기능_호출() throws Exception {
-    // given
-    given(bookReadUseCase.readMemberBooksProcess(any(ReadMemberBooksQuery.class)))
-        .willReturn(DEFAULT_MEMBER_BOOKS_RESPONSE);
-
-    int expectedSize = DEFAULT_MEMBER_BOOKS_RESPONSE.books().size();
-    var first = DEFAULT_MEMBER_BOOKS_RESPONSE.books().get(0);
-
-    // when & then
-    mvc.perform(get("/members/me/books")
-            .requestAttr("memberId", MEMBER_ID))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.books.length()").value(expectedSize))
-        .andExpect(jsonPath("$.books[0].id").value(first.id().intValue()))
-        .andExpect(jsonPath("$.books[0].title").value(first.title()));
-
-    verify(bookReadUseCase, times(1)).readMemberBooksProcess(any(ReadMemberBooksQuery.class));
   }
 
   @Test
@@ -269,23 +205,6 @@ class MemberControllerTest {
         .andExpect(jsonPath("$.success").value(true))
         .andExpect(jsonPath("$.result").value("DELETED"));
 
-    verify(modifyUseCase, times(1))
-        .softRemoveMemberProcess(any(RemoveMemberCommand.class), any(HttpServletResponse.class));
-  }
-
-  @Test
-  void 회원_소유_도서_삭제_기능_호출() throws Exception {
-    // given
-    long memberBookId = 1L;
-
-    // when & then
-    mvc.perform(delete("/members/books/{memberBookId}", memberBookId)
-            .requestAttr("memberId", MEMBER_ID))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.success").value(true))
-        .andExpect(jsonPath("$.result").value("DELETED"));
-
-    verify(bookRemoveUseCase, times(1))
-        .removeMemberBookProcess(any(RemoveMemberBookCommand.class));
+    verify(modifyUseCase, times(1)).softRemoveMemberProcess(any(RemoveMemberCommand.class), any(HttpServletResponse.class));
   }
 }


### PR DESCRIPTION
this closes #131
### 작업 내용
- [x] 다른 사용자의 책장 조회 기능 추가
- [x] 쿼리 기반 책장 조회로 변경 
- [x] 책장 조회 시 책장의 책 사용 여부 반영 (key : `available`, value : `boolean`)