### PR TITLE
feat: 회원 관리자 역할 추가

### DIFF
--- a/src/main/java/com/bob/core/adapter/member/out/MemberLoaderAdapter.java
+++ b/src/main/java/com/bob/core/adapter/member/out/MemberLoaderAdapter.java
@@ -1,6 +1,7 @@
 package com.bob.core.adapter.member.out;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,11 +26,30 @@ public class MemberLoaderAdapter implements MemberLoader {
     public Optional<AuthMember> load(String email) {
         try {
             Member member = memberReader.read(email);
-            return Optional.of(
-                AuthMember.of(member.getId(), member.getEmail(), member.getPassword(), member.getStatus().name()));
+            return Optional.of(AuthMember.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .status(member.getStatus().name())
+                .role(member.getRole().name())
+                .build()
+            );
         } catch (Exception e) {
             return Optional.empty();
         }
+    }
+
+    @Override
+    public AuthMember load(UUID id) {
+        Member member = memberReader.read(id);
+
+        return AuthMember.builder()
+            .id(member.getId())
+            .email(member.getEmail())
+            .password(member.getPassword())
+            .status(member.getStatus().name())
+            .role(member.getRole().name())
+            .build();
     }
 
     @Override

--- a/src/main/java/com/bob/core/application/member/MemberQueryService.java
+++ b/src/main/java/com/bob/core/application/member/MemberQueryService.java
@@ -70,6 +70,7 @@ public class MemberQueryService implements MemberReader {
 
         return MemberDetail.builder()
             .id(member.getId())
+            .role(member.getRole().name())
             .email(member.getEmail())
             .nickname(member.getNickname())
             .profileImageUrl(member.getProfileImageUrl())

--- a/src/main/java/com/bob/core/application/member/dto/result/MemberDetail.java
+++ b/src/main/java/com/bob/core/application/member/dto/result/MemberDetail.java
@@ -11,6 +11,7 @@ import com.bob.core.domain.member.SocialProvider;
 @Builder
 public record MemberDetail(
     UUID id,
+    String role,
     String email,
     String nickname,
     String profileImageUrl,
@@ -24,6 +25,7 @@ public record MemberDetail(
     public static MemberDetail deactivateMemberDetail(UUID id, MemberAreaDetail area, SocialProvider provider) {
         return MemberDetail.builder()
             .id(id)
+            .role("USER")
             .email("delete")
             .nickname("(알 수 없음)")
             .profileImageUrl(null)

--- a/src/main/java/com/bob/core/domain/member/Member.java
+++ b/src/main/java/com/bob/core/domain/member/Member.java
@@ -53,11 +53,14 @@ public class Member {
 
     private Status status;
 
+    private ROLE role;
+
     private LocalDateTime createdAt;
 
     public static Member createMember(String email, String password, String nickname, Integer emdAreaId) {
         return Member.builder()
             .status(ACTIVE)
+            .role(ROLE.USER)
             .email(requireNonNull(email))
             .password(requireNonNull(password))
             .nickname(requireNonNull(nickname))
@@ -70,6 +73,7 @@ public class Member {
         return Member.builder()
             .provider(SocialProvider.valueOf(requireNonNull(provider)))
             .status(ACTIVE)
+            .role(ROLE.USER)
             .email(requireNonNull(email))
             .password(null)
             .nickname(requireNonNull(nickname))

--- a/src/main/java/com/bob/core/domain/member/ROLE.java
+++ b/src/main/java/com/bob/core/domain/member/ROLE.java
@@ -1,0 +1,5 @@
+package com.bob.core.domain.member;
+
+public enum ROLE {
+    ADMIN, USER
+}

--- a/src/main/java/com/bob/infrastructure/secure/adapter/jwt/JwtTokenManager.java
+++ b/src/main/java/com/bob/infrastructure/secure/adapter/jwt/JwtTokenManager.java
@@ -1,11 +1,14 @@
 package com.bob.infrastructure.secure.adapter.jwt;
 
 import java.util.Date;
-import java.util.UUID;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -26,35 +29,37 @@ public class JwtTokenManager implements TokenManager {
     @Value("${jwt.access-token-expire-time}")
     private Long accessExpireTime;
 
-    public String create(String claim) {
-        return Jwts.builder()
+    @Override
+    public String create(Map<String, String> claims) {
+        return create(claims, accessExpireTime * 1000);
+    }
+
+    @Override
+    public String create(Map<String, String> claims, Long expiration) {
+        JwtBuilder builder = Jwts.builder()
             .setIssuer("bob")
             .setSubject("access-token")
-            .claim("memberId", claim)
             .setIssuedAt(new Date(System.currentTimeMillis()))
-            .setExpiration(new Date(System.currentTimeMillis() + accessExpireTime * 1000))
+            .setExpiration(new Date(System.currentTimeMillis() + expiration * 1000));
+
+        claims.forEach(builder::claim);
+
+        return builder
             .signWith(getSecretKey(key))
             .compact();
     }
 
-    public String create(String claim, Long expireTime) {
-        return Jwts.builder()
-            .setIssuer("bob")
-            .setSubject("access-token")
-            .claim("memberId", claim)
-            .setIssuedAt(new Date(System.currentTimeMillis()))
-            .setExpiration(new Date(System.currentTimeMillis() + expireTime * 1000))
-            .signWith(getSecretKey(key))
-            .compact();
-    }
-
-    public UUID getClaim(String token) {
-        return UUID.fromString(Jwts.parserBuilder()
+    @Override
+    public Map<String, String> getClaims(String token) {
+        Claims body = Jwts.parserBuilder()
             .setSigningKey(getSecretKey(key))
             .build()
             .parseClaimsJws(token)
-            .getBody()
-            .get("memberId", String.class));
+            .getBody();
+
+        return body.entrySet().stream()
+            .filter(entry -> entry.getValue() instanceof String)
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> (String)entry.getValue()));
     }
 
     public boolean verify(String token) {

--- a/src/main/java/com/bob/security/adapter/filter/LoginFilter.java
+++ b/src/main/java/com/bob/security/adapter/filter/LoginFilter.java
@@ -5,6 +5,7 @@ import static com.bob.global.utils.web.CookieUtils.addCookie;
 import static com.bob.global.utils.web.CookieUtils.getCookie;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.UUID;
 
 import jakarta.servlet.FilterChain;
@@ -63,11 +64,17 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
         MemberDetails principal = (MemberDetails)authentication.getPrincipal();
         UUID memberId = principal.id();
-        String accessToken = tokenManager.create(memberId.toString());
+        String role = principal.role();
+        Map<String, String> claims = Map.of("memberId", memberId.toString(), "role", role);
+
+        String accessToken = tokenManager.create(claims);
         String refreshKey = generateCode(32);
+
         authCachePort.updateRefreshKey(getCookie(request, headerProperties.refreshName()), refreshKey, memberId.toString());
+
         addCookie(response, headerProperties.accessName(), accessToken, headerProperties.refreshTokenExpireTime());
         addCookie(response, headerProperties.refreshName(), refreshKey, headerProperties.refreshTokenExpireTime());
+
         response.setStatus(HttpStatus.OK.value());
     }
 

--- a/src/main/java/com/bob/security/adapter/filter/TokenAuthorizationFilter.java
+++ b/src/main/java/com/bob/security/adapter/filter/TokenAuthorizationFilter.java
@@ -6,6 +6,8 @@ import static com.bob.global.utils.web.CookieUtils.getCookie;
 import static com.bob.global.utils.web.CookieUtils.removeCookie;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -73,7 +75,11 @@ public class TokenAuthorizationFilter extends OncePerRequestFilter {
             return;
         }
 
-        MemberDetails memberDetails = new MemberDetails(tokenManager.getClaim(accessToken), true);
+        Map<String, String> claims = tokenManager.getClaims(accessToken);
+        UUID memberId = UUID.fromString(claims.get("memberId"));
+        String role = claims.get("role");
+
+        MemberDetails memberDetails = new MemberDetails(memberId, role, true);
         Authentication authentication = new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/src/main/java/com/bob/security/adapter/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/bob/security/adapter/handler/OAuth2SuccessHandler.java
@@ -4,6 +4,7 @@ import static com.bob.global.utils.random.RandomUtils.generateCode;
 import static com.bob.global.utils.web.CookieUtils.addCookie;
 
 import java.io.IOException;
+import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +38,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         String memberId = authentication.getName();
-        String accessToken = tokenManager.create(memberId);
+        String role = ((OAuth2User) authentication.getPrincipal()).getAttributes().get("role").toString();
+
+        Map<String, String> claims = Map.of("memberId", memberId, "role", role);
+        String accessToken = tokenManager.create(claims);
         String refreshKey = generateCode(32);
 
         cachePort.setRefreshKey(refreshKey, memberId);

--- a/src/main/java/com/bob/security/application/MemberDetailsService.java
+++ b/src/main/java/com/bob/security/application/MemberDetailsService.java
@@ -22,6 +22,9 @@ public class MemberDetailsService implements UserDetailsService {
         AuthMember member = memberLoader.load(username)
             .orElseThrow(() -> new UsernameNotFoundException(username));
 
-        return new MemberDetails(member.id(), member.email(), member.password(), member.status().equals("ACTIVE"));
+        return new MemberDetails(
+            member.id(), member.email(), member.password(), member.role(),
+            member.status().equals("ACTIVE")
+        );
     }
 }

--- a/src/main/java/com/bob/security/application/OAuth2Service.java
+++ b/src/main/java/com/bob/security/application/OAuth2Service.java
@@ -1,9 +1,12 @@
 package com.bob.security.application;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -49,8 +52,12 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
             case "DEACTIVATED" -> throw new ApplicationAuthenticationException(AuthenticationError.MEMBER_DEACTIVATED) {};
             case "BANNED" -> throw new ApplicationAuthenticationException(AuthenticationError.MEMBER_BANNED) {};
             default -> {
-                final Map<String, Object> principalAttrs = Map.of("memberId", member.id().toString());
-                return new DefaultOAuth2User(null, principalAttrs, "memberId");
+                Map<String, Object> principalAttrs = Map.of("memberId", member.id().toString(), "role", member.role());
+
+                List<SimpleGrantedAuthority> authorities =
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.role()));
+
+                return new DefaultOAuth2User(authorities, principalAttrs, "memberId");
             }
         }
     }

--- a/src/main/java/com/bob/security/application/TokenService.java
+++ b/src/main/java/com/bob/security/application/TokenService.java
@@ -5,6 +5,9 @@ import static com.bob.global.utils.random.RandomUtils.generateCode;
 import static com.bob.global.utils.web.CookieUtils.addCookie;
 import static com.bob.global.utils.web.CookieUtils.getCookie;
 
+import java.util.Map;
+import java.util.UUID;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -14,17 +17,21 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.bob.global.exception.exceptions.ApplicationAuthenticationException;
+import com.bob.security.application.port.dto.AuthMember;
 import com.bob.security.application.port.in.TokenIssuer;
 import com.bob.security.application.port.out.AuthCachePort;
+import com.bob.security.application.port.out.MemberLoader;
 import com.bob.security.application.port.out.TokenManager;
 
 @Service
 @RequiredArgsConstructor
 public class TokenService implements TokenIssuer {
 
-    private final TokenManager tokenProvider;
+    private final TokenManager tokenManager;
 
     private final AuthCachePort cachePort;
+
+    private final MemberLoader memberLoader;
 
     @Value("${jwt.access-name}")
     private String accessName;
@@ -42,7 +49,9 @@ public class TokenService implements TokenIssuer {
         String id = getId(old);
         cachePort.updateRefreshKey(old, current, id);
 
-        String accessToken = tokenProvider.create(id);
+        AuthMember member = memberLoader.load(UUID.fromString(id));
+
+        String accessToken = tokenManager.create(Map.of("memberId", id, "role", member.role()));
         addCookie(response, accessName, accessToken, refreshExpireTime);
         addCookie(response, refreshName, current, refreshExpireTime);
     }

--- a/src/main/java/com/bob/security/application/port/dto/AuthMember.java
+++ b/src/main/java/com/bob/security/application/port/dto/AuthMember.java
@@ -2,9 +2,9 @@ package com.bob.security.application.port.dto;
 
 import java.util.UUID;
 
-public record AuthMember(UUID id, String email, String password, String status) {
+import lombok.Builder;
 
-    public static AuthMember of(UUID id, String email, String password, String status) {
-        return new AuthMember(id, email, password, status);
-    }
+@Builder
+public record AuthMember(UUID id, String email, String password, String status, String role) {
+
 }

--- a/src/main/java/com/bob/security/application/port/dto/SocialAuthMember.java
+++ b/src/main/java/com/bob/security/application/port/dto/SocialAuthMember.java
@@ -2,9 +2,9 @@ package com.bob.security.application.port.dto;
 
 import java.util.UUID;
 
-public record SocialAuthMember(UUID id, String status) {
+public record SocialAuthMember(UUID id, String status, String role) {
 
     public static SocialAuthMember of(UUID id, String status) {
-        return new SocialAuthMember(id, status);
+        return new SocialAuthMember(id, status, "USER");
     }
 }

--- a/src/main/java/com/bob/security/application/port/out/MemberLoader.java
+++ b/src/main/java/com/bob/security/application/port/out/MemberLoader.java
@@ -1,6 +1,7 @@
 package com.bob.security.application.port.out;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import com.bob.security.application.port.dto.AuthMember;
 import com.bob.security.application.port.dto.SocialAuthMember;
@@ -8,6 +9,8 @@ import com.bob.security.application.port.dto.SocialAuthMember;
 public interface MemberLoader {
 
     Optional<AuthMember> load(String email);
+
+    AuthMember load(UUID id);
 
     SocialAuthMember load(String provider, String email, String nickname);
 }

--- a/src/main/java/com/bob/security/application/port/out/TokenManager.java
+++ b/src/main/java/com/bob/security/application/port/out/TokenManager.java
@@ -1,15 +1,14 @@
 package com.bob.security.application.port.out;
 
-import java.util.UUID;
+import java.util.Map;
 
-/* FUTURE : 여러 개의 claim 포함 시 map 파라미터 활용 및 조회 */
 public interface TokenManager {
 
-    String create(String claim);
+    String create(Map<String, String> claims);
 
-    String create(String claim, Long expireTime);
+    String create(Map<String, String> claims, Long expiration);
 
-    UUID getClaim(String token);
+    Map<String, String> getClaims(String token);
 
     boolean verify(String token);
 

--- a/src/main/java/com/bob/security/model/MemberDetails.java
+++ b/src/main/java/com/bob/security/model/MemberDetails.java
@@ -5,17 +5,28 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-public record MemberDetails(UUID id, String email, String password, boolean enabled) implements UserDetails {
+public record MemberDetails(
+    UUID id,
+    String email,
+    String password,
+    String role,
+    boolean enabled
+) implements UserDetails {
 
     public MemberDetails(UUID id, boolean enabled) {
-        this(id, null, null, enabled);
+        this(id, null, null, "USER", enabled);
+    }
+
+    public MemberDetails(UUID id, String role, boolean enabled) {
+        this(id, null, null, role, enabled);
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
     }
 
     @Override
@@ -33,5 +44,3 @@ public record MemberDetails(UUID id, String email, String password, boolean enab
         return enabled;
     }
 }
-
-

--- a/src/main/resources/META-INF/orm.xml
+++ b/src/main/resources/META-INF/orm.xml
@@ -113,6 +113,10 @@
                 <column name="status" nullable="false"/>
                 <enumerated>STRING</enumerated>
             </basic>
+            <basic name="role">
+                <column name="role" nullable="false"/>
+                <enumerated>STRING</enumerated>
+            </basic>
             <basic name="createdAt">
                 <column name="created_at" nullable="false"/>
             </basic>

--- a/src/test/java/com/bob/core/adapter/member/out/MemberLoaderAdapterTest.java
+++ b/src/test/java/com/bob/core/adapter/member/out/MemberLoaderAdapterTest.java
@@ -29,6 +29,7 @@ record MemberLoaderAdapterTest(MemberLoaderAdapter memberLoaderAdapter, MemberRe
 
         AuthMember loaded = found.get();
         assertThat(loaded.id()).isEqualTo(member.getId());
+        assertThat(loaded.role()).isEqualTo("USER");
     }
 
     @Test
@@ -45,5 +46,6 @@ record MemberLoaderAdapterTest(MemberLoaderAdapter memberLoaderAdapter, MemberRe
         SocialAuthMember loaded = memberLoaderAdapter.load("GOOGLE", "test@google.com", "tester");
 
         assertThat(loaded.id()).isEqualTo(socialMember.getId());
+        assertThat(loaded.role()).isEqualTo("USER");
     }
 }

--- a/src/test/java/com/bob/core/application/member/port/in/MemberReaderTest.java
+++ b/src/test/java/com/bob/core/application/member/port/in/MemberReaderTest.java
@@ -71,6 +71,7 @@ record MemberReaderTest(MemberReader memberReader, MemberRepository memberReposi
 
         assertThat(detail).isNotNull();
         assertThat(detail.id()).isEqualTo(member.getId());
+        assertThat(detail.role()).isEqualTo(member.getRole().name());
         assertThat(detail.area()).isNotNull();
         assertThat(detail.bookcase()).isNotNull();
         assertThat(detail.wishes()).isNotNull();
@@ -85,6 +86,7 @@ record MemberReaderTest(MemberReader memberReader, MemberRepository memberReposi
 
         assertThat(detail).isNotNull();
         assertThat(detail.id()).isEqualTo(member.getId());
+        assertThat(detail.role()).isEqualTo(member.getRole().name());
         assertThat(detail.email()).isEqualTo("delete");
         assertThat(detail.nickname()).isEqualTo("(알 수 없음)");
         assertThat(detail.area()).isNotNull();

--- a/src/test/java/com/bob/infrastructure/secure/adapter/jwt/JwtTokenManagerTest.java
+++ b/src/test/java/com/bob/infrastructure/secure/adapter/jwt/JwtTokenManagerTest.java
@@ -3,7 +3,7 @@ package com.bob.infrastructure.secure.adapter.jwt;
 import static com.bob.support.fixture.member.domain.MemberFixture.MEMBER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.UUID;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,7 +24,12 @@ class JwtTokenManagerTest {
 
     @Test
     void 토큰_생성() {
-        String token = jwtTokenManager.create(MEMBER_ID.toString());
+        Map<String, String> claims = Map.of(
+            "memberId", MEMBER_ID.toString(),
+            "role", "USER"
+        );
+
+        String token = jwtTokenManager.create(claims);
 
         assertThat(token).isNotBlank();
         assertThat(token.split("\\.")).hasSize(3);
@@ -32,16 +37,22 @@ class JwtTokenManagerTest {
 
     @Test
     void 토큰_claim_추출() {
-        String token = jwtTokenManager.create(MEMBER_ID.toString());
+        Map<String, String> claims = Map.of(
+            "memberId", MEMBER_ID.toString(),
+            "role", "USER"
+        );
+        String token = jwtTokenManager.create(claims);
 
-        UUID claim = jwtTokenManager.getClaim(token);
+        Map<String, String> extractedClaims = jwtTokenManager.getClaims(token);
 
-        assertThat(claim).isEqualTo(MEMBER_ID);
+        assertThat(extractedClaims.get("memberId")).isEqualTo(MEMBER_ID.toString());
+        assertThat(extractedClaims.get("role")).isEqualTo("USER");
     }
 
     @Test
     void 토큰_서명_검증() {
-        String token = jwtTokenManager.create(MEMBER_ID.toString());
+        Map<String, String> claims = Map.of("memberId", MEMBER_ID.toString());
+        String token = jwtTokenManager.create(claims);
 
         boolean isVerified = jwtTokenManager.verify(token);
 
@@ -49,17 +60,9 @@ class JwtTokenManagerTest {
     }
 
     @Test
-    void 토큰_서명_검증_시_만료된_토큰이더라도_올바른_서명의_토큰이라면_true_반환() {
-        String token = jwtTokenManager.create(MEMBER_ID.toString(), -1L);
-
-        boolean verified = jwtTokenManager.verify(token);
-
-        assertThat(verified).isTrue();
-    }
-
-    @Test
     void 토큰_서명_검증_시_조작된_토큰이면_false_반환() {
-        String invalidSignToken = jwtTokenManager.create(MEMBER_ID.toString()) + "invalid";
+        Map<String, String> claims = Map.of("memberId", MEMBER_ID.toString());
+        String invalidSignToken = jwtTokenManager.create(claims) + "invalid";
 
         boolean verified = jwtTokenManager.verify(invalidSignToken);
 
@@ -68,7 +71,8 @@ class JwtTokenManagerTest {
 
     @Test
     void 토큰_만료_확인() {
-        String token = jwtTokenManager.create(MEMBER_ID.toString());
+        Map<String, String> claims = Map.of("memberId", MEMBER_ID.toString());
+        String token = jwtTokenManager.create(claims);
 
         boolean expired = jwtTokenManager.expire(token);
 
@@ -77,7 +81,8 @@ class JwtTokenManagerTest {
 
     @Test
     void 토큰_만료_확인_시_만료된_토큰이면_true_반환() {
-        String token = jwtTokenManager.create(MEMBER_ID.toString(), -1L);
+        Map<String, String> claims = Map.of("memberId", MEMBER_ID.toString());
+        String token = jwtTokenManager.create(claims, -1L);
 
         boolean expired = jwtTokenManager.expire(token);
 
@@ -86,7 +91,8 @@ class JwtTokenManagerTest {
 
     @Test
     void 토큰_만료_확인_시_조작된_토큰이더라도_true_반환() {
-        String invalidSignToken = jwtTokenManager.create(MEMBER_ID.toString()) + "invalid";
+        Map<String, String> claims = Map.of("memberId", MEMBER_ID.toString());
+        String invalidSignToken = jwtTokenManager.create(claims) + "invalid";
 
         boolean expired = jwtTokenManager.expire(invalidSignToken);
 

--- a/src/test/java/com/bob/security/adapter/filter/LoginFilterTest.java
+++ b/src/test/java/com/bob/security/adapter/filter/LoginFilterTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
@@ -120,7 +121,7 @@ class LoginFilterTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(
             memberDetails, null, memberDetails.getAuthorities()
         );
-        given(tokenManager.create(any(String.class))).willReturn(ACCESS_TOKEN);
+        given(tokenManager.create(anyMap())).willReturn(ACCESS_TOKEN);
         given(headerProperties.refreshName()).willReturn("REFRESH_COOKIE_NAME");
         given(headerProperties.accessName()).willReturn("AUTHORIZATION");
         given(headerProperties.refreshTokenExpireTime()).willReturn(600L);

--- a/src/test/java/com/bob/security/adapter/filter/TokenAuthorizationFilterTest.java
+++ b/src/test/java/com/bob/security/adapter/filter/TokenAuthorizationFilterTest.java
@@ -4,6 +4,7 @@ import static com.bob.global.exception.response.AuthenticationError.ACCESS_TOKEN
 import static com.bob.global.exception.response.AuthenticationError.AUTHENTICATION_FAILED;
 import static com.bob.support.fixture.auth.CookieFixture.ACCESS_TOKEN;
 import static com.bob.support.fixture.auth.CookieFixture.defaultAuthCookie;
+import static com.bob.support.fixture.member.domain.MemberFixture.MEMBER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.argThat;
@@ -11,7 +12,7 @@ import static org.mockito.BDDMockito.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-import java.util.UUID;
+import java.util.Map;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.Cookie;
@@ -77,10 +78,11 @@ class TokenAuthorizationFilterTest {
 
     @Test
     void 토큰_인증() throws Exception {
+        Map<String, String> claims = Map.of("memberId", MEMBER_ID.toString(), "role", "USER");
         given(request.getCookies()).willReturn(new Cookie[] {defaultAuthCookie()});
         given(tokenManager.verify(ACCESS_TOKEN)).willReturn(true);
         given(tokenManager.expire(ACCESS_TOKEN)).willReturn(false);
-        given(tokenManager.getClaim(ACCESS_TOKEN)).willReturn(UUID.randomUUID());
+        given(tokenManager.getClaims(ACCESS_TOKEN)).willReturn(claims);
 
         tokenAuthorizationFilter.doFilterInternal(request, response, filterChain);
 
@@ -88,6 +90,11 @@ class TokenAuthorizationFilterTest {
         assertThat(authentication).isNotNull();
         assertThat(authentication.isAuthenticated()).isTrue();
         assertThat(authentication.getPrincipal()).isInstanceOf(MemberDetails.class);
+
+        MemberDetails details = (MemberDetails)authentication.getPrincipal();
+        assertThat(details.getAuthorities())
+            .extracting("authority")
+            .contains("ROLE_USER");
 
         then(filterChain).should().doFilter(request, response);
     }

--- a/src/test/java/com/bob/security/adapter/handler/OAuth2SuccessHandlerTest.java
+++ b/src/test/java/com/bob/security/adapter/handler/OAuth2SuccessHandlerTest.java
@@ -5,12 +5,15 @@ import static com.bob.support.fixture.auth.CookieFixture.AUTH_COOKIE_NAME;
 import static com.bob.support.fixture.auth.CookieFixture.REFRESH_COOKIE_NAME;
 import static com.bob.support.fixture.member.domain.MemberFixture.MEMBER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 import jakarta.servlet.http.Cookie;
 
@@ -26,6 +29,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.bob.security.application.port.out.AuthCachePort;
@@ -58,7 +64,7 @@ class OAuth2SuccessHandlerTest {
         given(headerProperties.accessName()).willReturn(AUTH_COOKIE_NAME);
         given(headerProperties.refreshName()).willReturn(REFRESH_COOKIE_NAME);
         given(headerProperties.refreshTokenExpireTime()).willReturn(1L);
-        given(tokenManager.create(MEMBER_ID.toString())).willReturn(ACCESS_TOKEN);
+        given(tokenManager.create(anyMap())).willReturn(ACCESS_TOKEN);
 
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
@@ -67,11 +73,19 @@ class OAuth2SuccessHandlerTest {
     @Test
     void 소셜_로그인() throws Exception {
         String memberId = MEMBER_ID.toString();
-        var authentication = new UsernamePasswordAuthenticationToken(memberId, null);
+        Map<String, Object> attributes = Map.of("memberId", memberId, "role", "USER");
+
+        OAuth2User oauth2User = new DefaultOAuth2User(
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            "memberId"
+        );
+
+        var authentication = new UsernamePasswordAuthenticationToken(oauth2User, null, oauth2User.getAuthorities());
 
         successHandler.onAuthenticationSuccess(request, response, authentication);
 
-        then(tokenManager).should(times(1)).create(MEMBER_ID.toString());
+        then(tokenManager).should(times(1)).create(anyMap());
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         then(cachePort).should(times(1)).setRefreshKey(captor.capture(), eq(memberId));

--- a/src/test/java/com/bob/security/application/OAuth2ServiceTest.java
+++ b/src/test/java/com/bob/security/application/OAuth2ServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType.BEARER;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -61,7 +63,11 @@ class OAuth2ServiceTest {
         ClientRegistration registration = googleRegistration();
         OAuth2UserRequest request = requestOf(registration);
         Map<String, Object> attrs = Map.of("sub", "1", "email", "test@google.com", "name", "foo");
-        OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "sub");
+        OAuth2User loadedUser = new DefaultOAuth2User(
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            attrs,
+            "sub"
+        );
         given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
         given(memberLoader.load(eq("GOOGLE"), eq("test@google.com"), eq("foo")))
             .willReturn(createActiveSocialAuthMember());
@@ -79,7 +85,11 @@ class OAuth2ServiceTest {
         OAuth2UserRequest request = requestOf(registration);
         Map<String, Object> response = Map.of("id", "1", "email", "test@naver.com", "nickname", "foo");
         Map<String, Object> attrs = Map.of("response", response);
-        OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "response");
+        OAuth2User loadedUser = new DefaultOAuth2User(
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            attrs,
+            "response"
+        );
         given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
         given(memberLoader.load(eq("NAVER"), eq("test@naver.com"), eq("foo")))
             .willReturn(createActiveSocialAuthMember());
@@ -106,7 +116,11 @@ class OAuth2ServiceTest {
         ClientRegistration registration = googleRegistration();
         OAuth2UserRequest request = requestOf(registration);
         Map<String, Object> attrs = Map.of("sub", "1", "email", "test@google.com", "name", "tester");
-        OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "sub");
+        OAuth2User loadedUser = new DefaultOAuth2User(
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            attrs,
+            "sub"
+        );
         given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
         given(memberLoader.load(anyString(), anyString(), anyString())).willReturn(createDeactivatedSocialAuthMember());
 
@@ -121,7 +135,11 @@ class OAuth2ServiceTest {
         OAuth2UserRequest request = requestOf(registration);
         Map<String, Object> response = Map.of("id", "1", "email", "test@naver.com", "nickname", "tester");
         Map<String, Object> attrs = Map.of("response", response);
-        OAuth2User loadedUser = new DefaultOAuth2User(null, attrs, "response");
+        OAuth2User loadedUser = new DefaultOAuth2User(
+            Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")),
+            attrs,
+            "response"
+        );
         given(oAuth2UserService.loadUser(request)).willReturn(loadedUser);
         given(memberLoader.load(anyString(), anyString(), anyString())).willReturn(createBannedSocialAuthMember());
 

--- a/src/test/java/com/bob/security/model/MemberDetailsTest.java
+++ b/src/test/java/com/bob/security/model/MemberDetailsTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class MemberDetailsTest {
 
-    MemberDetails memberDetails = new MemberDetails(MEMBER_ID, "test@example.com", "password", true);
+    MemberDetails memberDetails = new MemberDetails(MEMBER_ID, "test@example.com", "password", "USER", true);
 
     @Test
     void 패스워드_조회() {
@@ -17,6 +17,13 @@ class MemberDetailsTest {
     @Test
     void 이름_조회() {
         assertThat(memberDetails.getUsername()).isEqualTo("test@example.com");
+    }
+
+    @Test
+    void 역할_조회() {
+        assertThat(memberDetails.getAuthorities())
+            .extracting("authority")
+            .contains("ROLE_USER");
     }
 
     @Test

--- a/src/test/java/com/bob/support/fixture/auth/port/dto/AuthMemberFixture.java
+++ b/src/test/java/com/bob/support/fixture/auth/port/dto/AuthMemberFixture.java
@@ -7,7 +7,13 @@ import com.bob.security.application.port.dto.AuthMember;
 public class AuthMemberFixture {
 
     public static AuthMember createAuthMember(String status) {
-        return AuthMember.of(MEMBER_ID, "test@email.com", "password", status);
+        return AuthMember.builder()
+            .id(MEMBER_ID)
+            .email("test@email.com")
+            .password("password")
+            .status(status)
+            .role("USER")
+            .build();
     }
 
     public static AuthMember createActiveAuthMember() {

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS members
     area_id           BIGINT       NOT NULL,
     provider          ENUM ('GOOGLE', 'NAVER'),
     status            ENUM ('ACTIVE', 'DEACTIVATED', 'BANNED'),
+    role              ENUM ('USER', 'ADMIN'),
     created_at        DATETIME,
     UNIQUE KEY UK_MEMBER_AREA_ID (area_id),
     CONSTRAINT FK_MEMBER_AREA FOREIGN KEY (area_id) REFERENCES member_areas (id)
@@ -360,10 +361,10 @@ INSERT INTO member_areas (id, emd_id, authenticated_at) VALUES
 (3, 213, CURDATE());
 
 -- 회원
-INSERT INTO members (id, email, password, nickname, area_id, status) VALUES
-(UUID_TO_BIN('0199f8c2-30ed-7ee3-a757-16196412518c'), 'test@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'tester', 1, 'ACTIVE'),
-(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a302'), 'other@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'other', 2, 'ACTIVE'),
-(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a303'), 'mock@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'mock', 3, 'ACTIVE');
+INSERT INTO members (id, email, password, nickname, area_id, status, role) VALUES
+(UUID_TO_BIN('0199f8c2-30ed-7ee3-a757-16196412518c'), 'test@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'tester', 1, 'ACTIVE', 'USER'),
+(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a302'), 'other@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'other', 2, 'ACTIVE', 'USER'),
+(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a303'), 'mock@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'mock', 3, 'ACTIVE', 'USER');
 
 INSERT INTO member_wishes (id, member_id, book_id) VALUES
 (1, UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a302'), 2);


### PR DESCRIPTION
this closes #167 

### 작업 내용
- [x] 회원 역할 구분 (`USER`, `ADMIN`)
- [x] 인증 객체, 토큰 생성 시 `role` 추가
