### PR TITLE
fix: 로그아웃 시 쿠키 삭제 기능 수정

### DIFF
--- a/src/main/java/com/bob/security/config/SecurityConfig.java
+++ b/src/main/java/com/bob/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.bob.security.config;
 
+import static com.bob.global.utils.web.CookieUtils.removeCookie;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 import java.util.List;
@@ -91,9 +92,11 @@ public class SecurityConfig {
             )
             .logout(filter -> filter
                 .logoutUrl("/auth/logout")
-                .logoutSuccessHandler((req, res, auth) -> res.setStatus(SC_OK))
-                .addLogoutHandler((req, res, auth) -> req.getSession().invalidate())
-                .deleteCookies("JSESSIONID", "AUTHORIZATION", "REFRESH_KEY")
+                .logoutSuccessHandler((req, res, auth) -> {
+                    removeCookie(res, "AUTHORIZATION");
+                    removeCookie(res, "REFRESH_KEY");
+                    res.setStatus(SC_OK);
+                })
             )
             .sessionManagement(m -> m.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))

--- a/src/test/java/com/bob/security/config/LogoutTest.java
+++ b/src/test/java/com/bob/security/config/LogoutTest.java
@@ -1,39 +1,100 @@
 package com.bob.security.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import jakarta.servlet.http.Cookie;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import com.bob.support.annotation.ContainerTest;
 
 @DisplayName("로그아웃 테스트")
 @ContainerTest
 @AutoConfigureMockMvc
-class LogoutTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+@TestPropertySource(properties = "cookie.same-site=LAX")
+record LogoutTest(MockMvc mockMvc) {
 
     @Test
     void 로그아웃() throws Exception {
-        Cookie jsessionCookie = new Cookie("JSESSIONID", "fake-session");
-        Cookie authCookie = new Cookie("AUTHORIZATION", "fake-access-token");
-        Cookie refreshCookie = new Cookie("REFRESH", "fake-refresh-token");
+        // 로그인 API 호출
+        String loginRequest = """
+            {
+                "email": "test@test.com",
+                "password": "1234"
+            }
+            """;
 
-        mockMvc.perform(post("/auth/logout")
-                .cookie(jsessionCookie, authCookie, refreshCookie))
+        MvcResult loginResult = mockMvc.perform(post("/auth/login")
+                .contentType(APPLICATION_JSON)
+                .content(loginRequest))
             .andExpect(status().isOk())
-            .andExpect(cookie().maxAge("JSESSIONID", 0))
-            .andExpect(cookie().maxAge("AUTHORIZATION", 0))
-            .andExpect(cookie().maxAge("REFRESH_KEY", 0));
+            .andReturn();
+
+        // 쿠키 검증
+        List<String> loginCookies = loginResult.getResponse().getHeaders("Set-Cookie");
+        assertThat(loginCookies).hasSize(2);
+
+        String authCookie = loginCookies.stream()
+            .filter(cookie -> cookie.startsWith("AUTHORIZATION="))
+            .findFirst()
+            .orElseThrow();
+        assertThat(authCookie)
+            .contains("Domain=.bookbridge.kr")
+            .contains("HttpOnly")
+            .contains("Secure")
+            .contains("SameSite=LAX")
+            .doesNotContain("Max-Age=0");
+
+        String refreshCookie = loginCookies.stream()
+            .filter(cookie -> cookie.startsWith("REFRESH_KEY="))
+            .findFirst()
+            .orElseThrow();
+        assertThat(refreshCookie)
+            .contains("Domain=.bookbridge.kr")
+            .contains("HttpOnly")
+            .contains("Secure")
+            .contains("SameSite=LAX")
+            .doesNotContain("Max-Age=0");
+
+        // 로그아웃 API 호출
+        MvcResult logoutResult = mockMvc.perform(post("/auth/logout")
+                .cookie(loginResult.getResponse().getCookies()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        // 쿠키 삭제 검증
+        List<String> logoutCookies = logoutResult.getResponse().getHeaders("Set-Cookie");
+        assertThat(logoutCookies).hasSize(2);
+
+        String removedAuthCookie = logoutCookies.stream()
+            .filter(cookie -> cookie.startsWith("AUTHORIZATION="))
+            .findFirst()
+            .orElseThrow();
+        assertThat(removedAuthCookie)
+            .contains("Domain=.bookbridge.kr")
+            .contains("Max-Age=0")
+            .contains("HttpOnly")
+            .contains("Secure")
+            .contains("SameSite=LAX");
+
+        String removedRefreshCookie = logoutCookies.stream()
+            .filter(cookie -> cookie.startsWith("REFRESH_KEY="))
+            .findFirst()
+            .orElseThrow();
+        assertThat(removedRefreshCookie)
+            .contains("Domain=.bookbridge.kr")
+            .contains("Max-Age=0")
+            .contains("HttpOnly")
+            .contains("Secure")
+            .contains("SameSite=LAX");
     }
 }

--- a/src/test/resources/sql/schema.sql
+++ b/src/test/resources/sql/schema.sql
@@ -362,9 +362,9 @@ INSERT INTO member_areas (id, emd_id, authenticated_at) VALUES
 
 -- 회원
 INSERT INTO members (id, email, password, nickname, area_id, status, role) VALUES
-(UUID_TO_BIN('0199f8c2-30ed-7ee3-a757-16196412518c'), 'test@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'tester', 1, 'ACTIVE', 'USER'),
-(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a302'), 'other@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'other', 2, 'ACTIVE', 'USER'),
-(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a303'), 'mock@test.com', '{bcrypt}$2a$10$e9yC6oOgw6QJA/XalvPlcOUkjTfuqfqxRH1TECCdUrgNHGiB/RoCa', 'mock', 3, 'ACTIVE', 'USER');
+(UUID_TO_BIN('0199f8c2-30ed-7ee3-a757-16196412518c'), 'test@test.com', '{bcrypt}$2a$10$0wsmn7K4OYal.QNhW5.26.nmNROkJ4utkzCPjgzZS.sPyLnjVx5sa', 'tester', 1, 'ACTIVE', 'USER'),
+(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a302'), 'other@test.com', '{bcrypt}$2a$10$0wsmn7K4OYal.QNhW5.26.nmNROkJ4utkzCPjgzZS.sPyLnjVx5sa', 'other', 2, 'ACTIVE', 'USER'),
+(UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a303'), 'mock@test.com', '{bcrypt}$2a$10$0wsmn7K4OYal.QNhW5.26.nmNROkJ4utkzCPjgzZS.sPyLnjVx5sa', 'mock', 3, 'ACTIVE', 'USER');
 
 INSERT INTO member_wishes (id, member_id, book_id) VALUES
 (1, UUID_TO_BIN('019a6928-6f73-79f7-bd1b-6bfd4771a302'), 2);


### PR DESCRIPTION
this fixes #171 

### 작업 내용
- [x] 로그아웃 쿠키 삭제 기능 수정
- [x] 로그아웃 테스트 개선 

기존 : 쿠키 제거 시 security `deleteCookie()` 사용
변경 : 쿠키 제거 시 `CookieUtils.removeCookie()` 를 사용하여 직접 제거