### PR TITLE
fix: 회원 프로필 수정 시 변경사항 유무 검증 로직 수정

### DIFF
--- a/src/main/java/com/bob/core/application/member/MemberCommandService.java
+++ b/src/main/java/com/bob/core/application/member/MemberCommandService.java
@@ -124,7 +124,7 @@ public class MemberCommandService implements MemberRegister, MemberModifier {
         boolean nicknameUnchanged = Objects.equals(member.getNickname(), command.nickname());
 
         MemberArea area = member.getArea();
-        boolean areaUnchanged = !command.authenticateArea() || Objects.equals(area.getEmdId(), command.emdId());
+        boolean areaUnchanged = !command.authenticateArea() && Objects.equals(area.getEmdId(), command.emdId());
 
         if (interestsUnchanged && nicknameUnchanged && areaUnchanged)
             throw new ApplicationException(NO_CHANGES);

--- a/src/test/java/com/bob/core/application/member/port/in/MemberModifierTest.java
+++ b/src/test/java/com/bob/core/application/member/port/in/MemberModifierTest.java
@@ -12,6 +12,7 @@ import static com.bob.support.fixture.member.domain.MemberFixture.createCustomPa
 import static com.bob.support.fixture.member.domain.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.List;
 
@@ -88,6 +89,14 @@ record MemberModifierTest(
 
         assertThat(member.getArea().getEmdId()).isNotEqualTo(999);
         assertThat(member.getArea().getEmdId()).isEqualTo(current);
+    }
+
+    @Test
+    void 프로필_정보_수정_변경사항_없음_및_위치_인증_여부_true() {
+        Member member = memberRepository.save(createMember("test@example.com", "password", "nickname", EMD_AREA_ID));
+        var command = new ChangeProfileCommand("nickname", EMD_AREA_ID, true, CENTER_LAT, CENTER_LON, List.of());
+
+        assertDoesNotThrow(() -> memberModifier.changeProfile(member.getId(), command));
     }
 
     @Test


### PR DESCRIPTION
this fixes #168 

### 작업 내용
- [x] 회원 프로필 수정 시 `areaAuthenticate` : `true` 인 경우 회원 프로필 업데이트