### PR TITLE
fix: 유효하지 않은 인증 Cookie 무효화

### DIFF
--- a/src/main/java/com/bob/core/member/adapter/api/MemberApi.java
+++ b/src/main/java/com/bob/core/member/adapter/api/MemberApi.java
@@ -1,5 +1,6 @@
 package com.bob.core.member.adapter.api;
 
+import static com.bob.global.utils.web.CookieUtils.removeCookie;
 import static com.bob.shared.web.response.ResponseSymbol.CREATED;
 import static com.bob.shared.web.response.ResponseSymbol.DELETED;
 import static com.bob.shared.web.response.ResponseSymbol.SENT;
@@ -70,10 +71,15 @@ public class MemberApi {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberDetailResponse> readDetail(@AuthenticationId UUID memberId) {
-        MemberDetail detail = memberReader.readDetail(memberId, true);
+    public MemberDetailResponse readDetail(@AuthenticationId UUID memberId, HttpServletResponse response) {
+        try {
+            return MemberDetailResponse.of(memberReader.readDetail(memberId, true));
+        } catch (IllegalArgumentException ex) {
+            removeCookie(response, "AUTHORIZATION");
+            removeCookie(response, "REFRESH_KEY");
 
-        return ResponseEntity.ok(MemberDetailResponse.of(detail));
+            throw ex;
+        }
     }
 
     @GetMapping("/{memberId}")

--- a/src/test/java/com/bob/core/member/adapter/api/MemberApiTest.java
+++ b/src/test/java/com/bob/core/member/adapter/api/MemberApiTest.java
@@ -6,8 +6,12 @@ import static com.bob.support.fixture.area.domain.AreaFixture.EMD_AREA_ID;
 import static com.bob.support.fixture.member.domain.MemberFixture.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+
+import jakarta.servlet.http.Cookie;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -218,6 +222,38 @@ record MemberApiTest(
 
         Member updated = memberRepository.findById(member.getId()).orElseThrow();
         assertThat(updated.isDeactivated()).isTrue();
+    }
+
+    @Test
+    void 내_정보_조회_시_예외가_발생하면_쿠키_무효화() {
+        setAuthentication(UUID.randomUUID());
+
+        MvcTestResult result = mvcTester.get()
+            .uri("/members/me")
+            .cookie(
+                new Cookie("AUTHORIZATION", "invalid-access-token"),
+                new Cookie("REFRESH_KEY", "invalid-refresh-key")
+            )
+            .exchange();
+
+        // 쿠키 존재 검증
+        List<String> requestCookieNames = Arrays.stream(Objects.requireNonNull(result.getRequest().getCookies()))
+            .map(Cookie::getName)
+            .toList();
+
+        assertThat(requestCookieNames).contains("AUTHORIZATION", "REFRESH_KEY");
+
+        // 쿠키 무효화 검증
+        assertThat(result).hasStatus(500);
+        List<String> cookies = result.getResponse().getHeaders("Set-Cookie");
+        assertThat(cookies).anySatisfy(cookie -> {
+            assertThat(cookie).contains("AUTHORIZATION=");
+            assertThat(cookie).contains("Max-Age=0");
+        });
+        assertThat(cookies).anySatisfy(cookie -> {
+            assertThat(cookie).contains("REFRESH_KEY=");
+            assertThat(cookie).contains("Max-Age=0");
+        });
     }
 
     void setAuthentication(UUID memberId) {


### PR DESCRIPTION
this fixes #194 

### 작업 내용 
- [x] 유효하지 않은 값(token)을 가진 인증 Cookie 무효화